### PR TITLE
docs: add specialized bug report templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/browser-bug.yml
+++ b/.github/ISSUE_TEMPLATE/browser-bug.yml
@@ -1,0 +1,47 @@
+name: Browser Bug Report
+description: Report a bug in the browser client
+title: "[Browser Bug]: "
+labels: ["bug", "browser"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Go to the page...
+        2. Click on '...'
+        3. See error
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        examples:
+          - **OS**: Ubuntu 22.04
+          - **Browser**: Chrome 115
+          - **App**: 1.0.0
+      value: |
+          - OS:
+          - Browser:
+          - App:
+      render: markdown
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/dev-bug.yml
+++ b/.github/ISSUE_TEMPLATE/dev-bug.yml
@@ -1,0 +1,47 @@
+name: Dev Bug Report
+description: Report a bug encountered during development
+title: "[Dev Bug]: "
+labels: ["bug", "dev"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Run 'npm install'
+        2. Execute 'npm start'
+        3. See error
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        examples:
+          - **OS**: Ubuntu 22.04
+          - **Node**: 20.x
+          - **App**: 1.0.0
+      value: |
+          - OS:
+          - Node:
+          - App:
+      render: markdown
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/mobile-bug.yml
+++ b/.github/ISSUE_TEMPLATE/mobile-bug.yml
@@ -1,0 +1,53 @@
+name: Mobile Bug Report
+description: Report a bug in the mobile application
+title: "[Mobile Bug]: "
+labels: ["bug", "mobile"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Open the app...
+        2. Tap on '...'
+        3. See error
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        examples:
+          - **Device**: iPhone 13
+          - **OS**: iOS 17
+          - **App**: 1.0.0
+      value: |
+          - Device:
+          - OS:
+          - App:
+      render: markdown
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Paste any relevant logs.
+      render: shell
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here.


### PR DESCRIPTION
## Summary
- replace single bug report template with dedicated mobile, browser, and dev issue forms
- remove expected behavior prompts from bug reports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7d3daa8f8832bbff870371e5b5c7e