### PR TITLE
test: add coverage for TabBar, SearchTabs, and ImageViewer

### DIFF
--- a/COMPONENT_TESTS.md
+++ b/COMPONENT_TESTS.md
@@ -9,7 +9,7 @@ This checklist shows which components under `apps/akari/components` have tests.
 - [x] GifPicker.tsx
 - [x] HandleHistoryModal.tsx
 - [x] HapticTab.tsx
-- [ ] ImageViewer.tsx
+- [x] ImageViewer.tsx
 - [x] Label.tsx
 - [x] Labels.tsx
 - [x] LanguageSelector.tsx
@@ -26,10 +26,10 @@ This checklist shows which components under `apps/akari/components` have tests.
 - [x] ResponsiveLayout.tsx
 - [ ] RichText.tsx
 - [ ] RichTextWithFacets.tsx
-- [ ] SearchTabs.tsx
+- [x] SearchTabs.tsx
 - [ ] Sidebar.tsx
 - [x] TabBadge.tsx
-- [ ] TabBar.tsx
+- [x] TabBar.tsx
 - [x] ThemedCard.tsx
 - [x] ThemedFeatureCard.tsx
 - [x] ThemedText.tsx

--- a/apps/akari/__tests__/components/ImageViewer.test.tsx
+++ b/apps/akari/__tests__/components/ImageViewer.test.tsx
@@ -1,0 +1,67 @@
+import { act, fireEvent, render } from '@testing-library/react-native';
+
+import { ImageViewer } from '@/components/ImageViewer';
+import { useThemeColor } from '@/hooks/useThemeColor';
+import { useTranslation } from '@/hooks/useTranslation';
+
+jest.mock('expo-image', () => ({ Image: jest.fn(() => null) }));
+jest.mock('@/hooks/useThemeColor');
+jest.mock('@/hooks/useTranslation');
+
+const mockUseThemeColor = useThemeColor as jest.Mock;
+const mockUseTranslation = useTranslation as jest.Mock;
+
+describe('ImageViewer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseThemeColor.mockReturnValue('#000');
+    mockUseTranslation.mockReturnValue({
+      t: (key: string) => {
+        const map: Record<string, string> = {
+          'common.loading': 'Loading',
+          'common.failedToLoadImage': 'Failed to load image',
+        };
+        return map[key] ?? key;
+      },
+    });
+  });
+
+  it('renders alt text and handles close action', () => {
+    const onClose = jest.fn();
+    const { getByText } = render(
+      <ImageViewer visible onClose={onClose} imageUrl="url" altText="Alt" />,
+    );
+
+    expect(getByText('Alt')).toBeTruthy();
+    fireEvent.press(getByText('✕'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows loading text until image loads', () => {
+    const { getByText, queryByText } = render(
+      <ImageViewer visible onClose={() => {}} imageUrl="url" />,
+    );
+
+    expect(getByText('Loading')).toBeTruthy();
+
+    const Image = require('expo-image').Image as jest.Mock;
+    act(() => {
+      Image.mock.calls[0][0].onLoad();
+    });
+
+    expect(queryByText('Loading')).toBeNull();
+  });
+
+  it('displays error text when image fails to load', () => {
+    const { getByText } = render(
+      <ImageViewer visible onClose={() => {}} imageUrl="url" />,
+    );
+
+    const Image = require('expo-image').Image as jest.Mock;
+    act(() => {
+      Image.mock.calls[0][0].onError();
+    });
+
+    expect(getByText('Failed to load image')).toBeTruthy();
+  });
+});

--- a/apps/akari/__tests__/components/SearchTabs.test.tsx
+++ b/apps/akari/__tests__/components/SearchTabs.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render } from '@testing-library/react-native';
+
+import { SearchTabs } from '@/components/SearchTabs';
+import { useBorderColor } from '@/hooks/useBorderColor';
+import { useThemeColor } from '@/hooks/useThemeColor';
+import { useTranslation } from '@/hooks/useTranslation';
+
+jest.mock('@/hooks/useBorderColor');
+jest.mock('@/hooks/useThemeColor');
+jest.mock('@/hooks/useTranslation');
+
+const mockUseBorderColor = useBorderColor as jest.Mock;
+const mockUseThemeColor = useThemeColor as jest.Mock;
+const mockUseTranslation = useTranslation as jest.Mock;
+
+describe('SearchTabs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseBorderColor.mockReturnValue('#ccc');
+    mockUseThemeColor.mockReturnValue('#000');
+    mockUseTranslation.mockReturnValue({
+      t: (key: string) => {
+        const map: Record<string, string> = {
+          'search.all': 'All',
+          'search.users': 'Users',
+          'search.posts': 'Posts',
+        };
+        return map[key] ?? key;
+      },
+    });
+  });
+
+  it('renders translated tab labels', () => {
+    const { getByText } = render(
+      <SearchTabs activeTab="all" onTabChange={() => {}} />,
+    );
+
+    expect(getByText('All')).toBeTruthy();
+    expect(getByText('Users')).toBeTruthy();
+    expect(getByText('Posts')).toBeTruthy();
+  });
+
+  it('triggers onTabChange when a tab is pressed', () => {
+    const onTabChange = jest.fn();
+    const { getByText } = render(
+      <SearchTabs activeTab="all" onTabChange={onTabChange} />,
+    );
+
+    fireEvent.press(getByText('Users'));
+
+    expect(onTabChange).toHaveBeenCalledWith('users');
+  });
+});

--- a/apps/akari/__tests__/components/TabBar.test.tsx
+++ b/apps/akari/__tests__/components/TabBar.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render } from '@testing-library/react-native';
+
+import { TabBar } from '@/components/TabBar';
+import { useBorderColor } from '@/hooks/useBorderColor';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+jest.mock('@/hooks/useBorderColor');
+jest.mock('@/hooks/useThemeColor');
+
+const mockUseBorderColor = useBorderColor as jest.Mock;
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+describe('TabBar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseBorderColor.mockReturnValue('#ccc');
+    mockUseThemeColor.mockReturnValue('#000');
+  });
+
+  const flattenStyles = (style: unknown): any[] =>
+    Array.isArray(style) ? style.flat(Infinity) : [style];
+
+  it('highlights the active tab', () => {
+    const tabs = [
+      { key: 'home', label: 'Home' },
+      { key: 'settings', label: 'Settings' },
+    ] as const;
+
+    const { getByText } = render(
+      <TabBar tabs={tabs} activeTab="home" onTabChange={() => {}} />,
+    );
+
+    const activeText = getByText('Home');
+    const inactiveText = getByText('Settings');
+
+    const activeStyles = flattenStyles(activeText.props.style);
+    const inactiveStyles = flattenStyles(inactiveText.props.style);
+
+    expect(activeStyles).toEqual(
+      expect.arrayContaining([expect.objectContaining({ fontWeight: '600' })]),
+    );
+    expect(inactiveStyles).toEqual(
+      expect.arrayContaining([expect.objectContaining({ fontWeight: '400' })]),
+    );
+  });
+
+  it('calls onTabChange when a tab is pressed', () => {
+    const tabs = [
+      { key: 'home', label: 'Home' },
+      { key: 'settings', label: 'Settings' },
+    ] as const;
+    const onTabChange = jest.fn();
+
+    const { getByText } = render(
+      <TabBar tabs={tabs} activeTab="home" onTabChange={onTabChange} />,
+    );
+
+    fireEvent.press(getByText('Settings'));
+
+    expect(onTabChange).toHaveBeenCalledWith('settings');
+  });
+});


### PR DESCRIPTION
## Summary
- add TabBar component tests for active styling and callbacks
- cover SearchTabs translation labels and interactions
- ensure ImageViewer handles alt text, loading and errors

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68c7191e7ea4832bbfb89563ba762606