### PR TITLE
test: add error case for useRefreshSession

### DIFF
--- a/apps/akari/__tests__/hooks/mutations/useRefreshSession.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useRefreshSession.test.tsx
@@ -63,5 +63,22 @@ describe('useRefreshSession mutation hook', () => {
     });
     expect(invalidateSpy).toHaveBeenCalled();
   });
+
+  it('throws if no PDS URL is available', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValueOnce({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRefreshSession(), { wrapper });
+
+    result.current.mutate({ refreshToken: 'refresh' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(result.current.error).toEqual(
+      new Error('No PDS URL available for this account'),
+    );
+    expect(mockRefreshSession).not.toHaveBeenCalled();
+    expect(mockSetAuth.mutate).not.toHaveBeenCalled();
+  });
 });
 


### PR DESCRIPTION
## Summary
- add regression test covering missing PDS URL in useRefreshSession

## Testing
- `npm --workspace apps/akari run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68c7e8b74818832bb18869fad3f93a4c