### PR TITLE
test: add useCurrentAccount query hook tests

### DIFF
--- a/apps/akari/__tests__/hooks/queries/useCurrentAccount.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useCurrentAccount.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { storage } from '@/utils/secureStorage';
+import { Account } from '@/types/account';
+
+jest.mock('@/utils/secureStorage', () => ({
+  storage: {
+    getItem: jest.fn(),
+  },
+}));
+
+const mockGetItem = storage.getItem as jest.Mock;
+
+describe('useCurrentAccount query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns stored current account', async () => {
+    const account: Account = {
+      did: 'did:1',
+      handle: 'user',
+      jwtToken: 't',
+      refreshToken: 'r',
+    };
+    mockGetItem.mockReturnValue(account);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCurrentAccount(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(account);
+    expect(mockGetItem).toHaveBeenCalledWith('currentAccount');
+  });
+
+  it('handles missing current account', async () => {
+    mockGetItem.mockReturnValue(null);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCurrentAccount(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(mockGetItem).toHaveBeenCalledWith('currentAccount');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for useCurrentAccount query hook

## Testing
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c7c6b1364c832b8f81e1245e5f1049