### PR TITLE
test: add MediaTab component tests

### DIFF
--- a/COMPONENT_TESTS.md
+++ b/COMPONENT_TESTS.md
@@ -40,7 +40,7 @@ This checklist shows which components under `apps/akari/components` have tests.
 - [ ] YouTubeEmbed.tsx
 - [ ] profile/FeedsTab.tsx
 - [ ] profile/LikesTab.tsx
-- [ ] profile/MediaTab.tsx
+- [x] profile/MediaTab.tsx
 - [ ] profile/PostsTab.tsx
 - [ ] profile/RepliesTab.tsx
 - [ ] profile/StarterpacksTab.tsx

--- a/apps/akari/__tests__/components/profile/MediaTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/MediaTab.test.tsx
@@ -1,0 +1,144 @@
+import { render } from '@testing-library/react-native';
+import { FlatList } from 'react-native';
+
+import { MediaTab } from '@/components/profile/MediaTab';
+import { useAuthorMedia } from '@/hooks/queries/useAuthorMedia';
+import { router } from 'expo-router';
+
+jest.mock('@/hooks/queries/useAuthorMedia');
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+jest.mock('expo-router', () => ({ router: { push: jest.fn() } }));
+jest.mock('@/components/PostCard', () => ({ PostCard: jest.fn(() => null) }));
+jest.mock('@/components/skeletons', () => ({ FeedSkeleton: jest.fn(() => null) }));
+jest.mock('@/hooks/useThemeColor', () => ({ useThemeColor: () => '#000' }));
+
+const PostCardMock = require('@/components/PostCard').PostCard as jest.Mock;
+const FeedSkeletonMock = require('@/components/skeletons').FeedSkeleton as jest.Mock;
+const mockUseAuthorMedia = useAuthorMedia as jest.Mock;
+
+ type MediaItem = {
+  uri?: string;
+  indexedAt: string;
+  record?: { text?: string };
+  author: { handle: string; displayName?: string; avatar?: string };
+  likeCount?: number;
+  replyCount?: number;
+  repostCount?: number;
+  embed?: any;
+  embeds?: any[];
+  labels?: any;
+  viewer?: any;
+  cid?: string;
+};
+
+describe('MediaTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders loading skeleton when fetching media', () => {
+    mockUseAuthorMedia.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    render(<MediaTab handle="alice" />);
+    expect(FeedSkeletonMock).toHaveBeenCalledTimes(1);
+    expect(FeedSkeletonMock.mock.calls[0][0]).toMatchObject({ count: 3 });
+  });
+
+  it('shows empty state when no media is available', () => {
+    mockUseAuthorMedia.mockReturnValue({
+      data: [],
+      isLoading: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    const { getByText } = render(<MediaTab handle="alice" />);
+    expect(getByText('profile.noMedia')).toBeTruthy();
+  });
+
+  it('renders posts and navigates to post on press', () => {
+    const media: MediaItem[] = [
+      {
+        uri: 'at://post1',
+        indexedAt: '2024-01-01T00:00:00Z',
+        record: { text: 'hello' },
+        author: { handle: 'user1', displayName: 'User 1', avatar: 'a' },
+      },
+      {
+        uri: undefined,
+        indexedAt: '2024-01-02T00:00:00Z',
+        record: { text: 'skip' },
+        author: { handle: 'user2' },
+      },
+    ];
+
+    mockUseAuthorMedia.mockReturnValue({
+      data: media,
+      isLoading: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    render(<MediaTab handle="alice" />);
+
+    expect(PostCardMock).toHaveBeenCalledTimes(1);
+    const press = PostCardMock.mock.calls[0][0].onPress;
+    press();
+    expect(router.push).toHaveBeenCalledWith('/post/' + encodeURIComponent('at://post1'));
+  });
+
+  it('fetches next page when end is reached', () => {
+    const fetchNextPage = jest.fn();
+    mockUseAuthorMedia.mockReturnValue({
+      data: [
+        {
+          uri: 'at://post1',
+          indexedAt: '2024-01-01T00:00:00Z',
+          author: { handle: 'user1' },
+        },
+      ],
+      isLoading: false,
+      fetchNextPage,
+      hasNextPage: true,
+      isFetchingNextPage: false,
+    });
+
+    const { UNSAFE_getByType } = render(<MediaTab handle="alice" />);
+    const list = UNSAFE_getByType(FlatList);
+    list.props.onEndReached();
+    expect(fetchNextPage).toHaveBeenCalled();
+  });
+
+  it('does not fetch next page while already fetching and shows footer', () => {
+    const fetchNextPage = jest.fn();
+    mockUseAuthorMedia.mockReturnValue({
+      data: [
+        {
+          uri: 'at://post1',
+          indexedAt: '2024-01-01T00:00:00Z',
+          author: { handle: 'user1' },
+        },
+      ],
+      isLoading: false,
+      fetchNextPage,
+      hasNextPage: true,
+      isFetchingNextPage: true,
+    });
+
+    const { UNSAFE_getByType, getByText } = render(<MediaTab handle="alice" />);
+    const list = UNSAFE_getByType(FlatList);
+    list.props.onEndReached();
+    expect(fetchNextPage).not.toHaveBeenCalled();
+    expect(getByText('common.loading')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for profile MediaTab component
- mark MediaTab as tested in component checklist

## Testing
- `npm run test:coverage` *(fails: Missing script)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c719e3bd10832ba9e47e9ab7acfac4