### PR TITLE
test: add YouTubeEmbed component tests

### DIFF
--- a/apps/akari/__tests__/components/YouTubeEmbed.test.tsx
+++ b/apps/akari/__tests__/components/YouTubeEmbed.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import { Linking } from 'react-native';
+
+import { YouTubeEmbed } from '@/components/YouTubeEmbed';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+jest.mock('react-native-reanimated', () => require('react-native-reanimated/mock'));
+jest.mock('expo-image', () => ({ Image: jest.fn(() => null) }));
+jest.mock('@/hooks/useThemeColor');
+
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+type Embed = {
+  $type: 'app.bsky.embed.external';
+  external: {
+    description: string;
+    title: string;
+    uri: string;
+    thumb?: {
+      $type: 'blob';
+      ref: { $link: string };
+      mimeType: string;
+      size: number;
+    };
+  };
+};
+
+const createEmbed = (uri: string, thumbUrl?: string): Embed => ({
+  $type: 'app.bsky.embed.external',
+  external: {
+    description: 'Video description',
+    title: 'Video title',
+    uri,
+    ...(thumbUrl && {
+      thumb: {
+        $type: 'blob',
+        ref: { $link: thumbUrl },
+        mimeType: 'image/jpeg',
+        size: 123,
+      },
+    }),
+  },
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseThemeColor.mockReturnValue('#000');
+});
+
+describe('YouTubeEmbed', () => {
+  it.each([
+    ['watch link', 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'],
+    ['embed link', 'https://youtube.com/embed/dQw4w9WgXcQ'],
+  ])('renders video for %s and opens link on press', (_, uri) => {
+    const embed = createEmbed(uri);
+    const openUrl = jest.spyOn(Linking, 'openURL').mockResolvedValueOnce();
+
+    const { getByText } = render(<YouTubeEmbed embed={embed} />);
+
+    expect(getByText('Video title')).toBeTruthy();
+    expect(getByText('Video description')).toBeTruthy();
+    expect(getByText('YouTube')).toBeTruthy();
+
+    fireEvent.press(getByText('Video title'));
+
+    expect(openUrl).toHaveBeenCalledWith(uri);
+
+    const Image = require('expo-image').Image as jest.Mock;
+    const props = Image.mock.calls[0][0];
+    expect(props.source).toEqual({
+      uri: 'https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg',
+    });
+  });
+
+  it('uses provided thumbnail when URL is not YouTube', () => {
+    const embed = createEmbed(
+      'https://example.com/video',
+      'https://example.com/thumb.jpg',
+    );
+    const openUrl = jest.spyOn(Linking, 'openURL').mockResolvedValueOnce();
+    const { getByText } = render(<YouTubeEmbed embed={embed} />);
+
+    fireEvent.press(getByText('Video title'));
+    expect(openUrl).toHaveBeenCalledWith('https://example.com/video');
+
+    const Image = require('expo-image').Image as jest.Mock;
+    const props = Image.mock.calls[0][0];
+    expect(props.source).toEqual({ uri: 'https://example.com/thumb.jpg' });
+  });
+
+  it('renders without thumbnail when none available', () => {
+    const embed = createEmbed('https://example.com/video');
+    const openUrl = jest.spyOn(Linking, 'openURL').mockResolvedValueOnce();
+    const { getByText } = render(<YouTubeEmbed embed={embed} />);
+
+    fireEvent.press(getByText('Video title'));
+    expect(openUrl).toHaveBeenCalledWith('https://example.com/video');
+
+    const Image = require('expo-image').Image as jest.Mock;
+    expect(Image).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests verifying YouTubeEmbed renders and opens links
- cover thumbnail selection from YouTube or provided images
- handle absence of thumbnails gracefully

## Testing
- `npm run test:coverage --workspace=apps/akari`


------
https://chatgpt.com/codex/tasks/task_e_68c72ad3e318832b8c2a274c83a915c0