### PR TITLE
test: add comprehensive coverage for profile tabs

### DIFF
--- a/apps/akari/__tests__/components/profile/FeedsTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/FeedsTab.test.tsx
@@ -1,0 +1,158 @@
+import { act, fireEvent, render } from '@testing-library/react-native';
+import { FlatList, Text } from 'react-native';
+
+import { FeedsTab } from '@/components/profile/FeedsTab';
+import { useAuthorFeeds } from '@/hooks/queries/useAuthorFeeds';
+import { useThemeColor } from '@/hooks/useThemeColor';
+import { useTranslation } from '@/hooks/useTranslation';
+
+jest.mock('@/hooks/queries/useAuthorFeeds');
+
+jest.mock('@/hooks/useTranslation');
+
+jest.mock('@/hooks/useThemeColor');
+
+jest.mock('@/components/skeletons', () => {
+  const { Text } = require('react-native');
+  return { FeedSkeleton: () => <Text>feed skeleton</Text> };
+});
+
+jest.mock('@/components/ui/IconSymbol', () => {
+  const { Text } = require('react-native');
+  return { IconSymbol: ({ name }: { name: string }) => <Text>{name}</Text> };
+});
+
+const mockUseAuthorFeeds = useAuthorFeeds as jest.Mock;
+const mockUseTranslation = useTranslation as jest.Mock;
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+describe('FeedsTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseTranslation.mockReturnValue({ t: (k: string) => k });
+    mockUseThemeColor.mockImplementation((colors) =>
+      typeof colors === 'string' ? colors : colors.light,
+    );
+  });
+
+  it('shows skeleton while loading', () => {
+    mockUseAuthorFeeds.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    const { getByText } = render(<FeedsTab handle="alice" />);
+    expect(getByText('feed skeleton')).toBeTruthy();
+  });
+
+  it('shows empty state when no feeds', () => {
+    mockUseAuthorFeeds.mockReturnValue({
+      data: [],
+      isLoading: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    const { getByText } = render(<FeedsTab handle="alice" />);
+    expect(getByText('profile.noFeeds')).toBeTruthy();
+  });
+
+  it('renders feeds and handles pin and interactions', () => {
+    const fetchNextPage = jest.fn();
+    const feeds = [
+      {
+        uri: 'feed1',
+        displayName: 'Feed One',
+        creator: { handle: 'alice' },
+        description: 'desc',
+        likeCount: 1,
+        acceptsInteractions: true,
+      },
+      {
+        uri: 'feed2',
+        displayName: 'Feed Two',
+        creator: { handle: 'bob' },
+        likeCount: 0,
+        acceptsInteractions: false,
+      },
+    ];
+
+    mockUseAuthorFeeds.mockReturnValue({
+      data: feeds,
+      isLoading: false,
+      fetchNextPage,
+      hasNextPage: true,
+      isFetchingNextPage: false,
+    });
+
+    const { getByText, getAllByText, UNSAFE_getByType } = render(
+      <FeedsTab handle="alice" />,
+    );
+
+    expect(getByText('desc')).toBeTruthy();
+    expect(getByText('Interactive')).toBeTruthy();
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    fireEvent.press(getAllByText('pin')[0]);
+    expect(logSpy).toHaveBeenCalledWith('Pin feed:', 'feed1');
+    logSpy.mockRestore();
+
+    act(() => {
+      UNSAFE_getByType(FlatList).props.onEndReached();
+    });
+    expect(fetchNextPage).toHaveBeenCalled();
+  });
+
+  it('shows footer while fetching next page', () => {
+    const fetchNextPage = jest.fn();
+    mockUseAuthorFeeds.mockReturnValue({
+      data: [
+        {
+          uri: 'feed1',
+          displayName: 'Feed One',
+          creator: { handle: 'alice' },
+          likeCount: 1,
+        },
+      ],
+      isLoading: false,
+      fetchNextPage,
+      hasNextPage: true,
+      isFetchingNextPage: true,
+    });
+
+    const { getByText, UNSAFE_getByType } = render(<FeedsTab handle="alice" />);
+    expect(getByText('common.loading')).toBeTruthy();
+    act(() => {
+      UNSAFE_getByType(FlatList).props.onEndReached();
+    });
+    expect(fetchNextPage).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when no more feeds', () => {
+    const fetchNextPage = jest.fn();
+    mockUseAuthorFeeds.mockReturnValue({
+      data: [
+        {
+          uri: 'feed1',
+          displayName: 'Feed One',
+          creator: { handle: 'alice' },
+          likeCount: 1,
+        },
+      ],
+      isLoading: false,
+      fetchNextPage,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    const { UNSAFE_getByType } = render(<FeedsTab handle="alice" />);
+    act(() => {
+      UNSAFE_getByType(FlatList).props.onEndReached();
+    });
+    expect(fetchNextPage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/components/profile/PostsTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/PostsTab.test.tsx
@@ -148,5 +148,39 @@ describe('PostsTab', () => {
     });
     expect(fetchNextPage).not.toHaveBeenCalled();
   });
+
+  it('falls back to unknown when parent handle missing', () => {
+    const post = {
+      uri: 'at://example/post2',
+      indexedAt: '2024-01-01T00:00:00Z',
+      record: { text: 'child' },
+      author: { handle: 'alice', displayName: 'Alice', avatar: 'a' },
+      reply: {
+        parent: {
+          author: { displayName: 'NoHandle' },
+          record: { text: 'parent' },
+        },
+      },
+      likeCount: 0,
+      replyCount: 0,
+      repostCount: 0,
+      cid: 'cid',
+    } as any;
+
+    mockUseAuthorPosts.mockReturnValue({
+      data: [post],
+      isLoading: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    render(<PostsTab handle="alice" />);
+    const call = mockPostCard.mock.calls[0][0];
+    expect(call.post.replyTo).toEqual({
+      author: { handle: 'unknown', displayName: 'NoHandle' },
+      text: 'parent',
+    });
+  });
 });
 

--- a/apps/akari/__tests__/components/profile/StarterpacksTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/StarterpacksTab.test.tsx
@@ -125,5 +125,41 @@ describe('StarterpacksTab', () => {
     const { getByText } = render(<StarterpacksTab handle="alice" />);
     expect(getByText('common.loading')).toBeTruthy();
   });
+
+  it('does not fetch when no more starterpacks', () => {
+    const fetchNextPage = jest.fn();
+    mockUseAuthorStarterpacks.mockReturnValue({
+      data: [
+        {
+          uri: 'at://pack/1',
+          cid: 'cid1',
+          record: {
+            $type: 'app.bsky.graph.starterpack',
+            createdAt: '',
+            description: 'cool pack',
+            feeds: [],
+            list: '',
+            name: 'Pack One',
+            updatedAt: '',
+          },
+          creator: { handle: 'alice' },
+          joinedWeekCount: 0,
+          joinedAllTimeCount: 5,
+          labels: [],
+          indexedAt: '',
+        },
+      ],
+      isLoading: false,
+      fetchNextPage,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    const { UNSAFE_getByType } = render(<StarterpacksTab handle="alice" />);
+    act(() => {
+      UNSAFE_getByType(FlatList).props.onEndReached();
+    });
+    expect(fetchNextPage).not.toHaveBeenCalled();
+  });
 });
 


### PR DESCRIPTION
## Summary
- ensure `FeedsTab` handles loading, pin actions, and pagination
- cover reply handling and missing parent handles across profile tabs

## Testing
- `npm --workspace apps/akari run test:coverage -- __tests__/components/profile`


------
https://chatgpt.com/codex/tasks/task_e_68c74c4f3388832ba319c4e694d0c3d2