### PR TITLE
test: add layout test for messages tab

### DIFF
--- a/apps/akari/__tests__/app/tabs-messages-layout.test.tsx
+++ b/apps/akari/__tests__/app/tabs-messages-layout.test.tsx
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import MessagesLayout from '@/app/(tabs)/messages/_layout';
+
+jest.mock('expo-router', () => {
+  const React = require('react');
+  const Screen = jest.fn(() => null);
+  const Stack = jest.fn(({ children }: { children: React.ReactNode }) => <>{children}</>);
+  // @ts-ignore
+  Stack.Screen = Screen;
+  return { Stack };
+});
+
+describe('MessagesLayout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders stack with index and [handle] screens', () => {
+    const { Stack } = require('expo-router');
+    render(<MessagesLayout />);
+    expect(Stack.mock.calls[0][0].screenOptions).toEqual({ headerShown: false });
+    expect(Stack.Screen).toHaveBeenCalledTimes(2);
+    const names: string[] = [];
+    for (const call of Stack.Screen.mock.calls) {
+      names.push(call[0].name);
+    }
+    expect(names).toEqual(['index', '[handle]']);
+  });
+});


### PR DESCRIPTION
## Summary
- add layout test for messages tab

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68c752654f24832b9b1bd0fa276bbe56