### PR TITLE
feat: add html coverage link

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ jobs:
       contents: read
       pull-requests: write
       checks: write
+      pages: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -21,23 +23,25 @@ jobs:
         with:
           working-directory: apps/akari
           test-script: npm run test:coverage
-      - name: Upload HTML coverage report
+      - name: Setup Pages
         if: always()
-        id: upload-coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/configure-pages@v5
+      - name: Upload coverage to Pages
+        if: always()
+        uses: actions/upload-pages-artifact@v4
         with:
-          name: coverage-html
           path: apps/akari/coverage
+      - name: Deploy Pages
+        if: always()
+        id: deploy
+        uses: actions/deploy-pages@v4
       - name: Comment coverage link
         if: always()
         uses: actions/github-script@v7
         with:
           github-token: ${{ github.token }}
           script: |
-            const artifactId = '${{ steps.upload-coverage.outputs.artifact-id }}';
-            const runId = process.env.GITHUB_RUN_ID;
-            const repo = process.env.GITHUB_REPOSITORY;
-            const url = `https://github.com/${repo}/actions/runs/${runId}/artifacts/${artifactId}`;
+            const url = '${{ steps.deploy.outputs.page_url }}';
             await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,3 +21,26 @@ jobs:
         with:
           working-directory: apps/akari
           test-script: npm run test:coverage
+      - name: Upload HTML coverage report
+        if: always()
+        id: upload-coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: apps/akari/coverage
+      - name: Comment coverage link
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const artifactId = '${{ steps.upload-coverage.outputs.artifact-id }}';
+            const runId = process.env.GITHUB_RUN_ID;
+            const repo = process.env.GITHUB_REPOSITORY;
+            const url = `https://github.com/${repo}/actions/runs/${runId}/artifacts/${artifactId}`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `HTML coverage report: ${url}`
+            });

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,30 +43,30 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             const url = '${{ steps.deploy.outputs.page_url }}';
-            const marker = '<!-- coverage-report -->';
-            const body = url
-              ? `${marker}\nHTML coverage report: ${url}`
-              : `${marker}\nHTML coverage report not available`;
             const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
             });
+            const markerPattern = /<!-- jest coverage report action for options/;
             const existing = comments.find(
-              (c) => c.user?.login === 'github-actions[bot]' && c.body.includes(marker)
+              (c) => c.user?.login === 'github-actions[bot]' && markerPattern.test(c.body)
             );
+            const footer = url
+              ? `\n\nHTML coverage report: ${url}`
+              : `\n\nHTML coverage report not available`;
             if (existing) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: existing.id,
-                body,
+                body: `${existing.body}${footer}`,
               });
             } else {
               await github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body,
+                body: footer.trim(),
               });
             }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           working-directory: apps/akari
           test-script: npm run test:coverage
+        # Publish coverage report to GitHub Pages
       - name: Setup Pages
         if: always()
         uses: actions/configure-pages@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,30 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             const url = '${{ steps.deploy.outputs.page_url }}';
-            await github.rest.issues.createComment({
+            const marker = '<!-- coverage-report -->';
+            const body = url
+              ? `${marker}\nHTML coverage report: ${url}`
+              : `${marker}\nHTML coverage report not available`;
+            const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `HTML coverage report: ${url}`
             });
+            const existing = comments.find(
+              (c) => c.user?.login === 'github-actions[bot]' && c.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            }


### PR DESCRIPTION
## Summary
- upload coverage directory as artifact and comment link in PR workflow

## Testing
- `npm --prefix apps/akari run test:coverage` (fails: 2 failed, 5 passed)


------
https://chatgpt.com/codex/tasks/task_e_68c6dcb6f950832b98a6170dc44f67f6