### PR TITLE
test: add jest coverage for tenor api utilities

### DIFF
--- a/apps/akari/__tests__/utils/tenor.test.ts
+++ b/apps/akari/__tests__/utils/tenor.test.ts
@@ -1,190 +1,31 @@
-import { TenorAPI } from '@/tenor-api';
+const mockTenorAPI = jest.fn();
 
-describe('TenorAPI', () => {
-  const originalFetch = global.fetch;
+jest.mock('@/tenor-api', () => ({
+  TenorAPI: mockTenorAPI,
+}));
+
+describe('tenor utility', () => {
+  const EXPECTED_KEY = 'AIzaSyA497MbJK6lzNQ9VIGvUyxWG6QLzjndJm8';
 
   beforeEach(() => {
-    global.fetch = jest.fn();
+    jest.resetModules();
+    mockTenorAPI.mockClear();
   });
 
-  afterEach(() => {
-    (global.fetch as jest.Mock).mockReset();
+  it('creates a TenorAPI instance with the expected API key', () => {
+    const module = require('@/utils/tenor');
+
+    expect(mockTenorAPI).toHaveBeenCalledTimes(1);
+    expect(mockTenorAPI).toHaveBeenCalledWith(EXPECTED_KEY);
+    expect(module.tenorApi).toBe(mockTenorAPI.mock.instances[0]);
   });
 
-  afterAll(() => {
-    global.fetch = originalFetch;
-  });
+  it('reuses the same TenorAPI instance across imports', () => {
+    const first = require('@/utils/tenor');
+    const second = require('@/utils/tenor');
 
-  it('searches GIFs with correct parameters', async () => {
-    const mockData = { results: [], next: 'abc' };
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: async () => mockData,
-    });
-
-    const api = new TenorAPI('test');
-    const result = await api.searchGifs('cats', 5, '1');
-
-    expect(result).toEqual(mockData);
-    const url = new URL((global.fetch as jest.Mock).mock.calls[0][0]);
-    expect(url.pathname).toBe('/v2/search');
-    expect(url.searchParams.get('q')).toBe('cats');
-    expect(url.searchParams.get('limit')).toBe('5');
-    expect(url.searchParams.get('pos')).toBe('1');
-    expect(url.searchParams.get('key')).toBe('test');
-  });
-
-  it('throws when searchGifs fails', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500, statusText: 'Error' });
-
-    const api = new TenorAPI('test');
-    await expect(api.searchGifs('cats')).rejects.toThrow('Tenor API error: 500 Error');
-  });
-
-  it('retrieves trending GIFs', async () => {
-    const mockData = { results: [], next: 'def' };
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: async () => mockData,
-    });
-
-    const api = new TenorAPI('key');
-    const result = await api.getTrendingGifs(20, '2');
-
-    expect(result).toEqual(mockData);
-    const url = new URL((global.fetch as jest.Mock).mock.calls[0][0]);
-    expect(url.pathname).toBe('/v2/featured');
-    expect(url.searchParams.get('limit')).toBe('20');
-    expect(url.searchParams.get('pos')).toBe('2');
-  });
-
-  it('throws when getTrendingGifs fails', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
-
-    const api = new TenorAPI('key');
-    await expect(api.getTrendingGifs()).rejects.toThrow('Tenor API error: 404 Not Found');
-  });
-
-  it('gets GIF by id', async () => {
-    const gif = { id: '1', media_formats: { gif: { url: 'u', dims: [1, 1], size: 1 } }, created: 0, title: '', content_description: '', itemurl: '', url: 'u', tags: [], flags: [], hasaudio: false };
-    const mockData = { results: [gif] };
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: async () => mockData,
-    });
-
-    const api = new TenorAPI('key');
-    const result = await api.getGifById('1');
-    expect(result).toBe(gif);
-    const url = new URL((global.fetch as jest.Mock).mock.calls[0][0]);
-    expect(url.pathname).toBe('/v2/posts');
-    expect(url.searchParams.get('ids')).toBe('1');
-  });
-
-  it('throws when getGifById fails', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 400, statusText: 'Bad' });
-    const api = new TenorAPI('k');
-    await expect(api.getGifById('1')).rejects.toThrow('Tenor API error: 400 Bad');
-  });
-
-  it('downloads GIF as blob', async () => {
-    const mockBlob = new Blob(['data']);
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      blob: async () => mockBlob,
-    });
-
-    const api = new TenorAPI('k');
-    const result = await api.downloadGifAsBlob('https://example.com/g.gif');
-    expect(result).toBe(mockBlob);
-    expect(global.fetch).toHaveBeenCalledWith('https://example.com/g.gif');
-  });
-
-  it('throws when downloadGifAsBlob fails', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500, statusText: 'Fail' });
-    const api = new TenorAPI('k');
-    await expect(api.downloadGifAsBlob('https://example.com/g.gif')).rejects.toThrow('Failed to download GIF: 500 Fail');
-  });
-
-  it('converts GIF to attached image', () => {
-    const gif = {
-      id: '1',
-      title: 't',
-      media_formats: { gif: { url: 'https://example.com/a.gif', dims: [100, 200], size: 1 } },
-      created: 0,
-      content_description: 'desc',
-      itemurl: 'i',
-      url: 'https://example.com/a.gif',
-      tags: [],
-      flags: [],
-      hasaudio: false,
-    };
-
-    const api = new TenorAPI('k');
-    const result = api.convertGifToAttachedImage(gif);
-    const url = new URL(result.uri);
-    expect(result.alt).toBe('desc');
-    expect(url.searchParams.get('ww')).toBe('100');
-    expect(url.searchParams.get('hh')).toBe('200');
-    expect(result.tenorId).toBe('1');
-  });
-
-  it('handles GIF without format dimensions', () => {
-    const gif = {
-      id: '2',
-      title: 't',
-      media_formats: {},
-      created: 0,
-      content_description: '',
-      itemurl: '',
-      url: 'https://example.com/b.gif',
-      tags: [],
-      flags: [],
-      hasaudio: false,
-    } as any;
-
-    const api = new TenorAPI('k');
-    const result = api.convertGifToAttachedImage(gif);
-    const url = new URL(result.uri);
-    expect(url.searchParams.get('ww')).toBeNull();
-    expect(url.searchParams.get('hh')).toBeNull();
-  });
-
-  it('defaults alt text when description and title missing', () => {
-    const gif = {
-      id: '3',
-      title: '',
-      media_formats: { gif: { url: 'https://example.com/c.gif', dims: [1, 1], size: 1 } },
-      created: 0,
-      content_description: '',
-      itemurl: '',
-      url: 'https://example.com/c.gif',
-      tags: [],
-      flags: [],
-      hasaudio: false,
-    };
-
-    const api = new TenorAPI('k');
-    const result = api.convertGifToAttachedImage(gif);
-    expect(result.alt).toBe('GIF');
-  });
-
-  it('throws when no valid GIF URL', () => {
-    const gif = {
-      id: '1',
-      title: '',
-      media_formats: {},
-      created: 0,
-      content_description: '',
-      itemurl: '',
-      url: '',
-      tags: [],
-      flags: [],
-      hasaudio: false,
-    } as any;
-
-    const api = new TenorAPI('k');
-    expect(() => api.convertGifToAttachedImage(gif)).toThrow('No valid GIF URL found in media formats');
+    expect(mockTenorAPI).toHaveBeenCalledTimes(1);
+    expect(first.tenorApi).toBe(mockTenorAPI.mock.instances[0]);
+    expect(second.tenorApi).toBe(first.tenorApi);
   });
 });
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -19581,10 +19581,12 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.0.0",
         "@eslint/js": "^9.25.0",
+        "@types/jest": "^30.0.0",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~9.2.0",
-        "typescript": "~5.8.3",
-        "vitest": "^2.0.0"
+        "jest": "~29.7.0",
+        "ts-jest": "^29.4.1",
+        "typescript": "~5.8.3"
       },
       "peerDependencies": {
         "react": ">=18.0.0",

--- a/packages/tenor-api/__tests__/tenor-api.test.ts
+++ b/packages/tenor-api/__tests__/tenor-api.test.ts
@@ -1,0 +1,244 @@
+import { TenorAPI, type TenorGif, type TenorSearchResponse, type TenorTrendingResponse } from '../src';
+
+describe('TenorAPI', () => {
+  const originalFetch = global.fetch;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  const createGif = (overrides: Partial<TenorGif> = {}): TenorGif => {
+    const base: TenorGif = {
+      id: 'gif-id',
+      title: 'Example GIF',
+      media_formats: {
+        gif: { url: 'https://example.com/gif.gif', dims: [120, 80], size: 1_234 },
+      },
+      created: 0,
+      content_description: 'Example description',
+      itemurl: 'https://tenor.com/gif',
+      url: 'https://example.com/gif.gif',
+      tags: [],
+      flags: [],
+      hasaudio: false,
+    };
+
+    return {
+      ...base,
+      ...overrides,
+      media_formats: overrides.media_formats ?? base.media_formats,
+    };
+  };
+
+  it('searchGifs builds the correct request and returns data', async () => {
+    const payload: TenorSearchResponse = { results: [], next: 'cursor-2' };
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    });
+
+    const api = new TenorAPI('test-key');
+    const result = await api.searchGifs('cats', 5, 'cursor-1');
+
+    expect(result).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const requestUrl = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(requestUrl.origin + requestUrl.pathname).toBe('https://tenor.googleapis.com/v2/search');
+    expect(requestUrl.searchParams.get('q')).toBe('cats');
+    expect(requestUrl.searchParams.get('limit')).toBe('5');
+    expect(requestUrl.searchParams.get('pos')).toBe('cursor-1');
+    expect(requestUrl.searchParams.get('key')).toBe('test-key');
+    expect(requestUrl.searchParams.get('media_filter')).toBe('gif');
+    expect(requestUrl.searchParams.get('contentfilter')).toBe('medium');
+  });
+
+  it('searchGifs omits optional parameters when not provided', async () => {
+    const payload: TenorSearchResponse = { results: [], next: 'cursor' };
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    });
+
+    const api = new TenorAPI('test-key');
+    await api.searchGifs('dogs');
+
+    const requestUrl = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(requestUrl.searchParams.get('limit')).toBe('20');
+    expect(requestUrl.searchParams.get('pos')).toBeNull();
+  });
+
+  it('searchGifs throws an error when the response is not ok', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500, statusText: 'Server Error' });
+
+    const api = new TenorAPI('test-key');
+    await expect(api.searchGifs('cats')).rejects.toThrow('Tenor API error: 500 Server Error');
+  });
+
+  it('getTrendingGifs builds the correct request and returns data', async () => {
+    const payload: TenorTrendingResponse = { results: [], next: 'cursor' };
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    });
+
+    const api = new TenorAPI('test-key');
+    const result = await api.getTrendingGifs(10, 'cursor-1');
+
+    expect(result).toEqual(payload);
+
+    const requestUrl = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(requestUrl.origin + requestUrl.pathname).toBe('https://tenor.googleapis.com/v2/featured');
+    expect(requestUrl.searchParams.get('limit')).toBe('10');
+    expect(requestUrl.searchParams.get('pos')).toBe('cursor-1');
+    expect(requestUrl.searchParams.get('key')).toBe('test-key');
+  });
+
+  it('getTrendingGifs uses defaults when arguments are omitted', async () => {
+    const payload: TenorTrendingResponse = { results: [], next: 'cursor' };
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    });
+
+    const api = new TenorAPI('test-key');
+    await api.getTrendingGifs();
+
+    const requestUrl = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(requestUrl.searchParams.get('limit')).toBe('20');
+    expect(requestUrl.searchParams.get('pos')).toBeNull();
+  });
+
+  it('getTrendingGifs throws an error when the response is not ok', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+
+    const api = new TenorAPI('test-key');
+    await expect(api.getTrendingGifs()).rejects.toThrow('Tenor API error: 404 Not Found');
+  });
+
+  it('getGifById fetches the GIF and returns the first result', async () => {
+    const gif = createGif();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [gif] }),
+    });
+
+    const api = new TenorAPI('test-key');
+    const result = await api.getGifById('gif-id');
+
+    expect(result).toBe(gif);
+
+    const requestUrl = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(requestUrl.origin + requestUrl.pathname).toBe('https://tenor.googleapis.com/v2/posts');
+    expect(requestUrl.searchParams.get('ids')).toBe('gif-id');
+  });
+
+  it('getGifById throws an error when the response is not ok', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 400, statusText: 'Bad Request' });
+
+    const api = new TenorAPI('test-key');
+    await expect(api.getGifById('gif-id')).rejects.toThrow('Tenor API error: 400 Bad Request');
+  });
+
+  it('downloadGifAsBlob returns the blob from the response', async () => {
+    const blob = { size: 123 } as unknown as Blob;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      blob: async () => blob,
+    });
+
+    const api = new TenorAPI('test-key');
+    const result = await api.downloadGifAsBlob('https://example.com/g.gif');
+
+    expect(result).toBe(blob);
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com/g.gif');
+  });
+
+  it('downloadGifAsBlob throws when the response is not ok', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503, statusText: 'Failure' });
+
+    const api = new TenorAPI('test-key');
+    await expect(api.downloadGifAsBlob('https://example.com/g.gif')).rejects.toThrow(
+      'Failed to download GIF: 503 Failure',
+    );
+  });
+
+  it('convertGifToAttachedImage includes dimensions for the gif format', () => {
+    const gif = createGif();
+    const api = new TenorAPI('test-key');
+
+    const image = api.convertGifToAttachedImage(gif);
+    const url = new URL(image.uri);
+
+    expect(url.searchParams.get('ww')).toBe('120');
+    expect(url.searchParams.get('hh')).toBe('80');
+    expect(image.alt).toBe(gif.content_description);
+    expect(image.tenorId).toBe(gif.id);
+  });
+
+  it('convertGifToAttachedImage falls back to other media formats and defaults alt text', () => {
+    const gif = createGif({
+      media_formats: {
+        tinygif: { url: 'https://example.com/tiny.gif', dims: [60, 40], size: 512 },
+      },
+      url: 'https://example.com/fallback.gif',
+      content_description: '',
+      title: '',
+    });
+    const api = new TenorAPI('test-key');
+
+    const image = api.convertGifToAttachedImage(gif);
+    const url = new URL(image.uri);
+
+    expect(image.uri).toContain('https://example.com/tiny.gif');
+    expect(url.searchParams.get('ww')).toBe('60');
+    expect(url.searchParams.get('hh')).toBe('40');
+    expect(image.alt).toBe('GIF');
+  });
+
+  it('convertGifToAttachedImage uses the GIF url when no media formats exist', () => {
+    const gif = createGif({
+      media_formats: {} as TenorGif['media_formats'],
+      url: 'https://example.com/direct.gif',
+      content_description: 'Direct description',
+    });
+    const api = new TenorAPI('test-key');
+
+    const image = api.convertGifToAttachedImage(gif);
+
+    expect(image.uri).toBe('https://example.com/direct.gif');
+    expect(image.alt).toBe('Direct description');
+  });
+
+  it('convertGifToAttachedImage omits dimension parameters when none are available', () => {
+    const gif = createGif();
+    delete (gif.media_formats.gif as any).dims;
+    const api = new TenorAPI('test-key');
+
+    const image = api.convertGifToAttachedImage(gif);
+    const url = new URL(image.uri);
+
+    expect(url.searchParams.get('ww')).toBeNull();
+    expect(url.searchParams.get('hh')).toBeNull();
+  });
+
+  it('convertGifToAttachedImage throws when no valid url can be found', () => {
+    const gif = createGif({
+      media_formats: {} as TenorGif['media_formats'],
+      url: '',
+    });
+    const api = new TenorAPI('test-key');
+
+    expect(() => api.convertGifToAttachedImage(gif)).toThrow('No valid GIF URL found in media formats');
+  });
+});

--- a/packages/tenor-api/jest.config.cjs
+++ b/packages/tenor-api/jest.config.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+      tsconfig: './tsconfig.json',
+    },
+  },
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.{ts,tsx}', '!**/*.d.ts'],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'html'],
+};

--- a/packages/tenor-api/package.json
+++ b/packages/tenor-api/package.json
@@ -7,8 +7,9 @@
   "types": "src/index.ts",
   "scripts": {
     "build": "tsc",
-    "test": "vitest run",
-    "test:run": "vitest run",
+    "test": "jest --config ./jest.config.cjs",
+    "test:run": "jest --config ./jest.config.cjs",
+    "test:coverage": "jest --config ./jest.config.cjs --coverage",
     "lint": "eslint src --ext .ts"
   },
   "keywords": ["tenor", "api", "gif"],
@@ -16,8 +17,10 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
+    "@types/jest": "^30.0.0",
+    "jest": "~29.7.0",
+    "ts-jest": "^29.4.1",
     "typescript": "~5.8.3",
-    "vitest": "^2.0.0",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
     "@eslint/eslintrc": "^3.0.0",


### PR DESCRIPTION
## Summary
- add dedicated tests for the tenor utility to confirm the API client is initialised with the expected key and cached
- port the Tenor API behaviour tests into the `tenor-api` package with full Jest coverage
- configure the `tenor-api` workspace to run Jest and collect coverage results

## Testing
- npm run test:coverage --workspace apps/akari
- npm run test:coverage --workspace packages/tenor-api

------
https://chatgpt.com/codex/tasks/task_e_68c8711891fc832bb7c934727d709c28