### PR TITLE
test: ensure signin screen coverage

### DIFF
--- a/apps/akari/__tests__/app/(auth)/signin.test.tsx
+++ b/apps/akari/__tests__/app/(auth)/signin.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import type { RenderAPI } from '@testing-library/react-native';
+import { KeyboardAvoidingView, Platform } from 'react-native';
 
 import AuthScreen from '@/app/(auth)/signin';
 import { useAddAccount } from '@/hooks/mutations/useAddAccount';
@@ -48,9 +50,22 @@ const mockGetPdsUrlFromHandle = getPdsUrlFromHandle as jest.Mock;
 
 const mockRouterReplace = router.replace as jest.Mock;
 
+const handlePlaceholder = 'auth.blueskyHandlePlaceholder';
+const passwordPlaceholder = 'auth.appPasswordPlaceholder';
+
 let signInMutate: jest.Mock;
 let addAccountMutate: jest.Mock;
 let switchAccountMutate: jest.Mock;
+
+const renderScreen = () => render(<AuthScreen />);
+
+const fillCredentials = (
+  utils: RenderAPI,
+  { handle = 'user', password = 'password' }: { handle?: string; password?: string } = {},
+) => {
+  fireEvent.changeText(utils.getByPlaceholderText(handlePlaceholder), handle);
+  fireEvent.changeText(utils.getByPlaceholderText(passwordPlaceholder), password);
+};
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -78,7 +93,7 @@ beforeEach(() => {
 
 describe('AuthScreen', () => {
   it('shows error when fields are empty', () => {
-    const { getByText } = render(<AuthScreen />);
+    const { getByText } = renderScreen();
 
     fireEvent.press(getByText('common.signIn'));
 
@@ -91,12 +106,10 @@ describe('AuthScreen', () => {
   });
 
   it('shows error for invalid handle', () => {
-    const { getByText, getByPlaceholderText } = render(<AuthScreen />);
+    const utils = renderScreen();
 
-    fireEvent.changeText(getByPlaceholderText('auth.blueskyHandlePlaceholder'), 'invalid handle!');
-    fireEvent.changeText(getByPlaceholderText('auth.appPasswordPlaceholder'), 'pass');
-
-    fireEvent.press(getByText('common.signIn'));
+    fillCredentials(utils, { handle: 'invalid handle!', password: 'pass' });
+    fireEvent.press(utils.getByText('common.signIn'));
 
     expect(mockShowAlert).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -106,13 +119,64 @@ describe('AuthScreen', () => {
     );
   });
 
+  it('shows error when PDS server cannot be detected while signing in', async () => {
+    mockGetPdsUrlFromHandle.mockResolvedValueOnce(null);
+    const utils = renderScreen();
+
+    fillCredentials(utils);
+    fireEvent.press(utils.getByText('common.signIn'));
+
+    await waitFor(() => {
+      expect(mockShowAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'common.error',
+          message: 'Could not detect PDS server for this handle',
+        }),
+      );
+    });
+
+    expect(signInMutate).not.toHaveBeenCalled();
+  });
+
+  it('shows error when sign in mutation throws', async () => {
+    signInMutate.mockRejectedValueOnce(new Error('boom'));
+    const utils = renderScreen();
+
+    fillCredentials(utils);
+    fireEvent.press(utils.getByText('common.signIn'));
+
+    await waitFor(() => {
+      expect(mockShowAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'common.error',
+          message: 'boom',
+        }),
+      );
+    });
+  });
+
+  it('falls back to default sign in error message when error is not an Error instance', async () => {
+    signInMutate.mockRejectedValueOnce('failure');
+    const utils = renderScreen();
+
+    fillCredentials(utils);
+    fireEvent.press(utils.getByText('common.signIn'));
+
+    await waitFor(() => {
+      expect(mockShowAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'common.error',
+          message: 'auth.signInFailed',
+        }),
+      );
+    });
+  });
+
   it('signs in successfully', async () => {
-    const { getByText, getByPlaceholderText } = render(<AuthScreen />);
+    const utils = renderScreen();
 
-    fireEvent.changeText(getByPlaceholderText('auth.blueskyHandlePlaceholder'), 'user');
-    fireEvent.changeText(getByPlaceholderText('auth.appPasswordPlaceholder'), 'password');
-
-    fireEvent.press(getByText('common.signIn'));
+    fillCredentials(utils);
+    fireEvent.press(utils.getByText('common.signIn'));
 
     await waitFor(() => {
       expect(switchAccountMutate).toHaveBeenCalled();
@@ -131,42 +195,207 @@ describe('AuthScreen', () => {
       pdsUrl: 'https://pds',
     });
 
-    expect(mockShowAlert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        title: 'common.success',
-        message: 'auth.signedInSuccessfully',
-      }),
-    );
+    await waitFor(() => {
+      expect(mockShowAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'common.success',
+          message: 'auth.signedInSuccessfully',
+        }),
+      );
+    });
 
-    const alertConfig = mockShowAlert.mock.calls[0][0];
+    const alertConfig = mockShowAlert.mock.calls[mockShowAlert.mock.calls.length - 1][0];
     alertConfig.buttons[0].onPress();
     expect(mockRouterReplace).toHaveBeenCalledWith('/(tabs)');
   });
 
+  it('signs in and routes to settings when adding an account', async () => {
+    mockUseCurrentAccount.mockReturnValue({ data: { did: 'did:existing' } });
+    const utils = renderScreen();
+
+    expect(utils.queryByText('auth.needDifferentAccount')).toBeNull();
+
+    fillCredentials(utils);
+    const addAccountButtons = utils.getAllByText('common.addAccount');
+    fireEvent.press(addAccountButtons[addAccountButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(mockShowAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'common.success',
+          message: 'auth.accountAddedSuccessfully',
+        }),
+      );
+    });
+
+    const alertConfig = mockShowAlert.mock.calls[mockShowAlert.mock.calls.length - 1][0];
+    alertConfig.buttons[0].onPress();
+    expect(mockRouterReplace).toHaveBeenCalledWith('/(tabs)/settings');
+  });
+
+  it('shows error when trying to sign up with empty fields', () => {
+    const utils = renderScreen();
+
+    fireEvent.press(utils.getByText('auth.connectNew'));
+    fireEvent.press(utils.getByText('auth.connectAccount'));
+
+    expect(mockShowAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'common.error',
+        message: 'auth.fillAllFields',
+      }),
+    );
+  });
+
+  it('shows error for invalid handle during sign up', () => {
+    const utils = renderScreen();
+
+    fireEvent.press(utils.getByText('auth.connectNew'));
+    fillCredentials(utils, { handle: 'invalid handle!', password: 'password' });
+    fireEvent.press(utils.getByText('auth.connectAccount'));
+
+    expect(mockShowAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'common.error',
+        message: 'auth.invalidBlueskyHandle',
+      }),
+    );
+  });
+
+  it('shows error when PDS server cannot be detected during sign up', async () => {
+    mockGetPdsUrlFromHandle.mockResolvedValueOnce(null);
+    const utils = renderScreen();
+
+    fireEvent.press(utils.getByText('auth.connectNew'));
+    fillCredentials(utils);
+    fireEvent.press(utils.getByText('auth.connectAccount'));
+
+    await waitFor(() => {
+      expect(mockShowAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'common.error',
+          message: 'Could not detect PDS server for this handle',
+        }),
+      );
+    });
+
+    expect(signInMutate).not.toHaveBeenCalled();
+  });
+
+  it('shows error when connection fails during sign up', async () => {
+    signInMutate.mockRejectedValueOnce(new Error('connect error'));
+    const utils = renderScreen();
+
+    fireEvent.press(utils.getByText('auth.connectNew'));
+    fillCredentials(utils);
+    fireEvent.press(utils.getByText('auth.connectAccount'));
+
+    await waitFor(() => {
+      expect(mockShowAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'common.error',
+          message: 'connect error',
+        }),
+      );
+    });
+  });
+
+  it('falls back to default connection error message when sign up fails without Error instance', async () => {
+    signInMutate.mockRejectedValueOnce('failed');
+    const utils = renderScreen();
+
+    fireEvent.press(utils.getByText('auth.connectNew'));
+    fillCredentials(utils);
+    fireEvent.press(utils.getByText('auth.connectAccount'));
+
+    await waitFor(() => {
+      expect(mockShowAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'common.error',
+          message: 'auth.connectionFailed',
+        }),
+      );
+    });
+  });
+
   it('signs up successfully after toggling', async () => {
-    const { getByText, getByPlaceholderText } = render(<AuthScreen />);
+    const utils = renderScreen();
 
-    fireEvent.press(getByText('auth.connectNew'));
-
-    fireEvent.changeText(getByPlaceholderText('auth.blueskyHandlePlaceholder'), 'user');
-    fireEvent.changeText(getByPlaceholderText('auth.appPasswordPlaceholder'), 'password');
-
-    fireEvent.press(getByText('auth.connectAccount'));
+    fireEvent.press(utils.getByText('auth.connectNew'));
+    fillCredentials(utils);
+    fireEvent.press(utils.getByText('auth.connectAccount'));
 
     await waitFor(() => {
       expect(switchAccountMutate).toHaveBeenCalled();
     });
 
-    expect(mockShowAlert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        title: 'common.success',
-        message: 'auth.connectedSuccessfully',
-      }),
-    );
+    await waitFor(() => {
+      expect(mockShowAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'common.success',
+          message: 'auth.connectedSuccessfully',
+        }),
+      );
+    });
 
-    const alertConfig = mockShowAlert.mock.calls[0][0];
+    const alertConfig = mockShowAlert.mock.calls[mockShowAlert.mock.calls.length - 1][0];
     alertConfig.buttons[0].onPress();
     expect(mockRouterReplace).toHaveBeenCalledWith('/(tabs)');
+  });
+
+  it('toggles between modes and clears input values', () => {
+    const utils = renderScreen();
+
+    fillCredentials(utils);
+    expect(utils.getByDisplayValue('user')).toBeTruthy();
+
+    fireEvent.press(utils.getByText('auth.connectNew'));
+
+    expect(utils.queryByDisplayValue('user')).toBeNull();
+    expect(utils.queryByDisplayValue('password')).toBeNull();
+    expect(utils.getByText('common.signIn')).toBeTruthy();
+
+    fireEvent.press(utils.getByText('common.signIn'));
+    expect(utils.getByText('auth.connectNew')).toBeTruthy();
+  });
+
+  it('shows loading state while signing in', () => {
+    mockUseSignIn.mockReturnValue({ mutateAsync: signInMutate, isPending: true });
+    const utils = renderScreen();
+
+    expect(utils.getByText('auth.signingIn')).toBeTruthy();
+  });
+
+  it('shows loading state while connecting a new account', () => {
+    mockUseSignIn.mockReturnValue({ mutateAsync: signInMutate, isPending: true });
+    const utils = renderScreen();
+
+    fireEvent.press(utils.getByText('auth.connectNew'));
+
+    expect(utils.getByText('auth.connecting')).toBeTruthy();
+  });
+
+  it('shows loading state when adding an account to existing user', () => {
+    mockUseCurrentAccount.mockReturnValue({ data: { did: 'did:existing' } });
+    mockUseSignIn.mockReturnValue({ mutateAsync: signInMutate, isPending: true });
+    const utils = renderScreen();
+
+    expect(utils.getByText('auth.addingAccount')).toBeTruthy();
+  });
+
+  it('uses height keyboard behavior on non-iOS platforms', () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(Platform, 'OS');
+
+    Object.defineProperty(Platform, 'OS', { configurable: true, value: 'android' });
+
+    try {
+      const utils = renderScreen();
+      expect(utils.UNSAFE_getByType(KeyboardAvoidingView).props.behavior).toBe('height');
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(Platform, 'OS', originalDescriptor);
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- expand the AuthScreen test suite to cover error handling, success flows, mode toggling, and platform behaviour

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68c88ebd390c832b98c3bf183eea69ef