### PR TITLE
test: add useBorderColor hook coverage

### DIFF
--- a/apps/akari/__tests__/hooks/useBorderColor.test.ts
+++ b/apps/akari/__tests__/hooks/useBorderColor.test.ts
@@ -1,0 +1,38 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { useBorderColor } from '@/hooks/useBorderColor';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+jest.mock('@/hooks/useThemeColor', () => ({
+  useThemeColor: jest.fn(),
+}));
+
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+describe('useBorderColor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the value from useThemeColor', () => {
+    mockUseThemeColor.mockReturnValue('border-value');
+
+    const { result } = renderHook(() => useBorderColor());
+
+    expect(result.current).toBe('border-value');
+  });
+
+  it('delegates to useThemeColor with the border palette', () => {
+    mockUseThemeColor.mockReturnValue('border-value');
+
+    renderHook(() => useBorderColor());
+
+    expect(mockUseThemeColor).toHaveBeenCalledWith(
+      {
+        light: '#e8eaed',
+        dark: '#2d3133',
+      },
+      'background',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add targeted tests for the useBorderColor hook to ensure it delegates to useThemeColor

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c8713d5c98832b9efe42445927a0b3