### PR TITLE
test: add download handling tests for ImageViewer

### DIFF
--- a/apps/akari/__tests__/components/ImageViewer.test.tsx
+++ b/apps/akari/__tests__/components/ImageViewer.test.tsx
@@ -1,15 +1,19 @@
 import { act, fireEvent, render } from '@testing-library/react-native';
+import { Platform, Share } from 'react-native';
 
 import { ImageViewer } from '@/components/ImageViewer';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
+import { showAlert } from '@/utils/alert';
 
 jest.mock('expo-image', () => ({ Image: jest.fn(() => null) }));
 jest.mock('@/hooks/useThemeColor');
 jest.mock('@/hooks/useTranslation');
+jest.mock('@/utils/alert');
 
 const mockUseThemeColor = useThemeColor as jest.Mock;
 const mockUseTranslation = useTranslation as jest.Mock;
+const mockShowAlert = showAlert as jest.Mock;
 
 describe('ImageViewer', () => {
   beforeEach(() => {
@@ -20,6 +24,9 @@ describe('ImageViewer', () => {
         const map: Record<string, string> = {
           'common.loading': 'Loading',
           'common.failedToLoadImage': 'Failed to load image',
+          'common.checkOutImage': 'Check out this image',
+          'common.error': 'Error',
+          'common.failedToDownloadImage': 'Failed to download image',
         };
         return map[key] ?? key;
       },
@@ -63,5 +70,78 @@ describe('ImageViewer', () => {
     });
 
     expect(getByText('Failed to load image')).toBeTruthy();
+  });
+
+  it('uses Share API to download image on mobile platforms', async () => {
+    const originalOS = Platform.OS;
+    Platform.OS = 'ios';
+    const shareMock = jest.spyOn(Share, 'share').mockResolvedValue({} as any);
+
+    const { getByText } = render(
+      <ImageViewer visible onClose={() => {}} imageUrl="url" />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByText('⬇️'));
+    });
+
+    expect(shareMock).toHaveBeenCalledWith({
+      url: 'url',
+      message: 'Check out this image',
+    });
+
+    shareMock.mockRestore();
+    Platform.OS = originalOS;
+  });
+
+  it('creates a download link on web platforms', () => {
+    const originalOS = Platform.OS;
+    Platform.OS = 'web';
+
+    const click = jest.fn();
+    const link = { href: '', download: '', click } as HTMLAnchorElement;
+    const appendChild = jest.fn();
+    const removeChild = jest.fn();
+    (global as any).document = {
+      createElement: jest.fn(() => link),
+      body: { appendChild, removeChild },
+    } as unknown as Document;
+
+    const { getByText } = render(
+      <ImageViewer visible onClose={() => {}} imageUrl="url" />,
+    );
+
+    fireEvent.press(getByText('⬇️'));
+
+    expect((global as any).document.createElement).toHaveBeenCalledWith('a');
+    expect(link.href).toBe('url');
+    expect(link.download).toBe('image.jpg');
+    expect(click).toHaveBeenCalled();
+    expect(appendChild).toHaveBeenCalledWith(link);
+    expect(removeChild).toHaveBeenCalledWith(link);
+
+    delete (global as any).document;
+    Platform.OS = originalOS;
+  });
+
+  it('shows alert when download fails', async () => {
+    const originalOS = Platform.OS;
+    Platform.OS = 'ios';
+    jest.spyOn(Share, 'share').mockRejectedValue(new Error('fail'));
+
+    const { getByText } = render(
+      <ImageViewer visible onClose={() => {}} imageUrl="url" />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByText('⬇️'));
+    });
+
+    expect(mockShowAlert).toHaveBeenCalledWith({
+      title: 'Error',
+      message: 'Failed to download image',
+    });
+
+    Platform.OS = originalOS;
   });
 });


### PR DESCRIPTION
## Summary
- add tests for ImageViewer download button
- cover web download, mobile Share API, and error handling

## Testing
- `npm run test:coverage` *(fails: Missing script: "test:coverage")*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7472b4fd8832b85d46f6e4bcbc2c7