### PR TITLE
test: expand translation logger tests

### DIFF
--- a/apps/akari/__tests__/utils/translationLogger.test.ts
+++ b/apps/akari/__tests__/utils/translationLogger.test.ts
@@ -42,4 +42,84 @@ describe('translationLogger', () => {
     const report = getTranslationReport();
     expect(report).toBe('Translation logging is only available in development mode.');
   });
+
+  it('returns success message when no translations are missing', () => {
+    (global as any).__DEV__ = true;
+    const { translationLogger } = require('@/utils/translationLogger');
+    translationLogger.clearMissingTranslations();
+
+    const report = translationLogger.generateReport();
+    expect(report).toBe('✅ No missing translations found!');
+  });
+
+  it('groups missing translations by key and locale', () => {
+    (global as any).__DEV__ = true;
+    const { translationLogger } = require('@/utils/translationLogger');
+
+    translationLogger.clearMissingTranslations();
+    translationLogger.logMissing('greeting', 'en');
+    translationLogger.logMissing('greeting', 'fr');
+    translationLogger.logMissing('farewell', 'en');
+
+    const report = translationLogger.generateReport();
+    expect(report).toContain('❌ Found 3 missing translation');
+    expect(report).toContain('• greeting (missing in: en, fr)');
+    expect(report).toContain('• farewell (missing in: en)');
+  });
+
+  it('re-enables logging when enabled after disable', () => {
+    (global as any).__DEV__ = true;
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { translationLogger } = require('@/utils/translationLogger');
+
+    translationLogger.clearMissingTranslations();
+    translationLogger.disable();
+    translationLogger.enable();
+    translationLogger.logMissing('welcome', 'en');
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Missing translation'));
+  });
+
+  it('handles logUsage in enabled and disabled states', () => {
+    (global as any).__DEV__ = true;
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const { translationLogger } = require('@/utils/translationLogger');
+
+    translationLogger.clearMissingTranslations();
+    translationLogger.disable();
+    translationLogger.logUsage('key', 'en');
+    translationLogger.enable();
+    translationLogger.logUsage('key', 'en');
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns a copy of missing translations', () => {
+    (global as any).__DEV__ = true;
+    const { translationLogger } = require('@/utils/translationLogger');
+
+    translationLogger.clearMissingTranslations();
+    translationLogger.logMissing('greeting', 'en');
+
+    const logs = translationLogger.getMissingTranslations();
+    (logs as any).push({ key: 'other', locale: 'fr', timestamp: Date.now() });
+
+    expect(translationLogger.getMissingTranslations()).toHaveLength(1);
+  });
+
+  it('handles missing stack trace gracefully', () => {
+    (global as any).__DEV__ = true;
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { translationLogger } = require('@/utils/translationLogger');
+
+    translationLogger.clearMissingTranslations();
+    const OriginalError = Error;
+    (global as any).Error = function () {
+      return {} as Error;
+    } as unknown as ErrorConstructor;
+    translationLogger.logMissing('nostack', 'en');
+    (global as any).Error = OriginalError;
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary
- broaden translation logger test coverage for reports and toggling

## Testing
- `npm test`
- `npm run test:coverage` *(fails: cp: cannot stat '../../node_modules/nyc-dark/*.css')*

------
https://chatgpt.com/codex/tasks/task_e_68c75186df04832b9f1b0bc5812f3ba5