### PR TITLE
test: add skeleton component tests

### DIFF
--- a/COMPONENT_TESTS.md
+++ b/COMPONENT_TESTS.md
@@ -45,14 +45,14 @@ This checklist shows which components under `apps/akari/components` have tests.
 - [x] profile/RepliesTab.tsx
 - [x] profile/StarterpacksTab.tsx
 - [x] profile/VideosTab.tsx
-- [ ] skeletons/ConversationSkeleton.tsx
-- [ ] skeletons/FeedSkeleton.tsx
-- [ ] skeletons/NotificationSkeleton.tsx
-- [ ] skeletons/PostCardSkeleton.tsx
-- [ ] skeletons/PostDetailSkeleton.tsx
-- [ ] skeletons/ProfileHeaderSkeleton.tsx
-- [ ] skeletons/SearchResultSkeleton.tsx
-- [ ] skeletons/SettingsSkeleton.tsx
+- [x] skeletons/ConversationSkeleton.tsx
+- [x] skeletons/FeedSkeleton.tsx
+- [x] skeletons/NotificationSkeleton.tsx
+- [x] skeletons/PostCardSkeleton.tsx
+- [x] skeletons/PostDetailSkeleton.tsx
+- [x] skeletons/ProfileHeaderSkeleton.tsx
+- [x] skeletons/SearchResultSkeleton.tsx
+- [x] skeletons/SettingsSkeleton.tsx
 - [ ] ui/IconSymbol.ios.tsx
 - [ ] ui/IconSymbol.tsx
 - [ ] ui/Skeleton.tsx

--- a/apps/akari/__tests__/components/skeletons/ConversationSkeleton.test.tsx
+++ b/apps/akari/__tests__/components/skeletons/ConversationSkeleton.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react-native';
+
+import { ConversationSkeleton } from '@/components/skeletons/ConversationSkeleton';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+jest.mock('@/hooks/useThemeColor');
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+describe('ConversationSkeleton', () => {
+  beforeEach(() => {
+    mockUseThemeColor.mockImplementation((colors) => colors.light);
+  });
+
+  it('renders the expected number of skeleton elements', () => {
+    const { UNSAFE_getAllByType } = render(<ConversationSkeleton />);
+    const skeletons = UNSAFE_getAllByType(Skeleton);
+    expect(skeletons).toHaveLength(5);
+  });
+});

--- a/apps/akari/__tests__/components/skeletons/FeedSkeleton.test.tsx
+++ b/apps/akari/__tests__/components/skeletons/FeedSkeleton.test.tsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react-native';
+
+import { FeedSkeleton } from '@/components/skeletons/FeedSkeleton';
+import { PostCardSkeleton } from '@/components/skeletons/PostCardSkeleton';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+jest.mock('@/hooks/useThemeColor');
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+describe('FeedSkeleton', () => {
+  beforeEach(() => {
+    mockUseThemeColor.mockImplementation((colors) => colors.light);
+  });
+
+  it('renders three post card skeletons by default', () => {
+    const { UNSAFE_getAllByType } = render(<FeedSkeleton />);
+    expect(UNSAFE_getAllByType(PostCardSkeleton)).toHaveLength(3);
+  });
+
+  it('renders the specified number of post card skeletons', () => {
+    const { UNSAFE_getAllByType } = render(<FeedSkeleton count={5} />);
+    expect(UNSAFE_getAllByType(PostCardSkeleton)).toHaveLength(5);
+  });
+});

--- a/apps/akari/__tests__/components/skeletons/NotificationSkeleton.test.tsx
+++ b/apps/akari/__tests__/components/skeletons/NotificationSkeleton.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react-native';
+
+import { NotificationSkeleton } from '@/components/skeletons/NotificationSkeleton';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+jest.mock('@/hooks/useThemeColor');
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+describe('NotificationSkeleton', () => {
+  beforeEach(() => {
+    mockUseThemeColor.mockImplementation((colors) => colors.light);
+  });
+
+  it('renders all skeleton placeholders', () => {
+    const { UNSAFE_getAllByType } = render(<NotificationSkeleton />);
+    expect(UNSAFE_getAllByType(Skeleton)).toHaveLength(10);
+  });
+});

--- a/apps/akari/__tests__/components/skeletons/PostCardSkeleton.test.tsx
+++ b/apps/akari/__tests__/components/skeletons/PostCardSkeleton.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react-native';
+
+import { PostCardSkeleton } from '@/components/skeletons/PostCardSkeleton';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+jest.mock('@/hooks/useThemeColor');
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+describe('PostCardSkeleton', () => {
+  beforeEach(() => {
+    mockUseThemeColor.mockImplementation((colors) => colors.light);
+  });
+
+  it('renders the correct number of skeleton elements', () => {
+    const { UNSAFE_getAllByType } = render(<PostCardSkeleton />);
+    expect(UNSAFE_getAllByType(Skeleton)).toHaveLength(14);
+  });
+});

--- a/apps/akari/__tests__/components/skeletons/PostDetailSkeleton.test.tsx
+++ b/apps/akari/__tests__/components/skeletons/PostDetailSkeleton.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react-native';
+
+import { PostDetailSkeleton } from '@/components/skeletons/PostDetailSkeleton';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+jest.mock('@/hooks/useThemeColor');
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+describe('PostDetailSkeleton', () => {
+  beforeEach(() => {
+    mockUseThemeColor.mockImplementation((colors) => colors.light);
+  });
+
+  it('renders skeletons for post and comments', () => {
+    const { UNSAFE_getAllByType } = render(<PostDetailSkeleton />);
+    expect(UNSAFE_getAllByType(Skeleton)).toHaveLength(45);
+  });
+});

--- a/apps/akari/__tests__/components/skeletons/ProfileHeaderSkeleton.test.tsx
+++ b/apps/akari/__tests__/components/skeletons/ProfileHeaderSkeleton.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react-native';
+
+import { ProfileHeaderSkeleton } from '@/components/skeletons/ProfileHeaderSkeleton';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+jest.mock('@/hooks/useThemeColor');
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+describe('ProfileHeaderSkeleton', () => {
+  beforeEach(() => {
+    mockUseThemeColor.mockImplementation((colors) => colors.light);
+  });
+
+  it('renders all profile header skeleton elements', () => {
+    const { UNSAFE_getAllByType } = render(<ProfileHeaderSkeleton />);
+    expect(UNSAFE_getAllByType(Skeleton)).toHaveLength(14);
+  });
+});

--- a/apps/akari/__tests__/components/skeletons/SearchResultSkeleton.test.tsx
+++ b/apps/akari/__tests__/components/skeletons/SearchResultSkeleton.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react-native';
+
+import { SearchResultSkeleton } from '@/components/skeletons/SearchResultSkeleton';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+jest.mock('@/hooks/useThemeColor');
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+describe('SearchResultSkeleton', () => {
+  beforeEach(() => {
+    mockUseThemeColor.mockImplementation((colors) => colors.light);
+  });
+
+  it('renders all skeleton elements for a search result', () => {
+    const { UNSAFE_getAllByType } = render(<SearchResultSkeleton />);
+    expect(UNSAFE_getAllByType(Skeleton)).toHaveLength(4);
+  });
+});

--- a/apps/akari/__tests__/components/skeletons/SettingsSkeleton.test.tsx
+++ b/apps/akari/__tests__/components/skeletons/SettingsSkeleton.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react-native';
+
+import { SettingsSkeleton } from '@/components/skeletons/SettingsSkeleton';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+jest.mock('@/hooks/useThemeColor');
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+describe('SettingsSkeleton', () => {
+  beforeEach(() => {
+    mockUseThemeColor.mockImplementation((colors) => colors.light);
+  });
+
+  it('renders all settings skeleton elements', () => {
+    const { UNSAFE_getAllByType } = render(<SettingsSkeleton />);
+    expect(UNSAFE_getAllByType(Skeleton)).toHaveLength(21);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for conversation, feed, notification, post, profile header, search result, and settings skeleton components
- mark skeleton components as covered in component test checklist

## Testing
- `npm run test:coverage --workspace=akari`

------
https://chatgpt.com/codex/tasks/task_e_68c74406f92c832b9f1685b377c027fa