### PR TITLE
test: add PDS URL utility coverage

### DIFF
--- a/packages/bluesky-api/src/pds.test.ts
+++ b/packages/bluesky-api/src/pds.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getPdsUrlFromDid, getPdsUrlFromHandle } from './pds';
+
+describe('getPdsUrlFromDid', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns PDS endpoint when service is available', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          service: [{ id: '#atproto_pds', serviceEndpoint: 'https://pds.example.com' }],
+        }),
+    });
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    const url = await getPdsUrlFromDid('did:example:123');
+
+    expect(url).toBe('https://pds.example.com');
+    expect(mockFetch).toHaveBeenCalledWith('https://plc.directory/did:example:123');
+  });
+
+  it('returns null when response is not ok', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 } as Response);
+
+    const url = await getPdsUrlFromDid('did:bad');
+
+    expect(url).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('returns null when service is missing', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ service: [] }),
+    });
+
+    const url = await getPdsUrlFromDid('did:noService');
+
+    expect(url).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('returns null when fetch throws', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('network error'));
+
+    const url = await getPdsUrlFromDid('did:error');
+
+    expect(url).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});
+
+describe('getPdsUrlFromHandle', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('resolves handle and returns PDS URL', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ did: 'did:example:123' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            service: [{ id: '#atproto_pds', serviceEndpoint: 'https://pds.example.com' }],
+          }),
+      });
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    const url = await getPdsUrlFromHandle('@alice.test');
+
+    expect(url).toBe('https://pds.example.com');
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      'https://bsky.social/xrpc/com.atproto.identity.resolveHandle?handle=alice.test',
+    );
+    expect(mockFetch).toHaveBeenNthCalledWith(2, 'https://plc.directory/did:example:123');
+  });
+
+  it('returns null when handle resolution fails', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 } as Response);
+
+    const url = await getPdsUrlFromHandle('bad.handle');
+
+    expect(url).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('returns null when no DID is returned', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+
+    const url = await getPdsUrlFromHandle('nodid.handle');
+
+    expect(url).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('returns null when PDS lookup yields no service', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ did: 'did:example:123' }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ service: [] }) });
+
+    const url = await getPdsUrlFromHandle('@alice.test');
+
+    expect(url).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest coverage for PDS URL resolution helpers
- verify handle and DID lookups for expected and error cases

## Testing
- `npm --prefix packages/bluesky-api test -- --coverage`
- `npm test`
- `npm run test:coverage` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fa1e6e04832bb367e67c837b733d