### PR TITLE
chore: add test coverage turbo script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "test": "turbo run test --filter=akari",
+    "test:coverage": "turbo run test:coverage",
     "clean": "turbo run clean",
     "ios": "turbo run ios --filter=akari",
     "android": "turbo run android --filter=akari",

--- a/turbo.json
+++ b/turbo.json
@@ -21,6 +21,7 @@
     "test": {
       "dependsOn": ["^build"]
     },
+    "test:coverage": {},
     "ios": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## Summary
- add a root-level `test:coverage` npm script that runs the coverage task through Turborepo
- configure a matching `test:coverage` pipeline in `turbo.json` without build dependencies so coverage tasks can run directly

## Testing
- npm run test:coverage *(fails: existing tests in `clearsky-api` and `tenor-api` cannot resolve `msw` types)*

------
https://chatgpt.com/codex/tasks/task_e_68c88f1da1cc832baf2356b26fe1251a