### PR TITLE
test: add coverage for TabBadge and ThemedCard

### DIFF
--- a/COMPONENT_TESTS.md
+++ b/COMPONENT_TESTS.md
@@ -28,9 +28,9 @@ This checklist shows which components under `apps/akari/components` have tests.
 - [ ] RichTextWithFacets.tsx
 - [ ] SearchTabs.tsx
 - [ ] Sidebar.tsx
-- [ ] TabBadge.tsx
+- [x] TabBadge.tsx
 - [ ] TabBar.tsx
-- [ ] ThemedCard.tsx
+- [x] ThemedCard.tsx
 - [x] ThemedFeatureCard.tsx
 - [ ] ThemedText.tsx
 - [ ] ThemedView.tsx

--- a/apps/akari/__tests__/components/TabBadge.test.tsx
+++ b/apps/akari/__tests__/components/TabBadge.test.tsx
@@ -1,0 +1,58 @@
+import { render } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
+
+import { TabBadge } from '@/components/TabBadge';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+jest.mock('@/hooks/useThemeColor');
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+describe('TabBadge', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseThemeColor.mockImplementation((colors) => colors.light);
+  });
+
+  it('returns null when count is zero', () => {
+    const { toJSON } = render(<TabBadge count={0} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('displays the count when greater than zero', () => {
+    const { getByText } = render(<TabBadge count={5} />);
+    expect(getByText('5')).toBeTruthy();
+  });
+
+  it('shows "99+" when count exceeds 99', () => {
+    const { getByText } = render(<TabBadge count={150} />);
+    expect(getByText('99+')).toBeTruthy();
+  });
+
+  it('applies small badge styles when size is small', () => {
+    const { toJSON } = render(<TabBadge count={1} size="small" />);
+    const view = toJSON() as any;
+    const style = StyleSheet.flatten(view.props.style);
+    expect(style.height).toBe(16);
+  });
+
+  it('applies medium badge styles by default', () => {
+    const { toJSON } = render(<TabBadge count={1} />);
+    const view = toJSON() as any;
+    const style = StyleSheet.flatten(view.props.style);
+    expect(style.height).toBe(20);
+  });
+
+  it('calls useThemeColor for background and text colors', () => {
+    render(<TabBadge count={1} />);
+    expect(mockUseThemeColor).toHaveBeenNthCalledWith(
+      1,
+      { light: '#ff3b30', dark: '#ff453a' },
+      'tint',
+    );
+    expect(mockUseThemeColor).toHaveBeenNthCalledWith(
+      2,
+      { light: '#ffffff', dark: '#ffffff' },
+      'text',
+    );
+  });
+});

--- a/apps/akari/__tests__/components/ThemedCard.test.tsx
+++ b/apps/akari/__tests__/components/ThemedCard.test.tsx
@@ -1,0 +1,60 @@
+import { render } from '@testing-library/react-native';
+import { StyleSheet, View } from 'react-native';
+
+import { ThemedCard } from '@/components/ThemedCard';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+jest.mock('@/hooks/useThemeColor');
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+describe('ThemedCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseThemeColor.mockImplementation((colors) => colors.light);
+  });
+
+  it('renders with default colors', () => {
+    const { getByTestId } = render(<ThemedCard testID="card" />);
+    expect(getByTestId('card')).toBeTruthy();
+    expect(mockUseThemeColor).toHaveBeenNthCalledWith(
+      1,
+      { light: '#ffffff', dark: '#1a1d1e' },
+      'background',
+    );
+    expect(mockUseThemeColor).toHaveBeenNthCalledWith(
+      2,
+      { light: '#e8eaed', dark: '#2d3133' },
+      'background',
+    );
+  });
+
+  it('applies custom colors when provided', () => {
+    render(
+      <ThemedCard
+        lightColor="#aaa"
+        darkColor="#000"
+        lightBorderColor="#bbb"
+        darkBorderColor="#111"
+      />,
+    );
+    expect(mockUseThemeColor).toHaveBeenNthCalledWith(
+      1,
+      { light: '#aaa', dark: '#000' },
+      'background',
+    );
+    expect(mockUseThemeColor).toHaveBeenNthCalledWith(
+      2,
+      { light: '#bbb', dark: '#111' },
+      'background',
+    );
+  });
+
+  it('merges additional styles', () => {
+    const { getByTestId } = render(
+      <ThemedCard testID="card" style={{ margin: 10 }} />,
+    );
+    const card = getByTestId('card');
+    const style = StyleSheet.flatten(card.props.style);
+    expect(style.margin).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary
- add comprehensive tests for TabBadge covering display logic and theme color usage
- test ThemedCard default, custom colors, and style merging
- update component checklist for new test coverage

## Testing
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c6eb979d68832b9145c120825e7744