### PR TITLE
test: align package coverage reporters

### DIFF
--- a/packages/bluesky-api/jest.config.cjs
+++ b/packages/bluesky-api/jest.config.cjs
@@ -20,6 +20,8 @@ module.exports = {
   coverageProvider: 'v8',
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts', '!src/**/*.d.ts'],
+  coverageReporters: ['text', 'lcov', 'html'],
+  coverageDirectory: 'coverage',
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },

--- a/packages/clearsky-api/jest.config.cjs
+++ b/packages/clearsky-api/jest.config.cjs
@@ -6,6 +6,10 @@ module.exports = {
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts', '!src/**/*.d.ts'],
+  coverageReporters: ['text', 'lcov', 'html'],
+  coverageDirectory: 'coverage',
   globals: {
     'ts-jest': {
       useESM: true,


### PR DESCRIPTION
## Summary
- configure bluesky-api and clearsky-api Jest setups to emit text, lcov, and HTML coverage reports
- store coverage output alongside the existing coverage directories for package test runs

## Testing
- npm run test --workspace bluesky-api
- npm run test --workspace clearsky-api

------
https://chatgpt.com/codex/tasks/task_e_68c881d36f4c832bbf613a365296819f