### PR TITLE
test: add tests for ExternalEmbed component

### DIFF
--- a/COMPONENT_TESTS.md
+++ b/COMPONENT_TESTS.md
@@ -3,7 +3,7 @@
 This checklist shows which components under `apps/akari/components` have tests.
 
 - [x] Collapsible.tsx
-- [ ] ExternalEmbed.tsx
+- [x] ExternalEmbed.tsx
 - [x] ExternalLink.tsx
 - [ ] GifEmbed.tsx
 - [x] GifPicker.tsx

--- a/apps/akari/__tests__/components/ExternalEmbed.test.tsx
+++ b/apps/akari/__tests__/components/ExternalEmbed.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import { Linking } from 'react-native';
+
+import { ExternalEmbed } from '@/components/ExternalEmbed';
+import { useThemeColor } from '@/hooks/useThemeColor';
+import { useTranslation } from '@/hooks/useTranslation';
+
+jest.mock('react-native-reanimated', () => {
+  const Reanimated = require('react-native-reanimated/mock');
+  Reanimated.default.call = () => {};
+  return Reanimated;
+});
+
+jest.mock('expo-image', () => ({ Image: jest.fn(() => null) }));
+jest.mock('@/hooks/useThemeColor');
+jest.mock('@/hooks/useTranslation');
+
+const mockUseThemeColor = useThemeColor as jest.Mock;
+const mockUseTranslation = useTranslation as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseThemeColor.mockReturnValue('#000');
+  mockUseTranslation.mockReturnValue({ t: (key: string) => key });
+});
+
+const createEmbed = (uri: string) => ({
+  $type: 'app.bsky.embed.external',
+  external: {
+    description: 'A cool site',
+    thumb: {
+      $type: 'blob',
+      ref: { $link: 'https://example.com/thumb.jpg' },
+      mimeType: 'image/jpeg',
+      size: 123,
+    },
+    title: 'Example Site',
+    uri,
+  },
+});
+
+describe('ExternalEmbed', () => {
+  it('renders title, description, and domain', () => {
+    const embed = createEmbed('https://example.com/article');
+    const { getByText } = render(<ExternalEmbed embed={embed} />);
+
+    expect(getByText('Example Site')).toBeTruthy();
+    expect(getByText('A cool site')).toBeTruthy();
+    expect(getByText('example.com')).toBeTruthy();
+
+    const Image = require('expo-image').Image as jest.Mock;
+    const props = Image.mock.calls[0][0];
+    expect(props.source).toEqual({ uri: 'https://example.com/thumb.jpg' });
+  });
+
+  it('opens link when pressed', () => {
+    const openUrl = jest.spyOn(Linking, 'openURL').mockResolvedValueOnce();
+    const embed = createEmbed('https://example.com/article');
+    const { getByText } = render(<ExternalEmbed embed={embed} />);
+
+    fireEvent.press(getByText('Example Site'));
+
+    expect(openUrl).toHaveBeenCalledWith('https://example.com/article');
+  });
+
+  it('falls back to translation key for invalid url', () => {
+    const embed = createEmbed('not-a-valid-url');
+    const { getByText } = render(<ExternalEmbed embed={embed} />);
+
+    expect(getByText('common.externalLink')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for ExternalEmbed to verify rendering and link behavior
- mark ExternalEmbed component as tested in checklist

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68c6f37a84fc832b91c723e0b933e7e1