### PR TITLE
test: add coverage for useAddAccount hook

### DIFF
--- a/apps/akari/__tests__/hooks/mutations/authMutations.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/authMutations.test.tsx
@@ -8,7 +8,6 @@ import { useSetAuthentication } from '@/hooks/mutations/useSetAuthentication';
 import { useClearAuthentication } from '@/hooks/mutations/useClearAuthentication';
 import { useSetCurrentAccount } from '@/hooks/mutations/useSetCurrentAccount';
 import { useSetSelectedFeed } from '@/hooks/mutations/useSetSelectedFeed';
-import { useAddAccount } from '@/hooks/mutations/useAddAccount';
 import { useRemoveAccount } from '@/hooks/mutations/useRemoveAccount';
 import { useWipeAllData } from '@/hooks/mutations/useWipeAllData';
 import { useSwitchAccount } from '@/hooks/mutations/useSwitchAccount';
@@ -133,20 +132,6 @@ describe('authentication and account mutation hooks', () => {
       expect(queryClient.getQueryData(['selectedFeed'])).toBe('feed');
     });
     expect(storage.setItem).toHaveBeenCalledWith('selectedFeed', 'feed');
-  });
-
-  it('useAddAccount adds account', async () => {
-    const { queryClient, wrapper } = createWrapper();
-    (storage.getItem as jest.Mock).mockReturnValue([]);
-    const { result } = renderHook(() => useAddAccount(), { wrapper });
-    const account = { did: 'a1', handle: 'h1' } as any;
-
-    result.current.mutate(account);
-
-    await waitFor(() => {
-      expect(queryClient.getQueryData(['accounts'])).toEqual([account]);
-    });
-    expect(storage.setItem).toHaveBeenCalledWith('accounts', [account]);
   });
 
   it('useRemoveAccount removes account and updates current', async () => {

--- a/apps/akari/__tests__/hooks/mutations/useAddAccount.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useAddAccount.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useAddAccount } from '@/hooks/mutations/useAddAccount';
+import { storage } from '@/utils/secureStorage';
+
+jest.mock('@/utils/secureStorage', () => ({
+  storage: {
+    setItem: jest.fn(),
+    getItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+describe('useAddAccount', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('adds first account and persists to storage', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    (storage.getItem as jest.Mock).mockReturnValue(undefined);
+    const { result } = renderHook(() => useAddAccount(), { wrapper });
+    const account = { did: 'a1', handle: 'h1' } as any;
+
+    result.current.mutate(account);
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(['accounts'])).toEqual([account]);
+    });
+    expect(storage.setItem).toHaveBeenCalledWith('accounts', [account]);
+  });
+
+  it('appends account when existing accounts are present', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const existingQueryAccounts = [{ did: 'q1', handle: 'hq1' } as any];
+    const existingStoredAccounts = [{ did: 's1', handle: 'hs1' } as any];
+
+    queryClient.setQueryData(['accounts'], existingQueryAccounts);
+    (storage.getItem as jest.Mock).mockReturnValue(existingStoredAccounts);
+
+    const { result } = renderHook(() => useAddAccount(), { wrapper });
+    const newAccount = { did: 'a2', handle: 'h2' } as any;
+
+    result.current.mutate(newAccount);
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(['accounts'])).toEqual([
+        ...existingQueryAccounts,
+        newAccount,
+      ]);
+    });
+    expect(storage.getItem).toHaveBeenCalledWith('accounts');
+    expect(storage.setItem).toHaveBeenCalledWith('accounts', [
+      ...existingStoredAccounts,
+      newAccount,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add dedicated tests for useAddAccount to verify first account persistence and merging with existing accounts
- remove redundant useAddAccount test from authMutations suite

## Testing
- `npm run lint -- --filter=akari`
- `npm run test:coverage -w apps/akari`


------
https://chatgpt.com/codex/tasks/task_e_68c7dcfdf168832b84021193565d8ee2