### PR TITLE
test: add coverage for mutation hooks

### DIFF
--- a/apps/akari/__tests__/hooks/mutations/authMutations.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/authMutations.test.tsx
@@ -1,0 +1,224 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useSetJwtToken } from '@/hooks/mutations/useSetJwtToken';
+import { useSetRefreshToken } from '@/hooks/mutations/useSetRefreshToken';
+import { useSetAuthentication } from '@/hooks/mutations/useSetAuthentication';
+import { useClearAuthentication } from '@/hooks/mutations/useClearAuthentication';
+import { useSetCurrentAccount } from '@/hooks/mutations/useSetCurrentAccount';
+import { useSetSelectedFeed } from '@/hooks/mutations/useSetSelectedFeed';
+import { useAddAccount } from '@/hooks/mutations/useAddAccount';
+import { useRemoveAccount } from '@/hooks/mutations/useRemoveAccount';
+import { useWipeAllData } from '@/hooks/mutations/useWipeAllData';
+import { useSwitchAccount } from '@/hooks/mutations/useSwitchAccount';
+
+import { storage } from '@/utils/secureStorage';
+jest.mock('@/utils/secureStorage', () => ({
+  storage: {
+    setItem: jest.fn(),
+    getItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+describe('authentication and account mutation hooks', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('useSetJwtToken stores token', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const { result } = renderHook(() => useSetJwtToken(), { wrapper });
+
+    result.current.mutate('abc');
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(['jwtToken'])).toBe('abc');
+    });
+
+    expect(storage.setItem).toHaveBeenCalledWith('jwtToken', 'abc');
+  });
+
+  it('useSetRefreshToken stores token', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const { result } = renderHook(() => useSetRefreshToken(), { wrapper });
+
+    result.current.mutate('def');
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(['refreshToken'])).toBe('def');
+    });
+
+    expect(storage.setItem).toHaveBeenCalledWith('refreshToken', 'def');
+  });
+
+  it('useSetAuthentication sets all auth data', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const { result } = renderHook(() => useSetAuthentication(), { wrapper });
+
+    result.current.mutate({
+      token: 't',
+      refreshToken: 'r',
+      did: 'did',
+      handle: 'handle',
+      pdsUrl: 'url',
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(['jwtToken'])).toBe('t');
+    });
+    expect(queryClient.getQueryData(['refreshToken'])).toBe('r');
+    expect(queryClient.getQueryData(['currentAccount'])).toMatchObject({
+      did: 'did',
+      handle: 'handle',
+      jwtToken: 't',
+      refreshToken: 'r',
+      pdsUrl: 'url',
+    });
+    expect(storage.setItem).toHaveBeenCalledWith('jwtToken', 't');
+    expect(storage.setItem).toHaveBeenCalledWith('refreshToken', 'r');
+    expect(storage.setItem).toHaveBeenCalledWith(
+      'currentAccount',
+      expect.objectContaining({ did: 'did', handle: 'handle' }),
+    );
+  });
+
+  it('useClearAuthentication clears auth data', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(['jwtToken'], 'old');
+    queryClient.setQueryData(['refreshToken'], 'old');
+
+    const { result } = renderHook(() => useClearAuthentication(), { wrapper });
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(['jwtToken'])).toBeNull();
+    });
+    expect(queryClient.getQueryData(['refreshToken'])).toBeNull();
+    expect(storage.removeItem).toHaveBeenCalledWith('jwtToken');
+    expect(storage.removeItem).toHaveBeenCalledWith('refreshToken');
+  });
+
+  it('useSetCurrentAccount stores account', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const { result } = renderHook(() => useSetCurrentAccount(), { wrapper });
+    const account = { did: '1', handle: 'h', jwtToken: 't', refreshToken: 'r' };
+
+    result.current.mutate(account);
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(['currentAccount'])).toEqual(account);
+    });
+    expect(storage.setItem).toHaveBeenCalledWith('currentAccount', account);
+  });
+
+  it('useSetSelectedFeed stores feed', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const { result } = renderHook(() => useSetSelectedFeed(), { wrapper });
+
+    result.current.mutate('feed');
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(['selectedFeed'])).toBe('feed');
+    });
+    expect(storage.setItem).toHaveBeenCalledWith('selectedFeed', 'feed');
+  });
+
+  it('useAddAccount adds account', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    (storage.getItem as jest.Mock).mockReturnValue([]);
+    const { result } = renderHook(() => useAddAccount(), { wrapper });
+    const account = { did: 'a1', handle: 'h1' } as any;
+
+    result.current.mutate(account);
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(['accounts'])).toEqual([account]);
+    });
+    expect(storage.setItem).toHaveBeenCalledWith('accounts', [account]);
+  });
+
+  it('useRemoveAccount removes account and updates current', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const accounts = [{ did: '1', handle: 'h1' }, { did: '2', handle: 'h2' }];
+    queryClient.setQueryData(['accounts'], accounts);
+    queryClient.setQueryData(['currentAccount'], accounts[0]);
+    (storage.getItem as jest.Mock).mockReturnValue(accounts);
+
+    const { result } = renderHook(() => useRemoveAccount(), { wrapper });
+    result.current.mutate('1');
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(['accounts'])).toEqual([accounts[1]]);
+    });
+    expect(queryClient.getQueryData(['currentAccount'])).toEqual(accounts[1]);
+    expect(storage.setItem).toHaveBeenCalledWith('currentAccount', accounts[1]);
+    expect(storage.setItem).toHaveBeenCalledWith('accounts', [accounts[1]]);
+  });
+
+  it('useSwitchAccount switches account and sets auth', async () => {
+    const setAuth = jest
+      .spyOn(require('@/hooks/mutations/useSetAuthentication'), 'useSetAuthentication')
+      .mockReturnValue({ mutateAsync: jest.fn() });
+    const setCurrent = jest
+      .spyOn(require('@/hooks/mutations/useSetCurrentAccount'), 'useSetCurrentAccount')
+      .mockReturnValue({ mutateAsync: jest.fn() });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSwitchAccount(), { wrapper });
+    const account = {
+      did: '3',
+      handle: 'h3',
+      jwtToken: 't',
+      refreshToken: 'r',
+      pdsUrl: 'url',
+    } as any;
+
+    result.current.mutate(account);
+
+    await waitFor(() => {
+      expect(setCurrent().mutateAsync).toHaveBeenCalledWith(account);
+    });
+    expect(setAuth().mutateAsync).toHaveBeenCalledWith({
+      token: 't',
+      refreshToken: 'r',
+      did: '3',
+      handle: 'h3',
+      pdsUrl: 'url',
+    });
+  });
+
+  it('useWipeAllData clears everything', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(['accounts'], [{ did: '1' }]);
+    queryClient.setQueryData(['currentAccount'], { did: '1' });
+    queryClient.setQueryData(['jwtToken'], 't');
+    queryClient.setQueryData(['refreshToken'], 'r');
+
+    const { result } = renderHook(() => useWipeAllData(), { wrapper });
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(['accounts'])).toEqual([]);
+    });
+    expect(queryClient.getQueryData(['currentAccount'])).toBeNull();
+    expect(queryClient.getQueryData(['jwtToken'])).toBeNull();
+    expect(queryClient.getQueryData(['refreshToken'])).toBeNull();
+    expect(storage.removeItem).toHaveBeenCalledWith('accounts');
+    expect(storage.removeItem).toHaveBeenCalledWith('currentAccount');
+    expect(storage.removeItem).toHaveBeenCalledWith('jwtToken');
+    expect(storage.removeItem).toHaveBeenCalledWith('refreshToken');
+  });
+});
+

--- a/apps/akari/__tests__/hooks/mutations/useBlockUser.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useBlockUser.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useBlockUser } from '@/hooks/mutations/useBlockUser';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockBlockUser = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    blockUser: mockBlockUser,
+    unblockUser: jest.fn(),
+  })),
+}));
+
+describe('useBlockUser mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds' },
+    });
+    mockBlockUser.mockResolvedValue({});
+  });
+
+  it('blocks a user successfully', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlockUser(), { wrapper });
+
+    result.current.mutate({ did: 'did', action: 'block' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockBlockUser).toHaveBeenCalledWith('token', 'did');
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlockUser(), { wrapper });
+
+    result.current.mutate({ did: 'did', action: 'block' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});
+

--- a/apps/akari/__tests__/hooks/mutations/useCreatePost.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useCreatePost.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useCreatePost } from '@/hooks/mutations/useCreatePost';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockCreatePostApi = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createPost: mockCreatePostApi,
+  })),
+}));
+
+describe('useCreatePost mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds', handle: 'h' },
+    });
+    mockCreatePostApi.mockResolvedValue({ uri: 'uri' });
+  });
+
+  it('creates a post successfully', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreatePost(), { wrapper });
+
+    result.current.mutate({ text: 'hello' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreatePostApi).toHaveBeenCalledWith('token', 'did', {
+      text: 'hello',
+      replyTo: undefined,
+      images: undefined,
+    });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreatePost(), { wrapper });
+
+    result.current.mutate({ text: 'hello' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});
+

--- a/apps/akari/__tests__/hooks/mutations/useFollowUser.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useFollowUser.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useFollowUser } from '@/hooks/mutations/useFollowUser';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockFollowUser = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    followUser: mockFollowUser,
+    unfollowUser: jest.fn(),
+  })),
+}));
+
+describe('useFollowUser mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds' },
+    });
+    mockFollowUser.mockResolvedValue({});
+  });
+
+  it('follows a user successfully', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowUser(), { wrapper });
+
+    result.current.mutate({ did: 'did', action: 'follow' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockFollowUser).toHaveBeenCalledWith('token', 'did');
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowUser(), { wrapper });
+
+    result.current.mutate({ did: 'did', action: 'follow' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});
+

--- a/apps/akari/__tests__/hooks/mutations/useLikePost.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useLikePost.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useLikePost } from '@/hooks/mutations/useLikePost';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockLikePost = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    likePost: mockLikePost,
+    unlikePost: jest.fn(),
+  })),
+}));
+
+describe('useLikePost mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockLikePost.mockResolvedValue({});
+  });
+
+  it('likes a post successfully', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useLikePost(), { wrapper });
+
+    result.current.mutate({ postUri: 'uri', postCid: 'cid', action: 'like' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockLikePost).toHaveBeenCalledWith('token', 'uri', 'cid', 'did');
+  });
+
+  it('throws error when postCid missing for like', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useLikePost(), { wrapper });
+
+    result.current.mutate({ postUri: 'uri', action: 'like' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});
+

--- a/apps/akari/__tests__/hooks/mutations/useRefreshSession.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useRefreshSession.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useRefreshSession } from '@/hooks/mutations/useRefreshSession';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockSetAuth = { mutate: jest.fn() };
+const mockRefreshSession = jest.fn();
+
+jest.mock('@/hooks/mutations/useSetAuthentication', () => ({
+  useSetAuthentication: jest.fn(() => mockSetAuth),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    refreshSession: mockRefreshSession,
+  })),
+}));
+
+describe('useRefreshSession mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'url' } });
+    mockRefreshSession.mockResolvedValue({
+      accessJwt: 'token',
+      refreshJwt: 'refresh',
+      did: 'did',
+      handle: 'handle',
+    });
+  });
+
+  it('refreshes session and updates auth', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useRefreshSession(), { wrapper });
+
+    result.current.mutate({ refreshToken: 'refresh' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockRefreshSession).toHaveBeenCalledWith('refresh');
+    expect(mockSetAuth.mutate).toHaveBeenCalledWith({
+      token: 'token',
+      refreshToken: 'refresh',
+      did: 'did',
+      handle: 'handle',
+    });
+    expect(invalidateSpy).toHaveBeenCalled();
+  });
+});
+

--- a/apps/akari/__tests__/hooks/mutations/useSendMessage.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useSendMessage.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useSendMessage } from '@/hooks/mutations/useSendMessage';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockSendMessage = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    sendMessage: mockSendMessage,
+  })),
+}));
+
+describe('useSendMessage mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockSendMessage.mockResolvedValue({});
+  });
+
+  it('sends a message successfully', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSendMessage(), { wrapper });
+
+    result.current.mutate({ convoId: 'c1', text: 'hi' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockSendMessage).toHaveBeenCalledWith('token', 'c1', { text: 'hi' });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSendMessage(), { wrapper });
+
+    result.current.mutate({ convoId: 'c1', text: 'hi' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});
+

--- a/apps/akari/__tests__/hooks/mutations/useSignIn.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useSignIn.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useSignIn } from '@/hooks/mutations/useSignIn';
+
+const mockSetAuth = { mutateAsync: jest.fn() };
+const mockCreateSession = jest.fn();
+
+jest.mock('@/hooks/mutations/useSetAuthentication', () => ({
+  useSetAuthentication: jest.fn(() => mockSetAuth),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createSession: mockCreateSession,
+  })),
+}));
+
+describe('useSignIn mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateSession.mockResolvedValue({
+      accessJwt: 'token',
+      refreshJwt: 'refresh',
+      did: 'did',
+      handle: 'handle',
+    });
+  });
+
+  it('signs in and stores auth data', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useSignIn(), { wrapper });
+
+    result.current.mutate({ identifier: 'user', password: 'pass', pdsUrl: 'url' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreateSession).toHaveBeenCalledWith('user', 'pass');
+    expect(mockSetAuth.mutateAsync).toHaveBeenCalledWith({
+      token: 'token',
+      refreshToken: 'refresh',
+      did: 'did',
+      handle: 'handle',
+    });
+    expect(invalidateSpy).toHaveBeenCalled();
+  });
+});
+

--- a/apps/akari/__tests__/hooks/mutations/useUpdateProfile.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateProfile.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateProfile } from '@/hooks/mutations/useUpdateProfile';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockUpdateProfile = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    updateProfile: mockUpdateProfile,
+  })),
+}));
+
+describe('useUpdateProfile mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds' },
+    });
+    mockUpdateProfile.mockResolvedValue({});
+  });
+
+  it('updates profile successfully', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateProfile(), { wrapper });
+
+    result.current.mutate({ displayName: 'name' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockUpdateProfile).toHaveBeenCalledWith('token', {
+      displayName: 'name',
+      description: undefined,
+      avatar: undefined,
+      banner: undefined,
+    });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateProfile(), { wrapper });
+
+    result.current.mutate({ displayName: 'name' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for authentication and account mutation hooks
- verify Bluesky API mutation hooks (like, follow, block, create post, send message, profile update, sign-in, session refresh)

## Testing
- `npm run test:coverage` *(fails to copy nyc-dark CSS)*

------
https://chatgpt.com/codex/tasks/task_e_68c751b16ac0832badc452610de86d88