### PR TITLE
chore(workflows): run repo-wide coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,14 @@ jobs:
         with:
           node-version: 22
           cache: npm
-      - run: npm ci --workspace=apps/akari
-      - run: npm --prefix apps/akari run test:coverage
+      - run: npm ci
+      - run: npm run test:coverage --workspaces --if-present
+      - name: Merge coverage reports
+        run: mkdir -p coverage && rm -f coverage/lcov.info && npx --yes lcov-result-merger "**/coverage/lcov.info" coverage/lcov.info --ignore "node_modules/**"
       - name: Report coverage
         uses: vebr/jest-lcov-reporter@v0.2.0
         with:
           github-token: ${{ github.token }}
-          lcov-file: apps/akari/coverage/lcov.info
-          name: apps/akari
+          lcov-file: coverage/lcov.info
+          name: akari-monorepo
           update-comment: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - run: npm ci
       - run: npm run test:coverage --workspaces --if-present
       - name: Merge coverage reports
-        run: mkdir -p coverage && rm -f coverage/lcov.info && npx --yes lcov-result-merger "**/coverage/lcov.info" coverage/lcov.info --ignore "node_modules/**"
+        run: node ./scripts/merge-coverage.cjs
       - name: Report coverage
         uses: vebr/jest-lcov-reporter@v0.2.0
         with:

--- a/scripts/merge-coverage.cjs
+++ b/scripts/merge-coverage.cjs
@@ -1,0 +1,88 @@
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = process.cwd();
+const coverageDirName = 'coverage';
+const outputPath = path.join(rootDir, coverageDirName, 'lcov.info');
+
+const coverageFiles = [];
+
+function walk(currentDir) {
+  const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(currentDir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === '.git') {
+        continue;
+      }
+
+      walk(entryPath);
+      continue;
+    }
+
+    if (
+      entry.isFile() &&
+      entry.name === 'lcov.info' &&
+      path.basename(path.dirname(entryPath)) === coverageDirName &&
+      path.resolve(entryPath) !== outputPath
+    ) {
+      coverageFiles.push(entryPath);
+    }
+  }
+}
+
+walk(rootDir);
+coverageFiles.sort();
+
+if (coverageFiles.length === 0) {
+  throw new Error('No coverage reports were found to merge.');
+}
+
+const mergedLines = [];
+
+for (const filePath of coverageFiles) {
+  const reportContent = fs.readFileSync(filePath, 'utf8');
+  const lines = reportContent.split(/\r?\n/);
+  const workspaceRoot = path.dirname(path.dirname(filePath));
+  const relativePrefix = path.relative(rootDir, workspaceRoot).replace(/\\/g, '/');
+  const prefix = relativePrefix && relativePrefix !== '.' ? `${relativePrefix}/` : '';
+
+  for (const line of lines) {
+    if (line.startsWith('SF:')) {
+      const originalPath = line.slice(3).trim();
+      const normalized = normalizeSourcePath(originalPath, prefix);
+      mergedLines.push(`SF:${normalized}`);
+    } else {
+      mergedLines.push(line);
+    }
+  }
+}
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${mergedLines.join('\n')}\n`);
+
+function normalizeSourcePath(sourcePath, prefix) {
+  if (!sourcePath) {
+    return sourcePath;
+  }
+
+  let sanitized = sourcePath.replace(/\\/g, '/');
+
+  if (sanitized.startsWith('./')) {
+    sanitized = sanitized.slice(2);
+  }
+
+  if (sanitized.startsWith('/')) {
+    return sanitized;
+  }
+
+  const combined = `${prefix}${sanitized}`
+    .replace(/\\/g, '/')
+    .replace(/\/{2,}/g, '/');
+  if (combined.startsWith('./')) {
+    return combined;
+  }
+
+  return `./${combined}`;
+}


### PR DESCRIPTION
## Summary
- install dependencies for the entire monorepo and execute coverage across all workspaces
- merge the generated Jest lcov files and publish the aggregated report in the coverage comment

## Testing
- npm run test:coverage --workspaces --if-present

------
https://chatgpt.com/codex/tasks/task_e_68c87ab5d818832bade3c87ee3a970bb