### PR TITLE
test: cover VideoPlayer.web metadata

### DIFF
--- a/apps/akari/__tests__/components/VideoPlayer.web.test.tsx
+++ b/apps/akari/__tests__/components/VideoPlayer.web.test.tsx
@@ -41,6 +41,14 @@ describe('VideoPlayer.web', () => {
     expect(queryByText('Hidden')).toBeNull();
   });
 
+  it('ignores empty title and description', () => {
+    const { queryByText } = render(
+      <VideoPlayer videoUrl="https://example.com/video.mp4" title="   " description="" />,
+    );
+
+    expect(queryByText(/\S/)).toBeNull();
+  });
+
   it('shows error state and resets on tap', () => {
     const setStatus = jest.fn();
     const setError = jest.fn();


### PR DESCRIPTION
## Summary
- add test ensuring VideoPlayer.web ignores empty metadata

## Testing
- `npm run test:coverage -w apps/akari`


------
https://chatgpt.com/codex/tasks/task_e_68c7574b8afc832ba8ca5b5aa0532922