### PR TITLE
test: cover alert fallback case

### DIFF
--- a/apps/akari/__tests__/app/tabs/messages-handle.test.tsx
+++ b/apps/akari/__tests__/app/tabs/messages-handle.test.tsx
@@ -158,7 +158,7 @@ describe('ConversationScreen', () => {
     });
     expect(mutateAsync).toHaveBeenCalledWith({ convoId: '1', text: 'hello' });
     expect(getByPlaceholderText('messages.typeMessage').props.value).toBe('');
-  });
+  }, 10000);
 
   it('shows alert when sending fails', async () => {
     const conversation = { handle: 'alice', convoId: '1' };

--- a/apps/akari/__tests__/utils/alert.test.ts
+++ b/apps/akari/__tests__/utils/alert.test.ts
@@ -45,6 +45,20 @@ describe('alert utilities', () => {
     expect(onConfirm).not.toHaveBeenCalled();
   });
 
+  it('falls back to title when message is missing and no buttons supplied', () => {
+    jest.doMock('react-native', () => ({
+      Platform: { OS: 'web' },
+      Alert: { alert: jest.fn() },
+    }));
+    const confirmMock = jest.fn(() => true);
+    window.confirm = confirmMock;
+    const module = require('@/utils/alert');
+
+    module.showAlert({ title: 'Title Only' });
+
+    expect(confirmMock).toHaveBeenCalledWith('Title Only');
+  });
+
   it('calls Alert.alert on native platforms', () => {
     const alertMock = jest.fn();
     jest.doMock('react-native', () => ({


### PR DESCRIPTION
## Summary
- add coverage for `showAlert` when invoked without a message or buttons
- relax the messages handle test timeout so coverage runs pass reliably

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68c898dae588832b81b3c63bc025c0fd