### PR TITLE
test: cover dev utils logging

### DIFF
--- a/apps/akari/__tests__/utils/devUtils.test.ts
+++ b/apps/akari/__tests__/utils/devUtils.test.ts
@@ -1,6 +1,18 @@
 describe('devUtils', () => {
+  let originalDev: boolean | undefined;
+
+  beforeEach(() => {
+    originalDev = (global as any).__DEV__;
+  });
+
   afterEach(() => {
     jest.resetModules();
+    jest.restoreAllMocks();
+    if (typeof originalDev === 'undefined') {
+      delete (global as any).__DEV__;
+    } else {
+      (global as any).__DEV__ = originalDev;
+    }
   });
 
   it('logs translation stats in development', () => {
@@ -23,5 +35,21 @@ describe('devUtils', () => {
     const result = logTranslationStats();
     expect(result).toBeNull();
     expect(logSpy).toHaveBeenCalledWith('Translation checking is only available in development mode.');
+  });
+
+  it('logs available translations in development', () => {
+    (global as any).__DEV__ = true;
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const { logAvailableTranslations } = require('@/utils/devUtils');
+    logAvailableTranslations();
+    expect(logSpy).toHaveBeenCalledWith('🔍 To see all available translation keys, check utils/i18n.ts');
+  });
+
+  it('does not log available translations outside development', () => {
+    (global as any).__DEV__ = false;
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const { logAvailableTranslations } = require('@/utils/devUtils');
+    logAvailableTranslations();
+    expect(logSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add coverage for dev utils logging helpers in both dev and non-dev modes
- restore global __DEV__ value after each test to avoid cross-test leakage

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68c898caa870832b85217238a4bcbc55