### PR TITLE
test: add GifEmbed and Labels component tests

### DIFF
--- a/COMPONENT_TESTS.md
+++ b/COMPONENT_TESTS.md
@@ -5,13 +5,13 @@ This checklist shows which components under `apps/akari/components` have tests.
 - [x] Collapsible.tsx
 - [x] ExternalEmbed.tsx
 - [x] ExternalLink.tsx
-- [ ] GifEmbed.tsx
+- [x] GifEmbed.tsx
 - [x] GifPicker.tsx
 - [ ] HandleHistoryModal.tsx
 - [x] HapticTab.tsx
 - [ ] ImageViewer.tsx
 - [x] Label.tsx
-- [ ] Labels.tsx
+- [x] Labels.tsx
 - [ ] LanguageSelector.tsx
 - [ ] NotificationSettings.tsx
 - [ ] NotificationTest.tsx

--- a/apps/akari/__tests__/components/GifEmbed.test.tsx
+++ b/apps/akari/__tests__/components/GifEmbed.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import { Linking } from 'react-native';
+
+import { GifEmbed } from '@/components/GifEmbed';
+import { useThemeColor } from '@/hooks/useThemeColor';
+import { useTranslation } from '@/hooks/useTranslation';
+
+jest.mock('react-native-reanimated', () => {
+  const Reanimated = require('react-native-reanimated/mock');
+  Reanimated.default.call = () => {};
+  return Reanimated;
+});
+
+jest.mock('expo-image', () => ({ Image: jest.fn(() => null) }));
+jest.mock('@/hooks/useThemeColor');
+jest.mock('@/hooks/useTranslation');
+
+const mockUseThemeColor = useThemeColor as jest.Mock;
+const mockUseTranslation = useTranslation as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseThemeColor.mockReturnValue('#000');
+  mockUseTranslation.mockReturnValue({ t: (key: string) => key });
+});
+
+type Embed = {
+  $type: 'app.bsky.embed.external';
+  external: {
+    description?: string;
+    title: string;
+    uri: string;
+  };
+};
+
+const createEmbed = (description?: string): Embed => ({
+  $type: 'app.bsky.embed.external',
+  external: {
+    ...(description !== undefined && { description }),
+    title: 'Funny GIF',
+    uri: 'https://example.com/gif.gif',
+  },
+});
+
+describe('GifEmbed', () => {
+  it('renders GIF info and opens link on press', () => {
+    const embed = createEmbed('A cool gif');
+    const openUrl = jest.spyOn(Linking, 'openURL').mockResolvedValueOnce();
+    const { getByText } = render(<GifEmbed embed={embed} />);
+
+    expect(getByText('Funny GIF')).toBeTruthy();
+    expect(getByText('A cool gif')).toBeTruthy();
+    expect(getByText('GIF')).toBeTruthy();
+
+    fireEvent.press(getByText('Funny GIF'));
+
+    expect(openUrl).toHaveBeenCalledWith('https://example.com/gif.gif');
+
+    const Image = require('expo-image').Image as jest.Mock;
+    const props = Image.mock.calls[0][0];
+    expect(props.source).toEqual({ uri: 'https://example.com/gif.gif' });
+  });
+
+  it('handles missing description', () => {
+    const embed = createEmbed();
+    const { getByText, queryByText } = render(<GifEmbed embed={embed} />);
+
+    expect(getByText('Funny GIF')).toBeTruthy();
+    expect(queryByText('A cool gif')).toBeNull();
+    expect(getByText('GIF')).toBeTruthy();
+  });
+});

--- a/apps/akari/__tests__/components/Labels.test.tsx
+++ b/apps/akari/__tests__/components/Labels.test.tsx
@@ -1,0 +1,68 @@
+import { render } from '@testing-library/react-native';
+
+import { Labels } from '@/components/Labels';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+const mockLabel = jest.fn();
+
+jest.mock('@/components/Label', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    Label: (props: any) => {
+      mockLabel(props);
+      return React.createElement(Text, null, props.text);
+    },
+  };
+});
+
+jest.mock('@/hooks/useThemeColor');
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseThemeColor.mockReturnValue('#000');
+});
+
+describe('Labels', () => {
+  it('returns null when no labels provided', () => {
+    const { toJSON } = render(<Labels />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('returns null when labels are empty after filtering', () => {
+    const invalidLabels = [{ val: '   ' }];
+    const { toJSON } = render(<Labels labels={invalidLabels} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders up to maxLabels', () => {
+    const labels = [{ val: 'One' }, { val: 'Two' }, { val: 'Three' }];
+    const { getByText, queryByText } = render(
+      <Labels labels={labels} maxLabels={2} />,
+    );
+    expect(getByText('One')).toBeTruthy();
+    expect(getByText('Two')).toBeTruthy();
+    expect(queryByText('Three')).toBeNull();
+  });
+
+  it('applies correct label classifications', () => {
+    const labels = [
+      { val: 'Spammy', neg: true },
+      { val: 'Verified account' },
+      { val: 'Regular user' },
+    ];
+    render(<Labels labels={labels} />);
+
+    expect(mockLabel).toHaveBeenCalledTimes(3);
+    expect(mockLabel).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'Spammy', isWarning: true }),
+    );
+    expect(mockLabel).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'Verified account', isPositive: true }),
+    );
+    expect(mockLabel).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'Regular user' }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for GifEmbed component including link handling and missing description
- add tests for Labels component including filtering, limits, and classification
- mark GifEmbed and Labels components as covered in checklist

## Testing
- `npm run test:coverage -w akari`


------
https://chatgpt.com/codex/tasks/task_e_68c6f50376c8832b81a3fe0d64277ed8