### PR TITLE
test: replace vitest with jest for bluesky-api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19549,10 +19549,12 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.0.0",
         "@eslint/js": "^9.25.0",
+        "@types/jest": "^30.0.0",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~9.2.0",
-        "typescript": "~5.8.3",
-        "vitest": "^2.0.0"
+        "jest": "~29.7.0",
+        "ts-jest": "^29.4.1",
+        "typescript": "~5.8.3"
       },
       "peerDependencies": {
         "react": ">=18.0.0",

--- a/packages/bluesky-api/jest.config.cjs
+++ b/packages/bluesky-api/jest.config.cjs
@@ -1,0 +1,32 @@
+const baseTsconfig = require('./tsconfig.json');
+
+const jestTsconfig = {
+  ...baseTsconfig.compilerOptions,
+  types: [
+    ...new Set([
+      ...(baseTsconfig.compilerOptions?.types ?? []),
+      'jest',
+      'node',
+    ]),
+  ],
+};
+
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  extensionsToTreatAsEsm: ['.ts'],
+  coverageProvider: 'v8',
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts', '!src/**/*.d.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  globals: {
+    'ts-jest': {
+      useESM: true,
+      tsconfig: jestTsconfig,
+    },
+  },
+};

--- a/packages/bluesky-api/package.json
+++ b/packages/bluesky-api/package.json
@@ -6,9 +6,10 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "build": "tsc",
-    "test": "vitest run",
-    "test:run": "vitest run",
+    "build": "tsc -p tsconfig.build.json",
+    "test": "jest",
+    "test:run": "jest --coverage=false",
+    "test:coverage": "jest --coverage",
     "lint": "eslint src --ext .ts,.tsx"
   },
   "keywords": [
@@ -21,12 +22,14 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "typescript": "~5.8.3",
-    "vitest": "^2.0.0",
+    "@eslint/eslintrc": "^3.0.0",
+    "@eslint/js": "^9.25.0",
+    "@types/jest": "^30.0.0",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
-    "@eslint/eslintrc": "^3.0.0",
-    "@eslint/js": "^9.25.0"
+    "jest": "~29.7.0",
+    "ts-jest": "^29.4.1",
+    "typescript": "~5.8.3"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/bluesky-api/src/pds.test.ts
+++ b/packages/bluesky-api/src/pds.test.ts
@@ -1,16 +1,15 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
 import { getPdsUrlFromDid, getPdsUrlFromHandle } from './pds';
 
 describe('getPdsUrlFromDid', () => {
-  const originalFetch = globalThis.fetch;
+  const originalFetch = globalThis.fetch as typeof fetch;
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    jest.restoreAllMocks();
     globalThis.fetch = originalFetch;
   });
 
   it('returns PDS endpoint when service is available', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
+    const mockFetch = jest.fn().mockResolvedValue({
       ok: true,
       json: () =>
         Promise.resolve({
@@ -26,8 +25,8 @@ describe('getPdsUrlFromDid', () => {
   });
 
   it('returns null when response is not ok', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 } as Response);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    globalThis.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 } as Response);
 
     const url = await getPdsUrlFromDid('did:bad');
 
@@ -36,8 +35,8 @@ describe('getPdsUrlFromDid', () => {
   });
 
   it('returns null when service is missing', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    globalThis.fetch = vi.fn().mockResolvedValue({
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    globalThis.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ service: [] }),
     });
@@ -49,8 +48,8 @@ describe('getPdsUrlFromDid', () => {
   });
 
   it('returns null when fetch throws', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    globalThis.fetch = vi.fn().mockRejectedValue(new Error('network error'));
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    globalThis.fetch = jest.fn().mockRejectedValue(new Error('network error'));
 
     const url = await getPdsUrlFromDid('did:error');
 
@@ -60,15 +59,15 @@ describe('getPdsUrlFromDid', () => {
 });
 
 describe('getPdsUrlFromHandle', () => {
-  const originalFetch = globalThis.fetch;
+  const originalFetch = globalThis.fetch as typeof fetch;
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    jest.restoreAllMocks();
     globalThis.fetch = originalFetch;
   });
 
   it('resolves handle and returns PDS URL', async () => {
-    const mockFetch = vi
+    const mockFetch = jest
       .fn()
       .mockResolvedValueOnce({
         ok: true,
@@ -94,8 +93,8 @@ describe('getPdsUrlFromHandle', () => {
   });
 
   it('returns null when handle resolution fails', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 } as Response);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    globalThis.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 } as Response);
 
     const url = await getPdsUrlFromHandle('bad.handle');
 
@@ -104,8 +103,8 @@ describe('getPdsUrlFromHandle', () => {
   });
 
   it('returns null when no DID is returned', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    globalThis.fetch = jest.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
 
     const url = await getPdsUrlFromHandle('nodid.handle');
 
@@ -114,8 +113,8 @@ describe('getPdsUrlFromHandle', () => {
   });
 
   it('returns null when PDS lookup yields no service', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    globalThis.fetch = vi
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    globalThis.fetch = jest
       .fn()
       .mockResolvedValueOnce({
         ok: true,

--- a/packages/bluesky-api/tsconfig.build.json
+++ b/packages/bluesky-api/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary
- replace the Bluesky API Vitest suite with Jest equivalents
- add a package-level Jest configuration that inlines ts-jest compiler options instead of a dedicated test tsconfig
- keep tests covered by the main tsconfig while adding a build-specific project that omits test files from the emitted output

## Testing
- npm run build --workspace packages/bluesky-api
- npm run test:coverage --workspace packages/bluesky-api
- npx --yes --package typescript tsc -p packages/bluesky-api/tsconfig.json --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68c87453785c832b8c979ebd18c1e2ad