### PR TITLE
test: add coverage for themed components

### DIFF
--- a/COMPONENT_TESTS.md
+++ b/COMPONENT_TESTS.md
@@ -32,8 +32,8 @@ This checklist shows which components under `apps/akari/components` have tests.
 - [ ] TabBar.tsx
 - [x] ThemedCard.tsx
 - [x] ThemedFeatureCard.tsx
-- [ ] ThemedText.tsx
-- [ ] ThemedView.tsx
+- [x] ThemedText.tsx
+- [x] ThemedView.tsx
 - [ ] VideoEmbed.tsx
 - [ ] VideoPlayer.tsx
 - [ ] VideoPlayer.web.tsx

--- a/apps/akari/__tests__/components/ThemedText.test.tsx
+++ b/apps/akari/__tests__/components/ThemedText.test.tsx
@@ -1,0 +1,59 @@
+import { render } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
+
+import { ThemedText } from '@/components/ThemedText';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+jest.mock('@/hooks/useThemeColor');
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+describe('ThemedText', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseThemeColor.mockImplementation((colors) => colors.light ?? '#fff');
+  });
+
+  it('renders with default style', () => {
+    const { getByText } = render(<ThemedText>Test</ThemedText>);
+    const text = getByText('Test');
+    const style = StyleSheet.flatten(text.props.style);
+    expect(style.color).toBe('#fff');
+    expect(style.fontSize).toBe(16);
+    expect(mockUseThemeColor).toHaveBeenCalledWith(
+      { light: undefined, dark: undefined },
+      'text',
+    );
+  });
+
+  it('applies custom colors when provided', () => {
+    render(
+      <ThemedText lightColor="#aaa" darkColor="#000">
+        Colored
+      </ThemedText>,
+    );
+    expect(mockUseThemeColor).toHaveBeenCalledWith(
+      { light: '#aaa', dark: '#000' },
+      'text',
+    );
+  });
+
+  it.each([
+    ['default', { fontSize: 16, lineHeight: 24 }],
+    ['title', { fontSize: 32, lineHeight: 32, fontWeight: 'bold' }],
+    ['defaultSemiBold', { fontSize: 16, lineHeight: 24, fontWeight: '600' }],
+    ['subtitle', { fontSize: 20, fontWeight: 'bold' }],
+    ['link', { fontSize: 16, lineHeight: 30, color: '#0a7ea4' }],
+  ] as const)("applies '%s' type style", (type, expected) => {
+    const { getByText } = render(<ThemedText type={type}>Sample</ThemedText>);
+    const style = StyleSheet.flatten(getByText('Sample').props.style);
+    expect(style).toMatchObject(expected);
+  });
+
+  it('merges additional styles', () => {
+    const { getByText } = render(
+      <ThemedText style={{ margin: 10 }}>Margin</ThemedText>,
+    );
+    const style = StyleSheet.flatten(getByText('Margin').props.style);
+    expect(style.margin).toBe(10);
+  });
+});

--- a/apps/akari/__tests__/components/ThemedView.test.tsx
+++ b/apps/akari/__tests__/components/ThemedView.test.tsx
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
+
+import { ThemedView } from '@/components/ThemedView';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+jest.mock('@/hooks/useThemeColor');
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+describe('ThemedView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseThemeColor.mockImplementation((colors) => colors.light ?? '#fff');
+  });
+
+  it('renders with default colors', () => {
+    const { getByTestId } = render(<ThemedView testID="view" />);
+    const style = StyleSheet.flatten(getByTestId('view').props.style);
+    expect(style.backgroundColor).toBe('#fff');
+    expect(mockUseThemeColor).toHaveBeenCalledWith(
+      { light: undefined, dark: undefined },
+      'background',
+    );
+  });
+
+  it('applies custom colors when provided', () => {
+    render(
+      <ThemedView lightColor="#aaa" darkColor="#000" />,
+    );
+    expect(mockUseThemeColor).toHaveBeenCalledWith(
+      { light: '#aaa', dark: '#000' },
+      'background',
+    );
+  });
+
+  it('merges additional styles', () => {
+    const { getByTestId } = render(
+      <ThemedView testID="view" style={{ margin: 10 }} />,
+    );
+    const style = StyleSheet.flatten(getByTestId('view').props.style);
+    expect(style.margin).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for ThemedText variants and style merging
- add unit tests for ThemedView default and custom colors
- mark ThemedText and ThemedView as covered components

## Testing
- `npm --workspace apps/akari run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c6edad07ec832b87cafc9e8198a798