### PR TITLE
test: migrate clearsky-api tests to jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19565,14 +19565,89 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.0.0",
         "@eslint/js": "^9.25.0",
+        "@types/jest": "^29.5.12",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~9.2.0",
-        "typescript": "~5.8.3",
-        "vitest": "^2.0.0"
+        "jest": "^29.7.0",
+        "ts-jest": "^29.3.4",
+        "typescript": "~5.8.3"
       },
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-native": ">=0.70.0"
+      }
+    },
+    "packages/clearsky-api/node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/clearsky-api/node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "packages/clearsky-api/node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/clearsky-api/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/clearsky-api/node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "packages/tenor-api": {

--- a/packages/clearsky-api/jest.config.cjs
+++ b/packages/clearsky-api/jest.config.cjs
@@ -1,0 +1,15 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  globals: {
+    'ts-jest': {
+      useESM: true,
+      tsconfig: '<rootDir>/tsconfig.json',
+    },
+  },
+};

--- a/packages/clearsky-api/package.json
+++ b/packages/clearsky-api/package.json
@@ -13,8 +13,9 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "vitest run",
-    "test:run": "vitest run",
+    "test": "npm run test:run",
+    "test:run": "jest --runInBand",
+    "test:coverage": "jest --coverage",
     "lint": "eslint src --ext .ts,.tsx"
   },
   "keywords": [
@@ -28,12 +29,14 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "typescript": "~5.8.3",
-    "vitest": "^2.0.0",
+    "@eslint/eslintrc": "^3.0.0",
+    "@eslint/js": "^9.25.0",
+    "@types/jest": "^29.5.12",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
-    "@eslint/eslintrc": "^3.0.0",
-    "@eslint/js": "^9.25.0"
+    "jest": "^29.7.0",
+    "ts-jest": "^29.3.4",
+    "typescript": "~5.8.3"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/clearsky-api/src/client.test.ts
+++ b/packages/clearsky-api/src/client.test.ts
@@ -1,6 +1,29 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import { ClearSkyApi } from './api';
 import { ClearSkyApiClient } from './client';
+
+function setupFetchMock<T>({
+  ok,
+  jsonValue,
+  status,
+}: {
+  ok: boolean;
+  jsonValue: T;
+  status?: number;
+}): jest.MockedFunction<typeof fetch> {
+  const json = jest.fn(async () => jsonValue);
+  const fetchMock = jest
+    .fn(async () => ({
+      ok,
+      status: status ?? (ok ? 200 : 500),
+      json,
+    } as unknown as Response))
+    .mockName('fetch') as jest.MockedFunction<typeof fetch>;
+
+  global.fetch = fetchMock;
+
+  return fetchMock;
+}
 
 class TestClient extends ClearSkyApiClient {
   public getPublic<T>(endpoint: string, params?: Record<string, string>) {
@@ -17,18 +40,17 @@ class TestClient extends ClearSkyApiClient {
 }
 
 afterEach(() => {
-  vi.clearAllMocks();
+  jest.clearAllMocks();
 });
 
 describe('ClearSkyApiClient', () => {
   it('makes GET requests with query parameters', async () => {
-    const mockJson = vi.fn().mockResolvedValue({ result: 'ok' });
-    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: mockJson } as unknown as Response);
+    const fetchMock = setupFetchMock({ ok: true, jsonValue: { result: 'ok' } });
 
     const client = new TestClient('https://example.com');
     const data = await client.getPublic('/test', { q: 'search', page: '2' });
 
-    expect(fetch).toHaveBeenCalledWith('https://example.com/test?q=search&page=2', {
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com/test?q=search&page=2', {
       method: 'GET',
       headers: { 'Content-Type': 'application/json' },
     });
@@ -36,14 +58,13 @@ describe('ClearSkyApiClient', () => {
   });
 
   it('makes POST requests with JSON body', async () => {
-    const mockJson = vi.fn().mockResolvedValue({ success: true });
-    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: mockJson } as unknown as Response);
+    const fetchMock = setupFetchMock({ ok: true, jsonValue: { success: true } });
 
     const client = new TestClient('https://example.com');
     const body = { foo: 'bar' };
     const data = await client.postPublic('/create', body);
 
-    expect(fetch).toHaveBeenCalledWith('https://example.com/create', {
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com/create', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -53,27 +74,26 @@ describe('ClearSkyApiClient', () => {
 
   it('throws error with message from response when request fails', async () => {
     const errorResponse = { message: 'not found' };
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 404,
-      json: vi.fn().mockResolvedValue(errorResponse),
-    } as unknown as Response);
+    const fetchMock = setupFetchMock({ ok: false, status: 404, jsonValue: errorResponse });
 
     const client = new TestClient('https://example.com');
 
     await expect(client.getPublic('/missing')).rejects.toThrow('not found');
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com/missing', {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    });
   });
 });
 
 describe('ClearSkyApi', () => {
   it('fetches DID for a handle', async () => {
-    const mockJson = vi.fn().mockResolvedValue({ did: 'did:example:123' });
-    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: mockJson } as unknown as Response);
+    const fetchMock = setupFetchMock({ ok: true, jsonValue: { did: 'did:example:123' } });
 
     const api = new ClearSkyApi('https://example.com');
     const data = await api.getDid('alice');
 
-    expect(fetch).toHaveBeenCalledWith('https://example.com/api/v1/anon/get-did/alice', {
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com/api/v1/anon/get-did/alice', {
       method: 'GET',
       headers: { 'Content-Type': 'application/json' },
     });


### PR DESCRIPTION
## Summary
- replace clearsky-api Vitest-based unit tests with Jest equivalents and add a reusable fetch mock helper
- add a Jest configuration plus updated npm scripts and dev dependencies for the package
- ensure coverage execution via new npm test:coverage script

## Testing
- npm run test:coverage --workspace packages/clearsky-api

------
https://chatgpt.com/codex/tasks/task_e_68c8748408c0832bbe0471fac4c0fd0f