### PR TITLE
test: add not-found screen tests

### DIFF
--- a/apps/akari/__tests__/app/not-found.test.tsx
+++ b/apps/akari/__tests__/app/not-found.test.tsx
@@ -1,0 +1,48 @@
+import { render } from '@testing-library/react-native';
+
+import NotFoundScreen from '@/app/+not-found';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+jest.mock('expo-router', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+      <Text accessibilityRole="link" href={href}>
+        {children}
+      </Text>
+    ),
+    Stack: {
+      Screen: jest.fn(() => null),
+    },
+  };
+});
+
+jest.mock('@/hooks/useThemeColor');
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseThemeColor.mockImplementation((colors: { light?: string }) => colors.light ?? '#fff');
+});
+
+describe('NotFoundScreen', () => {
+  it('renders error message and link to home screen', () => {
+    const { getByText, getByRole } = render(<NotFoundScreen />);
+
+    expect(getByText('This screen does not exist.')).toBeTruthy();
+
+    const link = getByRole('link', { name: 'Go to home screen!' });
+    expect(link.props.href).toBe('/');
+  });
+
+  it('sets stack screen title', () => {
+    render(<NotFoundScreen />);
+
+    const { Screen } = require('expo-router').Stack;
+    expect(Screen).toHaveBeenCalled();
+    expect(Screen.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ options: { title: 'Oops!' } }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `+not-found` page

## Testing
- `npm run test:coverage --workspace=akari`


------
https://chatgpt.com/codex/tasks/task_e_68c744dfdd98832b8e1a945b841a967a