### PR TITLE
test: add StarterpacksTab component tests

### DIFF
--- a/COMPONENT_TESTS.md
+++ b/COMPONENT_TESTS.md
@@ -43,7 +43,7 @@ This checklist shows which components under `apps/akari/components` have tests.
 - [ ] profile/MediaTab.tsx
 - [ ] profile/PostsTab.tsx
 - [ ] profile/RepliesTab.tsx
-- [ ] profile/StarterpacksTab.tsx
+ - [x] profile/StarterpacksTab.tsx
 - [ ] profile/VideosTab.tsx
 - [ ] skeletons/ConversationSkeleton.tsx
 - [ ] skeletons/FeedSkeleton.tsx

--- a/apps/akari/__tests__/components/profile/StarterpacksTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/StarterpacksTab.test.tsx
@@ -1,0 +1,129 @@
+import { act, render } from '@testing-library/react-native';
+import { FlatList, Text } from 'react-native';
+
+import { StarterpacksTab } from '@/components/profile/StarterpacksTab';
+import { useAuthorStarterpacks } from '@/hooks/queries/useAuthorStarterpacks';
+import { useThemeColor } from '@/hooks/useThemeColor';
+import { useTranslation } from '@/hooks/useTranslation';
+
+jest.mock('@/hooks/queries/useAuthorStarterpacks');
+jest.mock('@/hooks/useThemeColor');
+jest.mock('@/hooks/useTranslation');
+jest.mock('@/components/skeletons', () => {
+  const { Text } = require('react-native');
+  return { FeedSkeleton: () => <Text>feed skeleton</Text> };
+});
+
+const mockUseAuthorStarterpacks = useAuthorStarterpacks as jest.Mock;
+const mockUseThemeColor = useThemeColor as jest.Mock;
+const mockUseTranslation = useTranslation as jest.Mock;
+
+describe('StarterpacksTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseThemeColor.mockImplementation((colors) => colors.light);
+    mockUseTranslation.mockReturnValue({ t: (key: string) => key });
+  });
+
+  it('shows loading skeleton while fetching data', () => {
+    mockUseAuthorStarterpacks.mockReturnValue({
+      data: [],
+      isLoading: true,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    const { getByText } = render(<StarterpacksTab handle="alice" />);
+    expect(getByText('feed skeleton')).toBeTruthy();
+  });
+
+  it('renders empty state when no starterpacks exist', () => {
+    mockUseAuthorStarterpacks.mockReturnValue({
+      data: [],
+      isLoading: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    const { getByText } = render(<StarterpacksTab handle="alice" />);
+    expect(getByText('profile.noStarterpacks')).toBeTruthy();
+  });
+
+  it('renders starterpacks and loads more on end reach', () => {
+    const fetchNextPage = jest.fn();
+    const starterpack = {
+      uri: 'at://pack/1',
+      cid: 'cid1',
+      record: {
+        $type: 'app.bsky.graph.starterpack',
+        createdAt: '',
+        description: 'cool pack',
+        feeds: [],
+        list: '',
+        name: 'Pack One',
+        updatedAt: '',
+      },
+      creator: { handle: 'alice' },
+      joinedWeekCount: 2,
+      joinedAllTimeCount: 5,
+      labels: [],
+      indexedAt: '',
+    } as any;
+
+    mockUseAuthorStarterpacks.mockReturnValue({
+      data: [starterpack],
+      isLoading: false,
+      fetchNextPage,
+      hasNextPage: true,
+      isFetchingNextPage: false,
+    });
+
+    const { getByText, UNSAFE_getByType, queryByText } = render(
+      <StarterpacksTab handle="alice" />,
+    );
+
+    expect(getByText('Pack One')).toBeTruthy();
+    expect(queryByText('common.loading')).toBeNull();
+
+    act(() => {
+      UNSAFE_getByType(FlatList).props.onEndReached();
+    });
+
+    expect(fetchNextPage).toHaveBeenCalled();
+  });
+
+  it('shows loading footer when fetching next page', () => {
+    mockUseAuthorStarterpacks.mockReturnValue({
+      data: [
+        {
+          uri: 'at://pack/1',
+          cid: 'cid1',
+          record: {
+            $type: 'app.bsky.graph.starterpack',
+            createdAt: '',
+            description: 'cool pack',
+            feeds: [],
+            list: '',
+            name: 'Pack One',
+            updatedAt: '',
+          },
+          creator: { handle: 'alice' },
+          joinedWeekCount: 2,
+          joinedAllTimeCount: 5,
+          labels: [],
+          indexedAt: '',
+        },
+      ],
+      isLoading: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: true,
+      isFetchingNextPage: true,
+    });
+
+    const { getByText } = render(<StarterpacksTab handle="alice" />);
+    expect(getByText('common.loading')).toBeTruthy();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for StarterpacksTab to cover loading, empty, pagination scenarios
- mark StarterpacksTab as tested in COMPONENT_TESTS.md

## Testing
- `npm run test:coverage --workspace=akari`


------
https://chatgpt.com/codex/tasks/task_e_68c719f3ee14832bad7b7e97fbad56c4