### PR TITLE
test: add coverage for ExternalLink component

### DIFF
--- a/apps/akari/__tests__/components/ExternalLink.test.tsx
+++ b/apps/akari/__tests__/components/ExternalLink.test.tsx
@@ -1,4 +1,6 @@
-import { render } from '@testing-library/react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { Platform } from 'react-native';
+import { openBrowserAsync } from 'expo-web-browser';
 import { ExternalLink } from '@/components/ExternalLink';
 
 jest.mock('react-native-reanimated', () => require('react-native-reanimated/mock'));
@@ -15,9 +17,56 @@ jest.mock('expo-router', () => {
   };
 });
 
+jest.mock('expo-web-browser', () => ({
+  openBrowserAsync: jest.fn(),
+}));
+
+const originalPlatform = Platform.OS;
+
+afterEach(() => {
+  Platform.OS = originalPlatform;
+  jest.clearAllMocks();
+});
+
 it('should render external link', () => {
   const { getByRole } = render(
     <ExternalLink href="https://example.com">Test Link</ExternalLink>,
   );
   expect(getByRole('link', { name: /test link/i })).toBeTruthy();
+});
+
+it('opens in an in-app browser on native platforms', async () => {
+  Platform.OS = 'ios';
+
+  const { getByRole } = render(
+    <ExternalLink href="https://example.com">Native Link</ExternalLink>,
+  );
+
+  const link = getByRole('link', { name: /native link/i });
+  const preventDefault = jest.fn();
+
+  fireEvent.press(link, { preventDefault });
+
+  await waitFor(() => {
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(openBrowserAsync).toHaveBeenCalledWith('https://example.com');
+  });
+});
+
+it('uses default browser on web without preventing default', async () => {
+  Platform.OS = 'web';
+
+  const { getByRole } = render(
+    <ExternalLink href="https://example.com">Web Link</ExternalLink>,
+  );
+
+  const link = getByRole('link', { name: /web link/i });
+  const preventDefault = jest.fn();
+
+  fireEvent.press(link, { preventDefault });
+
+  await waitFor(() => {
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(openBrowserAsync).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- test ExternalLink native vs web handling

## Testing
- `npm run test:coverage --workspace=apps/akari`


------
https://chatgpt.com/codex/tasks/task_e_68c741d88b1c832b840cc2c5a6eb87bc