### PR TITLE
test: add coverage for usePostThread hook

### DIFF
--- a/apps/akari/__tests__/hooks/queries/usePostThread.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/usePostThread.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { usePostThread } from '@/hooks/queries/usePostThread';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { BlueskyApi } from '@/bluesky-api';
+
+const mockGetPostThread = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPostThread: mockGetPostThread,
+  })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return { wrapper };
+};
+
+describe('usePostThread', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds' },
+    });
+  });
+
+  it('fetches a post thread', async () => {
+    const mockThread = { thread: { post: { uri: 'at://post/1' } } };
+    mockGetPostThread.mockResolvedValueOnce(mockThread);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => usePostThread('at://post/1'), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockThread);
+    });
+
+    expect(jest.mocked(BlueskyApi)).toHaveBeenCalledWith('https://pds');
+    expect(mockGetPostThread).toHaveBeenCalledWith('token', 'at://post/1');
+  });
+
+  it('returns error when pdsUrl is missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: {} });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => usePostThread('at://post/1'), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect((result.current.error as Error).message).toBe('No PDS URL available');
+    });
+
+    expect(mockGetPostThread).not.toHaveBeenCalled();
+  });
+
+  it('throws error when token is missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => usePostThread('at://post/1'), {
+      wrapper,
+    });
+
+    const fetchResult = await result.current.refetch();
+
+    expect(fetchResult.error).toBeInstanceOf(Error);
+    expect((fetchResult.error as Error).message).toBe('No access token or post URI');
+    expect(mockGetPostThread).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when post URI is missing', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => usePostThread(null), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.data).toBeUndefined();
+    });
+
+    expect(mockGetPostThread).not.toHaveBeenCalled();
+
+    const fetchResult = await result.current.refetch();
+    expect(fetchResult.error).toBeInstanceOf(Error);
+    expect((fetchResult.error as Error).message).toBe('No access token or post URI');
+  });
+});


### PR DESCRIPTION
## Summary
- add a focused test suite for the usePostThread hook covering success and error branches
- ensure the hook instantiates BlueskyApi with the active account and blocks execution without required inputs

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68c892d68bac832bbb20a1dfdadc4eb6