### PR TITLE
test: expand component coverage

### DIFF
--- a/COMPONENT_TESTS.md
+++ b/COMPONENT_TESTS.md
@@ -12,18 +12,18 @@ This checklist shows which components under `apps/akari/components` have tests.
 - [ ] ImageViewer.tsx
 - [x] Label.tsx
 - [x] Labels.tsx
-- [ ] LanguageSelector.tsx
-- [ ] NotificationSettings.tsx
-- [ ] NotificationTest.tsx
+- [x] LanguageSelector.tsx
+- [x] NotificationSettings.tsx
+- [x] NotificationTest.tsx
 - [ ] ParallaxScrollView.tsx
 - [x] PostCard.tsx
 - [ ] PostComposer.tsx
-- [ ] ProfileDropdown.tsx
+- [x] ProfileDropdown.tsx
 - [ ] ProfileEditModal.tsx
 - [ ] ProfileHeader.tsx
 - [ ] ProfileTabs.tsx
 - [x] RecordEmbed.tsx
-- [ ] ResponsiveLayout.tsx
+- [x] ResponsiveLayout.tsx
 - [ ] RichText.tsx
 - [ ] RichTextWithFacets.tsx
 - [ ] SearchTabs.tsx

--- a/apps/akari/__tests__/components/LanguageSelector.test.tsx
+++ b/apps/akari/__tests__/components/LanguageSelector.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render } from '@testing-library/react-native';
+
+import { LanguageSelector } from '@/components/LanguageSelector';
+import { useTranslation } from '@/hooks/useTranslation';
+import { getAvailableLocales, getTranslationData } from '@/utils/i18n';
+
+jest.mock('@/hooks/useTranslation');
+jest.mock('@/utils/i18n');
+
+const mockUseTranslation = useTranslation as jest.Mock;
+const mockGetAvailableLocales = getAvailableLocales as jest.Mock;
+const mockGetTranslationData = getTranslationData as jest.Mock;
+
+let changeLanguage: jest.Mock;
+
+describe('LanguageSelector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    changeLanguage = jest.fn();
+    mockUseTranslation.mockReturnValue({
+      t: (key: string) => key,
+      currentLocale: 'en',
+      changeLanguage,
+    });
+    mockGetAvailableLocales.mockReturnValue(['en', 'es']);
+    mockGetTranslationData.mockImplementation((locale: string) =>
+      locale === 'en'
+        ? { language: 'English', nativeName: 'English', flag: '🇺🇸' }
+        : { language: 'Spanish', nativeName: 'Español', flag: '🇪🇸' },
+    );
+  });
+
+  it('renders current language', () => {
+    const { getAllByText, getByText } = render(<LanguageSelector />);
+    expect(getAllByText('English').length).toBe(2);
+    expect(getByText('🇺🇸')).toBeTruthy();
+  });
+
+  it('allows selecting a different language', () => {
+    const { getByText } = render(<LanguageSelector />);
+    fireEvent.press(getByText('▼'));
+    fireEvent.press(getByText('Español'));
+    expect(changeLanguage).toHaveBeenCalledWith('es');
+  });
+});

--- a/apps/akari/__tests__/components/NotificationSettings.test.tsx
+++ b/apps/akari/__tests__/components/NotificationSettings.test.tsx
@@ -1,0 +1,47 @@
+import { act, fireEvent, render } from '@testing-library/react-native';
+
+import { NotificationSettings } from '@/components/NotificationSettings';
+import { usePushNotifications } from '@/hooks/usePushNotifications';
+import { useThemeColor } from '@/hooks/useThemeColor';
+import { useTranslation } from '@/hooks/useTranslation';
+
+jest.mock('@/hooks/usePushNotifications');
+jest.mock('@/hooks/useThemeColor');
+jest.mock('@/hooks/useTranslation');
+jest.mock('@/components/ui/IconSymbol', () => ({ IconSymbol: () => null }));
+jest.mock('@/components/NotificationTest', () => ({ NotificationTest: () => null }));
+
+const mockUsePushNotifications = usePushNotifications as jest.Mock;
+const mockUseThemeColor = useThemeColor as jest.Mock;
+const mockUseTranslation = useTranslation as jest.Mock;
+
+describe('NotificationSettings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseThemeColor.mockReturnValue('#000');
+    mockUseTranslation.mockReturnValue({ t: (key: string) => key });
+  });
+
+  it('enables push notifications', async () => {
+    const initialize = jest.fn().mockResolvedValue(true);
+    const onSettingsChange = jest.fn();
+    mockUsePushNotifications.mockReturnValue({
+      permissionStatus: 'denied',
+      expoPushToken: null,
+      isLoading: false,
+      error: null,
+      initialize,
+      clearBadge: jest.fn(),
+    });
+
+    const { getByRole } = render(
+      <NotificationSettings onSettingsChange={onSettingsChange} />,
+    );
+    const toggle = getByRole('switch');
+    await act(async () => {
+      fireEvent(toggle, 'valueChange', true);
+    });
+    expect(initialize).toHaveBeenCalled();
+    expect(onSettingsChange).toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/components/NotificationTest.test.tsx
+++ b/apps/akari/__tests__/components/NotificationTest.test.tsx
@@ -1,0 +1,54 @@
+import { act, fireEvent, render } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+
+import { NotificationTest } from '@/components/NotificationTest';
+import { useThemeColor } from '@/hooks/useThemeColor';
+import { useTranslation } from '@/hooks/useTranslation';
+import { scheduleLocalNotification } from '@/utils/notifications';
+
+jest.mock('@/hooks/useThemeColor');
+jest.mock('@/hooks/useTranslation');
+jest.mock('@/utils/notifications');
+jest.mock('@/components/ui/IconSymbol', () => ({ IconSymbol: () => null }));
+
+const mockUseThemeColor = useThemeColor as jest.Mock;
+const mockUseTranslation = useTranslation as jest.Mock;
+const mockScheduleLocalNotification = scheduleLocalNotification as jest.Mock;
+
+describe('NotificationTest', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseThemeColor.mockReturnValue('#000');
+    mockUseTranslation.mockReturnValue({ t: (key: string) => key });
+    mockScheduleLocalNotification.mockResolvedValue('123');
+    jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+  });
+
+  it('sends a test notification', async () => {
+    const onSent = jest.fn();
+    const { getByText } = render(
+      <NotificationTest onNotificationSent={onSent} />,
+    );
+    await act(async () => {
+      await fireEvent.press(getByText('notifications.sendTest'));
+    });
+    expect(mockScheduleLocalNotification).toHaveBeenCalledWith(
+      'Test Notification',
+      'This is a test notification from Akari v2!',
+      { type: 'test', timestamp: expect.any(String) },
+    );
+    expect(onSent).toHaveBeenCalled();
+  });
+
+  it('schedules a delayed test notification', async () => {
+    const { getByText } = render(<NotificationTest />);
+    await act(async () => {
+      await fireEvent.press(getByText('notifications.scheduleTest'));
+    });
+    expect(mockScheduleLocalNotification).toHaveBeenCalledWith(
+      'Delayed Test Notification',
+      'This notification was scheduled to appear 5 seconds later!',
+      { type: 'test', timestamp: expect.any(String) },
+    );
+  });
+});

--- a/apps/akari/__tests__/components/ProfileDropdown.test.tsx
+++ b/apps/akari/__tests__/components/ProfileDropdown.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render } from '@testing-library/react-native';
+
+import { ProfileDropdown } from '@/components/ProfileDropdown';
+import { useTranslation } from '@/hooks/useTranslation';
+import { useThemeColor } from '@/hooks/useThemeColor';
+import { useBorderColor } from '@/hooks/useBorderColor';
+
+jest.mock('@/hooks/useTranslation');
+jest.mock('@/hooks/useThemeColor');
+jest.mock('@/hooks/useBorderColor');
+
+const mockUseTranslation = useTranslation as jest.Mock;
+const mockUseThemeColor = useThemeColor as jest.Mock;
+const mockUseBorderColor = useBorderColor as jest.Mock;
+
+describe('ProfileDropdown', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseTranslation.mockReturnValue({ t: (key: string) => key });
+    mockUseThemeColor.mockReturnValue('#fff');
+    mockUseBorderColor.mockReturnValue('#ccc');
+  });
+
+  it('does not render when not visible', () => {
+    const { toJSON } = render(
+      <ProfileDropdown
+        isVisible={false}
+        onCopyLink={() => {}}
+        onSearchPosts={() => {}}
+        onAddToLists={() => {}}
+        onMuteAccount={() => {}}
+        onBlockPress={() => {}}
+        onReportAccount={() => {}}
+        isFollowing={false}
+        isBlocking={false}
+        isMuted={false}
+        isOwnProfile={false}
+      />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('handles option selection', () => {
+    const onCopyLink = jest.fn();
+    const { getByText } = render(
+      <ProfileDropdown
+        isVisible={true}
+        onCopyLink={onCopyLink}
+        onSearchPosts={() => {}}
+        onAddToLists={() => {}}
+        onMuteAccount={() => {}}
+        onBlockPress={() => {}}
+        onReportAccount={() => {}}
+        isFollowing={false}
+        isBlocking={false}
+        isMuted={false}
+        isOwnProfile={false}
+      />,
+    );
+    fireEvent.press(getByText('profile.copyLink'));
+    expect(onCopyLink).toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/components/ResponsiveLayout.test.tsx
+++ b/apps/akari/__tests__/components/ResponsiveLayout.test.tsx
@@ -1,0 +1,50 @@
+import { render } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+import { ResponsiveLayout } from '@/components/ResponsiveLayout';
+import { useResponsive } from '@/hooks/useResponsive';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+jest.mock('@/hooks/useResponsive');
+jest.mock('@/hooks/useThemeColor');
+jest.mock('@/components/Sidebar', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return { Sidebar: () => <View testID="sidebar" /> };
+});
+jest.mock('@/components/ThemedView', () => {
+  const { View } = require('react-native');
+  return { ThemedView: ({ children, ...props }: any) => <View {...props}>{children}</View> };
+});
+
+const mockUseResponsive = useResponsive as jest.Mock;
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+describe('ResponsiveLayout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseThemeColor.mockReturnValue('#fff');
+  });
+
+  it('renders sidebar on large screens', () => {
+    mockUseResponsive.mockReturnValue({ isLargeScreen: true });
+    const { getByTestId, getByText } = render(
+      <ResponsiveLayout>
+        <Text>Child</Text>
+      </ResponsiveLayout>,
+    );
+    expect(getByTestId('sidebar')).toBeTruthy();
+    expect(getByText('Child')).toBeTruthy();
+  });
+
+  it('renders children only on small screens', () => {
+    mockUseResponsive.mockReturnValue({ isLargeScreen: false });
+    const { queryByTestId, getByText } = render(
+      <ResponsiveLayout>
+        <Text>Child</Text>
+      </ResponsiveLayout>,
+    );
+    expect(getByText('Child')).toBeTruthy();
+    expect(queryByTestId('sidebar')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for LanguageSelector, NotificationSettings, NotificationTest, ProfileDropdown and ResponsiveLayout components
- update component test checklist

## Testing
- `npm run test:coverage -w akari`


------
https://chatgpt.com/codex/tasks/task_e_68c6fb67f044832b8cc923fdcf5d6152