### PR TITLE
fix(test): flush animated timers

### DIFF
--- a/apps/akari/jest.config.js
+++ b/apps/akari/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'jest-expo',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   collectCoverage: true,
   collectCoverageFrom: [
     'components/**/*.{ts,tsx}',

--- a/apps/akari/jest.setup.js
+++ b/apps/akari/jest.setup.js
@@ -1,0 +1,22 @@
+jest.mock('react-native-reanimated', () => {
+  const Reanimated = require('react-native-reanimated/mock');
+  Reanimated.default.call = () => {};
+  return Reanimated;
+});
+
+jest.mock('react-native/Libraries/Animated/NativeAnimatedModule');
+
+const { act } = require('@testing-library/react-native');
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  if (jest.isMockFunction(setTimeout)) {
+    act(() => {
+      jest.runAllTimers();
+    });
+    jest.useRealTimers();
+  }
+});


### PR DESCRIPTION
## Summary
- run fake timers in test setup and flush them inside act to avoid Animated state updates

## Testing
- `npm run test:coverage -w apps/akari`


------
https://chatgpt.com/codex/tasks/task_e_68c74a180a28832ba1500afbe9169d3b