### PR TITLE
test: add iOS TabBarBackground tests

### DIFF
--- a/apps/akari/__tests__/components/TabBarBackground.ios.test.tsx
+++ b/apps/akari/__tests__/components/TabBarBackground.ios.test.tsx
@@ -1,0 +1,39 @@
+import { render, renderHook } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
+import TabBarBackground, { useBottomTabOverflow } from '@/components/ui/TabBarBackground.ios';
+import { BlurView } from 'expo-blur';
+
+jest.mock('expo-blur', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    BlurView: ({ children, ...props }: any) => <View {...props}>{children}</View>,
+  };
+});
+
+jest.mock('@react-navigation/bottom-tabs', () => ({
+  useBottomTabBarHeight: jest.fn(),
+}));
+
+const mockUseBottomTabBarHeight = require('@react-navigation/bottom-tabs').useBottomTabBarHeight as jest.Mock;
+
+describe('TabBarBackground (iOS)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders BlurView with expected props', () => {
+    const { UNSAFE_getByType } = render(<TabBarBackground />);
+    const blurView = UNSAFE_getByType(BlurView);
+
+    expect(blurView.props.tint).toBe('systemChromeMaterial');
+    expect(blurView.props.intensity).toBe(100);
+    expect(blurView.props.style).toMatchObject(StyleSheet.absoluteFill);
+  });
+
+  it('useBottomTabOverflow returns tab bar height', () => {
+    mockUseBottomTabBarHeight.mockReturnValue(24);
+    const { result } = renderHook(() => useBottomTabOverflow());
+    expect(result.current).toBe(24);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for iOS TabBarBackground component
- verify BlurView props and bottom tab overflow hook

## Testing
- `npm run test:coverage --workspace=akari`


------
https://chatgpt.com/codex/tasks/task_e_68c7e8d756e0832bbb0df709259697bb