### PR TITLE
test: expand PostComposer coverage

### DIFF
--- a/apps/akari/__tests__/components/PostComposer.test.tsx
+++ b/apps/akari/__tests__/components/PostComposer.test.tsx
@@ -76,4 +76,43 @@ describe('PostComposer', () => {
     fireEvent.press(getByText('✕'));
     expect(queryByPlaceholderText('post.imageAltTextPlaceholder')).toBeNull();
   });
+
+  it('does not post when empty', async () => {
+    const mutateAsync = jest.fn();
+    mockUseCreatePost.mockReturnValue({ mutateAsync, isPending: false });
+    const onClose = jest.fn();
+
+    const { getByText } = render(<PostComposer visible onClose={onClose} />);
+
+    await act(async () => {
+      fireEvent.press(getByText('post.post'));
+    });
+
+    expect(mutateAsync).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('adds gif through GifPicker', async () => {
+    mockUseCreatePost.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+    const { getByLabelText, getByPlaceholderText } = render(
+      <PostComposer visible onClose={jest.fn()} />,
+    );
+
+    const gifPickerMock = require('@/components/GifPicker').GifPicker as jest.Mock;
+
+    fireEvent.press(getByLabelText('gif.addGif'));
+
+    const lastCall = gifPickerMock.mock.calls[gifPickerMock.mock.calls.length - 1][0];
+    expect(lastCall).toEqual(
+      expect.objectContaining({ visible: true, onSelectGif: expect.any(Function) }),
+    );
+
+    const { onSelectGif } = lastCall;
+
+    act(() => {
+      onSelectGif({ uri: 'gif.gif', alt: '', mimeType: 'image/gif', tenorId: '1' });
+    });
+
+    expect(getByPlaceholderText('post.imageAltTextPlaceholder')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- add regression tests for empty submissions and GIF attachments in PostComposer

## Testing
- `npm test -- -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c74737799c832b8989888e2644b22b