### PR TITLE
test: cover default useConversations configuration

### DIFF
--- a/apps/akari/__tests__/hooks/queries/useConversations.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useConversations.test.tsx
@@ -142,6 +142,18 @@ describe('useConversations', () => {
     expect(options.getNextPageParam({ cursor: 'next' })).toBe('next');
   });
 
+  it('uses default configuration values when parameters are omitted', async () => {
+    mockListConversations.mockResolvedValue({ cursor: undefined, convos: [] });
+
+    const options = renderUseConversations();
+
+    await options.queryFn({ pageParam: undefined });
+
+    expect(mockListConversations).toHaveBeenCalledWith('token', 50, undefined, undefined, undefined);
+    expect(options.queryKey).toEqual(['conversations', 50, undefined, undefined, 'did:me']);
+    expect(options.enabled).toBe(true);
+  });
+
   it('passes filters and cursor to the API', async () => {
     mockListConversations.mockResolvedValue({ cursor: 'cursor-2', convos: [] });
 


### PR DESCRIPTION
## Summary
- ensure useConversations exercises default pagination parameters by omitting optional arguments in a new test

## Testing
- npm run test --workspace=apps/akari -- --runTestsByPath __tests__/hooks/queries/useConversations.test.tsx --coverage
- npm run test:coverage *(fails: ConversationScreen sends message test exceeded default timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68c89921844c832b9d465ab9beea4a67