### PR TITLE
test: expand util test coverage

### DIFF
--- a/apps/akari/__tests__/utils/alert.test.ts
+++ b/apps/akari/__tests__/utils/alert.test.ts
@@ -1,0 +1,91 @@
+describe('alert utilities', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('uses window.confirm on web and executes primary action', () => {
+    jest.doMock('react-native', () => ({
+      Platform: { OS: 'web' },
+      Alert: { alert: jest.fn() },
+    }));
+    window.confirm = jest.fn(() => true);
+    const module = require('@/utils/alert');
+    const onConfirm = jest.fn();
+    const onCancel = jest.fn();
+    module.showAlert({
+      title: 'Title',
+      message: 'Message',
+      buttons: [
+        { text: 'Cancel', style: 'cancel', onPress: onCancel },
+        { text: 'OK', onPress: onConfirm },
+      ],
+    });
+    expect(onConfirm).toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('executes cancel action when user declines', () => {
+    jest.doMock('react-native', () => ({
+      Platform: { OS: 'web' },
+      Alert: { alert: jest.fn() },
+    }));
+    window.confirm = jest.fn(() => false);
+    const module = require('@/utils/alert');
+    const onConfirm = jest.fn();
+    const onCancel = jest.fn();
+    module.showAlert({
+      title: 'Title',
+      message: 'Message',
+      buttons: [
+        { text: 'Cancel', style: 'cancel', onPress: onCancel },
+        { text: 'OK', onPress: onConfirm },
+      ],
+    });
+    expect(onCancel).toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('calls Alert.alert on native platforms', () => {
+    const alertMock = jest.fn();
+    jest.doMock('react-native', () => ({
+      Platform: { OS: 'ios' },
+      Alert: { alert: alertMock },
+    }));
+    const module = require('@/utils/alert');
+    module.showAlert({ title: 'Title', message: 'Message' });
+    expect(alertMock).toHaveBeenCalledWith('Title', 'Message', undefined, undefined);
+  });
+
+  it('showConfirm triggers callbacks based on user choice', () => {
+    jest.doMock('react-native', () => ({
+      Platform: { OS: 'web' },
+      Alert: { alert: jest.fn() },
+    }));
+    const module = require('@/utils/alert');
+    const onConfirm = jest.fn();
+    const onCancel = jest.fn();
+
+    window.confirm = jest.fn(() => true);
+    module.showConfirm('T', 'M', onConfirm, onCancel);
+    expect(onConfirm).toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+
+    (window.confirm as jest.Mock).mockReturnValue(false);
+    module.showConfirm('T', 'M', onConfirm, onCancel);
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('showDestructiveConfirm executes confirm callback', () => {
+    jest.doMock('react-native', () => ({
+      Platform: { OS: 'web' },
+      Alert: { alert: jest.fn() },
+    }));
+    const module = require('@/utils/alert');
+    const onConfirm = jest.fn();
+    const onCancel = jest.fn();
+    window.confirm = jest.fn(() => true);
+    module.showDestructiveConfirm('T', 'M', 'Remove', onConfirm, onCancel);
+    expect(onConfirm).toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/utils/devUtils.test.ts
+++ b/apps/akari/__tests__/utils/devUtils.test.ts
@@ -1,0 +1,27 @@
+describe('devUtils', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('logs translation stats in development', () => {
+    (global as any).__DEV__ = true;
+    jest.doMock('@/utils/translationLogger', () => ({
+      getTranslationReport: jest.fn(() => 'report'),
+    }));
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const { logTranslationStats } = require('@/utils/devUtils');
+    const result = logTranslationStats();
+    expect(result).toBe('report');
+    expect(logSpy).toHaveBeenCalledWith('📊 Translation Report:');
+    expect(logSpy).toHaveBeenCalledWith('report');
+  });
+
+  it('returns null outside development', () => {
+    (global as any).__DEV__ = false;
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const { logTranslationStats } = require('@/utils/devUtils');
+    const result = logTranslationStats();
+    expect(result).toBeNull();
+    expect(logSpy).toHaveBeenCalledWith('Translation checking is only available in development mode.');
+  });
+});

--- a/apps/akari/__tests__/utils/pseudoLocalization.test.ts
+++ b/apps/akari/__tests__/utils/pseudoLocalization.test.ts
@@ -1,0 +1,27 @@
+import {
+  pseudoLocalizeString,
+  enhancedPseudoLocalizeString,
+  pseudoLocalizeObject,
+} from '@/utils/pseudoLocalization';
+
+describe('pseudoLocalization utilities', () => {
+  it('wraps text with brackets', () => {
+    const result = pseudoLocalizeString('hello');
+    expect(result).toBe('[hello]');
+  });
+
+  it('enhances text and preserves placeholders', () => {
+    const result = enhancedPseudoLocalizeString('Hello {{name}}');
+    expect(result).toBe('[Héllò {{name}}]');
+  });
+
+  it('recursively localizes objects', () => {
+    const source = { greeting: 'Hello', nested: { message: 'Good day' } };
+    const result = pseudoLocalizeObject(source) as {
+      greeting: string;
+      nested: { message: string };
+    };
+    expect(result.greeting).toBe('[Héllò]');
+    expect(result.nested.message).toBe('[Gòòd dày]');
+  });
+});

--- a/apps/akari/__tests__/utils/tabScrollRegistry.test.ts
+++ b/apps/akari/__tests__/utils/tabScrollRegistry.test.ts
@@ -1,0 +1,23 @@
+describe('tabScrollRegistry', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('runs registered handler on tab press', () => {
+    const module = require('@/utils/tabScrollRegistry');
+    const { tabScrollRegistry } = module;
+    const handler = jest.fn();
+    tabScrollRegistry.register('home', handler);
+    tabScrollRegistry.handleTabPress('home');
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('ignores unregistered tabs', () => {
+    const module = require('@/utils/tabScrollRegistry');
+    const { tabScrollRegistry } = module;
+    const handler = jest.fn();
+    tabScrollRegistry.register('home', handler);
+    tabScrollRegistry.handleTabPress('other');
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/utils/translationLogger.test.ts
+++ b/apps/akari/__tests__/utils/translationLogger.test.ts
@@ -1,0 +1,45 @@
+describe('translationLogger', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('records missing translations and generates report', () => {
+    (global as any).__DEV__ = true;
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const module = require('@/utils/translationLogger');
+    const { translationLogger, getTranslationReport } = module;
+
+    translationLogger.clearMissingTranslations();
+    translationLogger.logMissing('greeting', 'en');
+
+    const logs = translationLogger.getMissingTranslations();
+    expect(logs).toHaveLength(1);
+    expect(logs[0].key).toBe('greeting');
+
+    const report = getTranslationReport();
+    expect(report).toContain('❌ Found 1 missing translation');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Missing translation'));
+  });
+
+  it('does not log when disabled', () => {
+    (global as any).__DEV__ = true;
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const module = require('@/utils/translationLogger');
+    const { translationLogger } = module;
+
+    translationLogger.clearMissingTranslations();
+    translationLogger.disable();
+    translationLogger.logMissing('key', 'en');
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(translationLogger.getMissingTranslations()).toHaveLength(0);
+  });
+
+  it('returns message when not in development', () => {
+    (global as any).__DEV__ = false;
+    const { getTranslationReport } = require('@/utils/translationLogger');
+    const report = getTranslationReport();
+    expect(report).toBe('Translation logging is only available in development mode.');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for alert utility across web and native platforms
- cover translation logging and development helpers
- test pseudo-localization and tab scroll registry logic

## Testing
- `npm --prefix apps/akari run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68c6f4ad1c50832b89ff2d5bcd74fdc5