### PR TITLE
test: add LikesTab component tests

### DIFF
--- a/COMPONENT_TESTS.md
+++ b/COMPONENT_TESTS.md
@@ -39,7 +39,7 @@ This checklist shows which components under `apps/akari/components` have tests.
 - [ ] VideoPlayer.web.tsx
 - [ ] YouTubeEmbed.tsx
 - [ ] profile/FeedsTab.tsx
-- [ ] profile/LikesTab.tsx
+- [x] profile/LikesTab.tsx
 - [ ] profile/MediaTab.tsx
 - [ ] profile/PostsTab.tsx
 - [ ] profile/RepliesTab.tsx


### PR DESCRIPTION
## Summary
- add tests covering loading, empty, pagination, and navigation behavior for LikesTab
- mark LikesTab as tested in component coverage checklist

## Testing
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c719df5e08832bbc1e4ed04fc270e8