### PR TITLE
test: migrate bluesky-api tests to msw

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -714,6 +714,12 @@ describe('useLikePost Hook - Comprehensive Tests', () => {
 - Components you're testing integration with
 - Theme/styling logic (unless testing theme switching)
 
+### Network Request Mocking Standard
+
+- Use [Mock Service Worker (MSW)](https://mswjs.io/) to intercept HTTP requests in tests. Set up `setupServer`/`setupWorker` fixtures instead of reassigning `fetch` or other globals.
+- Prefer inspecting requests within MSW handlers to assert headers, payloads, and query parameters.
+- Reset MSW handlers between tests to avoid cross-test pollution.
+
 ### Test Quality Checklist
 
 Before considering a test complete, ensure:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1698,6 +1698,36 @@
         "rollup-pluginutils": "^2.8.2"
       }
     },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cookie": "^0.7.2"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "statuses": "^2.0.1"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -3180,6 +3210,144 @@
       "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==",
       "license": "MIT"
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.0.tgz",
+      "integrity": "sha512-JWaTfCxI1eTmJ1BIv86vUfjVatOdxwD0DAVKYevY8SazeUUZtW+tNbsdejVO1GYE0GXJW1N1ahmiC3TFd+7wZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.18.tgz",
+      "integrity": "sha512-MilmWOzHa3Ks11tzvuAmFoAd/wRuaP3SwlT1IZhyMke31FKLxPiuDWcGXhU+PKveNOpAc4axzAgrgxuIJJRmLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.2.2.tgz",
+      "integrity": "sha512-yXq/4QUnk4sHMtmbd7irwiepjB8jXU0kkFRL4nr/aDBA2mDz13cMakEWdDwX3eSCTkk03kwcndD1zfRAIlELxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.0",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/core/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -3899,6 +4067,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.39.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.6.tgz",
+      "integrity": "sha512-bndDP83naYYkfayr/qhBHMhk0YGwS1iv6vaEGcr0SQbO0IZtbOPqjKjds/WcG+bJA+1T5vCx6kprKOzn5Bg+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -3959,6 +4145,31 @@
       "engines": {
         "node": ">=12.4.0"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -4937,6 +5148,13 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -5132,6 +5350,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/tough-cookie": {
@@ -7338,6 +7563,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -7575,6 +7810,16 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.44.0",
@@ -10436,6 +10681,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
+      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/handlebars": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -10556,6 +10811,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
@@ -11220,6 +11482,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -14087,6 +14356,75 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.11.2.tgz",
+      "integrity": "sha512-MI54hLCsrMwiflkcqlgYYNJJddY5/+S0SnONvhv1owOplvqohKSQyGejpNdUGyCwgs4IH7PqaNbPw/sKOEze9Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bundled-es-modules/cookie": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.39.1",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.6.0",
+        "@types/statuses": "^2.0.4",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.7.0",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.0",
+        "type-fest": "^4.26.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -14607,6 +14945,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -14784,6 +15129,13 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "1.1.2",
@@ -15935,6 +16287,13 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/rettime": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.7.0.tgz",
+      "integrity": "sha512-LPRKoHnLKd/r3dVxcwO7vhCW+orkOGj9ViueosEBK6ie89CijnfRlhaDhHq/3Hxu4CkWQtxwlBG0mzTQY6uQjw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -16900,6 +17259,13 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strict-uri-encode": {
       "version": "2.0.0",
@@ -19543,6 +19909,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "packages/bluesky-api": {
       "version": "1.0.0",
       "license": "MIT",
@@ -19553,6 +19932,7 @@
         "eslint": "^9.25.0",
         "eslint-config-expo": "~9.2.0",
         "jest": "~29.7.0",
+        "msw": "^2.4.9",
         "ts-jest": "^29.4.1",
         "typescript": "~5.8.3"
       },

--- a/packages/bluesky-api/package.json
+++ b/packages/bluesky-api/package.json
@@ -28,6 +28,7 @@
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
     "jest": "~29.7.0",
+    "msw": "^2.4.9",
     "ts-jest": "^29.4.1",
     "typescript": "~5.8.3"
   },

--- a/packages/bluesky-api/src/client.test.ts
+++ b/packages/bluesky-api/src/client.test.ts
@@ -1,0 +1,214 @@
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { BlueskyApiClient } from './client';
+
+describe('BlueskyApiClient', () => {
+  const server = setupServer();
+
+  class TestClient extends BlueskyApiClient {
+    constructor() {
+      super('https://pds.example');
+    }
+
+    async callMakeRequest<T>(endpoint: string, options?: {
+      method?: 'GET' | 'POST';
+      headers?: Record<string, string>;
+      body?: Record<string, unknown> | FormData | Blob;
+      params?: Record<string, string>;
+    }): Promise<T> {
+      return this.makeRequest<T>(endpoint, options);
+    }
+
+    async callMakeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options?: {
+        method?: 'GET' | 'POST';
+        headers?: Record<string, string>;
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string>;
+      },
+    ): Promise<T> {
+      return this.makeAuthenticatedRequest<T>(endpoint, accessJwt, options);
+    }
+  }
+
+  class UploadClient extends BlueskyApiClient {
+    public lastCall?: {
+      endpoint: string;
+      accessJwt: string;
+      options: {
+        method?: 'GET' | 'POST';
+        headers?: Record<string, string>;
+        body?: Blob;
+        params?: Record<string, string>;
+      };
+    };
+
+    public response: unknown;
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    async callUploadBlob(accessJwt: string, blob: Blob, mimeType: string) {
+      return this.uploadBlob(accessJwt, blob, mimeType);
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: {
+        method?: 'GET' | 'POST';
+        headers?: Record<string, string>;
+        body?: Blob;
+        params?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      this.lastCall = { endpoint, accessJwt, options };
+      return this.response as T;
+    }
+  }
+
+  beforeAll(() => server.listen());
+
+  afterEach(() => {
+    server.resetHandlers();
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => server.close());
+
+  it('makes requests with JSON payloads and query params', async () => {
+    let capturedRequest: {
+      url: string;
+      method: string;
+      headers: Record<string, string>;
+      body: unknown;
+    } | null = null;
+
+    server.use(
+      http.post('https://pds.example/xrpc/test.endpoint', async ({ request }) => {
+        capturedRequest = {
+          url: request.url,
+          method: request.method,
+          headers: Object.fromEntries(request.headers.entries()),
+          body: await request.json(),
+        };
+        return HttpResponse.json({ success: true });
+      }),
+    );
+
+    const client = new TestClient();
+    const result = await client.callMakeRequest<{ success: boolean }>('/test.endpoint', {
+      method: 'POST',
+      headers: { 'X-Custom': 'value' },
+      body: { hello: 'world' },
+      params: { q: 'query' },
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(capturedRequest).not.toBeNull();
+    const request = capturedRequest!;
+    expect(request.url).toBe('https://pds.example/xrpc/test.endpoint?q=query');
+    expect(request.method).toBe('POST');
+    expect(request.headers['content-type']).toBe('application/json');
+    expect(request.headers['x-custom']).toBe('value');
+    expect(request.body).toEqual({ hello: 'world' });
+  });
+
+  it('omits content type header for FormData bodies', async () => {
+    let capturedHeaders: Record<string, string> | null = null;
+    let capturedFile: FormDataEntryValue | null = null;
+
+    server.use(
+      http.post('https://pds.example/xrpc/upload', async ({ request }) => {
+        capturedHeaders = Object.fromEntries(request.headers.entries());
+        const formData = await request.formData();
+        capturedFile = formData.get('file');
+        return HttpResponse.json({ done: true });
+      }),
+    );
+
+    const formData = new FormData();
+    formData.append('file', new Blob(['data'], { type: 'text/plain' }), 'file.txt');
+
+    const client = new TestClient();
+    await client.callMakeRequest('/upload', {
+      method: 'POST',
+      body: formData,
+    });
+
+    expect(capturedHeaders).not.toBeNull();
+    const headers = capturedHeaders!;
+    expect(headers['content-type']).toMatch(/^multipart\/form-data;/);
+    expect(headers['content-type']).not.toBe('application/json');
+    expect(capturedFile).toBeInstanceOf(Blob);
+  });
+
+  it('throws errors when response is not ok', async () => {
+    server.use(
+      http.get('https://pds.example/xrpc/fail', () =>
+        HttpResponse.json({ message: 'Bad request' }, { status: 400 }),
+      ),
+    );
+
+    const client = new TestClient();
+
+    await expect(client.callMakeRequest('/fail')).rejects.toThrow('Bad request');
+  });
+
+  it('includes bearer token headers for authenticated requests', async () => {
+    let capturedRequest: {
+      url: string;
+      headers: Record<string, string>;
+      method: string;
+    } | null = null;
+
+    server.use(
+      http.get('https://pds.example/xrpc/secure', async ({ request }) => {
+        capturedRequest = {
+          url: request.url,
+          headers: Object.fromEntries(request.headers.entries()),
+          method: request.method,
+        };
+        return HttpResponse.json({});
+      }),
+    );
+
+    const client = new TestClient();
+    await client.callMakeAuthenticatedRequest('/secure', 'token-123', {
+      params: { cursor: 'abc' },
+    });
+
+    expect(capturedRequest).not.toBeNull();
+    const request = capturedRequest!;
+    expect(request.url).toBe('https://pds.example/xrpc/secure?cursor=abc');
+    expect(request.method).toBe('GET');
+    expect(request.headers.authorization).toBe('Bearer token-123');
+  });
+
+  it('uploads blobs using the provided mime type', async () => {
+    const client = new UploadClient();
+    const response = {
+      blob: {
+        ref: { $link: 'blob-ref' },
+        mimeType: 'image/png',
+        size: 123,
+      },
+    };
+    client.response = response;
+
+    const blob = new Blob(['content'], { type: 'text/plain' });
+    const result = await client.callUploadBlob('jwt-token', blob, 'image/png');
+
+    expect(result).toEqual(response);
+    expect(client.lastCall).toBeDefined();
+    expect(client.lastCall?.endpoint).toBe('/com.atproto.repo.uploadBlob');
+    expect(client.lastCall?.accessJwt).toBe('jwt-token');
+    expect(client.lastCall?.options.headers).toEqual({ 'Content-Type': 'image/png' });
+    expect(client.lastCall?.options.body).toBeInstanceOf(Blob);
+    expect(client.lastCall?.options.body?.type).toBe('image/png');
+  });
+});

--- a/packages/bluesky-api/src/feeds.test.ts
+++ b/packages/bluesky-api/src/feeds.test.ts
@@ -1,0 +1,237 @@
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { BlueskyFeeds } from './feeds';
+
+describe('BlueskyFeeds', () => {
+  class MockFeeds extends BlueskyFeeds {
+    public makeAuthenticatedRequestMock = jest.fn();
+    public uploadImageMock = jest.fn();
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: {
+        method?: 'GET' | 'POST';
+        headers?: Record<string, string>;
+        body?: {
+          repo?: string;
+          collection?: string;
+          record?: Record<string, unknown>;
+          [key: string]: unknown;
+        };
+        params?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      return this.makeAuthenticatedRequestMock(endpoint, accessJwt, options);
+    }
+
+    async uploadImage(
+      accessJwt: string,
+      imageUri: string,
+      mimeType: string,
+    ): Promise<{
+      blob: {
+        ref: { $link: string };
+        mimeType: string;
+        size: number;
+      };
+    }> {
+      return this.uploadImageMock(accessJwt, imageUri, mimeType);
+    }
+  }
+
+  class UploadImageFeeds extends BlueskyFeeds {
+    public lastCall?: {
+      endpoint: string;
+      accessJwt: string;
+      options: {
+        method?: 'GET' | 'POST';
+        headers?: Record<string, string>;
+        body?: Blob;
+        params?: Record<string, string>;
+      };
+    };
+
+    public response: unknown;
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: {
+        method?: 'GET' | 'POST';
+        headers?: Record<string, string>;
+        body?: Blob;
+        params?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      this.lastCall = { endpoint, accessJwt, options };
+      return this.response as T;
+    }
+  }
+
+  const server = setupServer();
+
+  beforeAll(() => server.listen());
+
+  afterEach(() => {
+    server.resetHandlers();
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => server.close());
+
+  it('returns a post from a thread response', async () => {
+    const feeds = new MockFeeds();
+    const post = { uri: 'at://post/1', cid: 'cid', text: 'hello' };
+    feeds.makeAuthenticatedRequestMock.mockResolvedValueOnce({ thread: { post } });
+
+    const result = await feeds.getPost('jwt', 'at://post/1');
+
+    expect(result).toEqual(post);
+    expect(feeds.makeAuthenticatedRequestMock).toHaveBeenCalledWith(
+      '/app.bsky.feed.getPostThread',
+      'jwt',
+      { params: { uri: 'at://post/1' } },
+    );
+  });
+
+  it('throws when a post is missing in thread response', async () => {
+    const feeds = new MockFeeds();
+    feeds.makeAuthenticatedRequestMock.mockResolvedValueOnce({ thread: {} });
+
+    await expect(feeds.getPost('jwt', 'at://post/missing')).rejects.toThrow('Post not found');
+  });
+
+  it('throws when unlikePost is called with an invalid URI', async () => {
+    const feeds = new MockFeeds();
+
+    await expect(feeds.unlikePost('jwt', 'invalid/', 'did:example')).rejects.toThrow(
+      'Invalid like URI: could not extract rkey',
+    );
+    expect(feeds.makeAuthenticatedRequestMock).not.toHaveBeenCalled();
+  });
+
+  it('creates posts with image embeds', async () => {
+    const feeds = new MockFeeds();
+    const imageBlobOne = { ref: { $link: 'blob-1' }, mimeType: 'image/png', size: 10 };
+    const imageBlobTwo = { ref: { $link: 'blob-2' }, mimeType: 'image/jpeg', size: 20 };
+    feeds.uploadImageMock
+      .mockResolvedValueOnce({ blob: imageBlobOne })
+      .mockResolvedValueOnce({ blob: imageBlobTwo });
+
+    const response = { uri: 'at://post/created', cid: 'cid' };
+    feeds.makeAuthenticatedRequestMock.mockResolvedValueOnce(response);
+
+    const result = await feeds.createPost('jwt', 'did:example', {
+      text: 'A post with images',
+      images: [
+        { uri: 'file://one.png', alt: 'One', mimeType: 'image/png' },
+        { uri: 'file://two.jpg', alt: 'Two', mimeType: 'image/jpeg' },
+      ],
+    });
+
+    expect(result).toBe(response);
+    expect(feeds.uploadImageMock).toHaveBeenNthCalledWith(1, 'jwt', 'file://one.png', 'image/png');
+    expect(feeds.uploadImageMock).toHaveBeenNthCalledWith(2, 'jwt', 'file://two.jpg', 'image/jpeg');
+
+    const call = feeds.makeAuthenticatedRequestMock.mock.calls[0];
+    expect(call[0]).toBe('/com.atproto.repo.createRecord');
+    expect(call[1]).toBe('jwt');
+    const options = call[2];
+    expect(options.method).toBe('POST');
+    expect(options.body.repo).toBe('did:example');
+    expect(options.body.collection).toBe('app.bsky.feed.post');
+    const record = options.body.record as Record<string, unknown>;
+    expect(record.text).toBe('A post with images');
+    expect(record.$type).toBe('app.bsky.feed.post');
+    expect(record.langs).toEqual(['en']);
+    expect(record.createdAt).toEqual(expect.any(String));
+    expect(record.embed).toEqual({
+      $type: 'app.bsky.embed.images',
+      images: [
+        { alt: 'One', image: imageBlobOne },
+        { alt: 'Two', image: imageBlobTwo },
+      ],
+    });
+  });
+
+  it('creates posts with GIF embeds as external media', async () => {
+    const feeds = new MockFeeds();
+    const thumbnailBlob = { ref: { $link: 'thumb' }, mimeType: 'image/jpeg', size: 30 };
+    feeds.uploadImageMock.mockResolvedValueOnce({ blob: thumbnailBlob });
+
+    const response = { uri: 'at://post/gif', cid: 'cid' };
+    feeds.makeAuthenticatedRequestMock.mockResolvedValueOnce(response);
+
+    const result = await feeds.createPost('jwt', 'did:example', {
+      text: 'GIF post',
+      images: [
+        { uri: 'https://gif.example/gif.gif', alt: 'Funny gif', mimeType: 'image/gif', tenorId: '123' },
+      ],
+    });
+
+    expect(result).toBe(response);
+    expect(feeds.uploadImageMock).toHaveBeenCalledWith('jwt', 'https://gif.example/gif.gif', 'image/jpeg');
+
+    const [, , options] = feeds.makeAuthenticatedRequestMock.mock.calls[0];
+    const record = options.body.record as Record<string, unknown>;
+    expect(record.embed).toEqual({
+      $type: 'app.bsky.embed.external',
+      external: {
+        uri: 'https://gif.example/gif.gif',
+        title: 'Funny gif',
+        description: 'Alt: Funny gif',
+        thumb: {
+          $type: 'blob',
+          ref: thumbnailBlob.ref,
+          mimeType: thumbnailBlob.mimeType,
+          size: thumbnailBlob.size,
+        },
+      },
+    });
+  });
+
+  it('uploads images and forwards blobs to the upload endpoint', async () => {
+    let imageRequestUrl: string | null = null;
+
+    server.use(
+      http.get('https://cdn.example/image.png', async () => {
+        imageRequestUrl = 'https://cdn.example/image.png';
+        const blob = new Blob(['binary'], { type: 'image/png' });
+        const buffer = await blob.arrayBuffer();
+        return HttpResponse.arrayBuffer(buffer, {
+          headers: { 'Content-Type': 'image/png' },
+        });
+      }),
+    );
+
+    const feeds = new UploadImageFeeds();
+    const response = {
+      blob: {
+        ref: { $link: 'uploaded' },
+        mimeType: 'image/png',
+        size: 42,
+      },
+    };
+    feeds.response = response;
+
+    const result = await feeds.uploadImage('jwt', 'https://cdn.example/image.png', 'image/png');
+
+    expect(result).toEqual(response);
+    expect(imageRequestUrl).toBe('https://cdn.example/image.png');
+    expect(feeds.lastCall?.endpoint).toBe('/com.atproto.repo.uploadBlob');
+    expect(feeds.lastCall?.accessJwt).toBe('jwt');
+    expect(feeds.lastCall?.options.headers).toEqual({ 'Content-Type': 'image/png' });
+    expect(feeds.lastCall?.options.body).toBeInstanceOf(Blob);
+    expect(feeds.lastCall?.options.body?.type).toBe('image/png');
+  });
+});

--- a/packages/bluesky-api/src/notifications.test.ts
+++ b/packages/bluesky-api/src/notifications.test.ts
@@ -1,0 +1,88 @@
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { BlueskyNotifications } from './notifications';
+
+describe('BlueskyNotifications', () => {
+  const server = setupServer();
+
+  beforeAll(() => server.listen());
+
+  afterEach(() => {
+    server.resetHandlers();
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => server.close());
+
+  it('fetches notifications with query parameters', async () => {
+    const responseData = { notifications: [] };
+    let capturedUrl: string | null = null;
+    let capturedHeaders: Record<string, string> | null = null;
+
+    server.use(
+      http.get('https://custom.pds/xrpc/app.bsky.notification.listNotifications', async ({ request }) => {
+        capturedUrl = request.url;
+        capturedHeaders = Object.fromEntries(request.headers.entries());
+        return HttpResponse.json(responseData);
+      }),
+    );
+
+    const client = new BlueskyNotifications('https://custom.pds');
+    const result = await client.listNotifications('jwt-token', 10, 'cursor123', ['like', 'follow'], true, '2024-01-01T00:00:00Z');
+
+    expect(result).toEqual(responseData);
+    expect(capturedUrl).toBe(
+      'https://custom.pds/xrpc/app.bsky.notification.listNotifications?limit=10&cursor=cursor123&priority=true&seenAt=2024-01-01T00%3A00%3A00Z&reasons=like&reasons=follow',
+    );
+    expect(capturedHeaders).not.toBeNull();
+    const headers = capturedHeaders!;
+    expect(headers.authorization).toBe('Bearer jwt-token');
+    expect(headers['content-type']).toBe('application/json');
+  });
+
+  it('throws descriptive errors when notification request fails', async () => {
+    server.use(
+      http.get('https://bsky.social/xrpc/app.bsky.notification.listNotifications', () =>
+        HttpResponse.json({ message: 'Request failed' }, { status: 500, statusText: 'Server Error' }),
+      ),
+    );
+
+    const client = new BlueskyNotifications();
+
+    await expect(client.listNotifications('jwt-token')).rejects.toThrow('Request failed');
+  });
+
+  it('fetches unread notification counts', async () => {
+    const responseData = { count: 5 };
+    let capturedHeaders: Record<string, string> | null = null;
+
+    server.use(
+      http.get('https://example.pds/xrpc/app.bsky.notification.getUnreadCount', async ({ request }) => {
+        capturedHeaders = Object.fromEntries(request.headers.entries());
+        return HttpResponse.json(responseData);
+      }),
+    );
+
+    const client = new BlueskyNotifications('https://example.pds');
+    const result = await client.getUnreadCount('jwt-token');
+
+    expect(result).toEqual({ count: 5 });
+    expect(capturedHeaders).not.toBeNull();
+    const headers = capturedHeaders!;
+    expect(headers.authorization).toBe('Bearer jwt-token');
+    expect(headers['content-type']).toBe('application/json');
+  });
+
+  it('throws fallback errors when unread count json parsing fails', async () => {
+    server.use(
+      http.get('https://example.pds/xrpc/app.bsky.notification.getUnreadCount', () =>
+        HttpResponse.text('not json', { status: 404, statusText: 'Not Found' }),
+      ),
+    );
+
+    const client = new BlueskyNotifications('https://example.pds');
+
+    await expect(client.getUnreadCount('jwt-token')).rejects.toThrow('HTTP 404: Not Found');
+  });
+});

--- a/packages/bluesky-api/src/video.test.ts
+++ b/packages/bluesky-api/src/video.test.ts
@@ -1,0 +1,99 @@
+import { http, HttpResponse, delay } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { resolveBlueskyVideoUrl } from './video';
+
+describe('resolveBlueskyVideoUrl', () => {
+  const originalConsoleError = console.error;
+  const server = setupServer();
+
+  beforeAll(() => server.listen());
+
+  afterEach(() => {
+    server.resetHandlers();
+    jest.restoreAllMocks();
+    console.error = originalConsoleError;
+    jest.useRealTimers();
+  });
+
+  afterAll(() => server.close());
+
+  it('returns the original url for non-Bluesky playlists', async () => {
+    const url = 'https://example.com/video.mp4';
+    const result = await resolveBlueskyVideoUrl(url);
+    expect(result).toBe(url);
+  });
+
+  it('resolves playlist urls to video urls with session ids', async () => {
+    const playlist = `#EXTM3U\n#EXT-X-VERSION:3\nsegment1.ts\nvideo.m3u8?session_id=abc123`;
+    let capturedHeaders: Record<string, string> | null = null;
+
+    server.use(
+      http.get('https://video.bsky.app/path/playlist.m3u8', async ({ request }) => {
+        capturedHeaders = Object.fromEntries(request.headers.entries());
+        return HttpResponse.text(playlist, {
+          headers: { 'Content-Type': 'application/vnd.apple.mpegurl' },
+        });
+      }),
+    );
+
+    const result = await resolveBlueskyVideoUrl('https://video.bsky.app/path/playlist.m3u8');
+
+    expect(capturedHeaders).not.toBeNull();
+    const headers = capturedHeaders!;
+    expect(headers.accept).toBe('application/vnd.apple.mpegurl,application/x-mpegurl,*/*');
+    expect(headers['user-agent']).toBe('VideoPlayer/1.0');
+    expect(result).toBe('https://video.bsky.app/path/video.m3u8?session_id=abc123');
+  });
+
+  it('returns null and logs errors when playlist parsing fails', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    server.use(
+      http.get('https://video.bsky.app/path/playlist.m3u8', () =>
+        HttpResponse.text('#EXTM3U\n# Comment without session id', {
+          headers: { 'Content-Type': 'application/vnd.apple.mpegurl' },
+        }),
+      ),
+    );
+
+    const result = await resolveBlueskyVideoUrl('https://video.bsky.app/path/playlist.m3u8');
+
+    expect(result).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('returns null with http error message when fetch fails', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    server.use(
+      http.get('https://video.bsky.app/path/playlist.m3u8', () =>
+        HttpResponse.text('Not Found', { status: 404, statusText: 'Not Found' }),
+      ),
+    );
+
+    const result = await resolveBlueskyVideoUrl('https://video.bsky.app/path/playlist.m3u8');
+
+    expect(result).toBeNull();
+    expect(errorSpy).toHaveBeenCalledWith('Video resolution: Failed to resolve playlist:', expect.any(Error));
+  });
+
+  it('handles aborted requests gracefully', async () => {
+    jest.useFakeTimers();
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    server.use(
+      http.get('https://video.bsky.app/path/playlist.m3u8', async () => {
+        await delay('infinite');
+        return HttpResponse.text('');
+      }),
+    );
+
+    const promise = resolveBlueskyVideoUrl('https://video.bsky.app/path/playlist.m3u8');
+    jest.runOnlyPendingTimers();
+    const result = await promise;
+
+    expect(result).toBeNull();
+    expect(errorSpy).toHaveBeenCalledWith('Video resolution: Request timeout');
+  });
+});


### PR DESCRIPTION
## Summary
- replace direct fetch mocking in bluesky-api tests with MSW interceptors and request assertions
- cover image upload fetches with MSW and document the mocking requirement in agents.md
- add msw as a dev dependency for the bluesky-api package

## Testing
- npm run test:coverage --workspace packages/bluesky-api

------
https://chatgpt.com/codex/tasks/task_e_68c88afd0d5c832bbc2945420685e47c