### PR TITLE
test: add useTranslation hook tests

### DIFF
--- a/apps/akari/__tests__/hooks/useTranslation.test.ts
+++ b/apps/akari/__tests__/hooks/useTranslation.test.ts
@@ -1,0 +1,52 @@
+import { renderHook } from '@testing-library/react-native';
+
+import useTranslation from '@/hooks/useTranslation';
+import { useLanguage } from '@/contexts/LanguageContext';
+import i18n from '@/utils/i18n';
+
+jest.mock('@/contexts/LanguageContext');
+jest.mock('@/utils/i18n', () => ({
+  __esModule: true,
+  default: { t: jest.fn() },
+}));
+
+const mockUseLanguage = useLanguage as jest.Mock;
+const mockI18n = i18n as { t: jest.Mock };
+
+describe('useTranslation', () => {
+  let changeLanguage: jest.Mock;
+  let currentLocale: string;
+  let availableLocales: string[];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    changeLanguage = jest.fn();
+    currentLocale = 'en';
+    availableLocales = ['en', 'es'];
+    mockUseLanguage.mockReturnValue({
+      currentLocale,
+      changeLanguage,
+      availableLocales,
+    });
+  });
+
+  it('delegates translation to i18n.t with options', () => {
+    mockI18n.t.mockReturnValue('translated');
+
+    const { result } = renderHook(() => useTranslation());
+    const output = result.current.t('common.ok' as any, { count: 1 });
+
+    expect(mockI18n.t).toHaveBeenCalledWith('common.ok', { count: 1 });
+    expect(output).toBe('translated');
+  });
+
+  it('exposes language helpers from context', () => {
+    const { result } = renderHook(() => useTranslation());
+
+    expect(result.current.changeLanguage).toBe(changeLanguage);
+    expect(result.current.currentLocale).toBe(currentLocale);
+    expect(result.current.availableLocales).toEqual(availableLocales);
+    expect(result.current.locale).toBe(currentLocale);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for useTranslation hook to ensure translations use i18n and expose language context helpers

## Testing
- `npm run test:coverage --workspace=apps/akari`


------
https://chatgpt.com/codex/tasks/task_e_68c74cb5a97c832b877522001ef9b261