### PR TITLE
test: expand useMessages coverage

### DIFF
--- a/apps/akari/__tests__/hooks/queries/useMessages.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useMessages.test.tsx
@@ -8,6 +8,32 @@ import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 
 const mockGetMessages = jest.fn();
 
+jest.mock('@tanstack/react-query', () => {
+  const actual = jest.requireActual('@tanstack/react-query');
+  let lastOptions: unknown;
+
+  return {
+    ...actual,
+    useInfiniteQuery: (options: unknown) => {
+      lastOptions = options;
+      return actual.useInfiniteQuery(options as never);
+    },
+    __getLastInfiniteQueryOptions: () => lastOptions,
+    __resetLastInfiniteQueryOptions: () => {
+      lastOptions = undefined;
+    },
+  };
+});
+
+const { __getLastInfiniteQueryOptions, __resetLastInfiniteQueryOptions } =
+  jest.requireMock('@tanstack/react-query') as typeof import('@tanstack/react-query') & {
+    __getLastInfiniteQueryOptions: () => unknown;
+    __resetLastInfiniteQueryOptions: () => void;
+  };
+
+const getLastInfiniteQueryOptions = () => __getLastInfiniteQueryOptions();
+const resetLastInfiniteQueryOptions = () => __resetLastInfiniteQueryOptions();
+
 jest.mock('@/hooks/queries/useJwtToken', () => ({
   useJwtToken: jest.fn(),
 }));
@@ -35,6 +61,7 @@ describe('useMessages', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    resetLastInfiniteQueryOptions();
     (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
     (useCurrentAccount as jest.Mock).mockReturnValue({
       data: { did: 'did:me', pdsUrl: 'https://pds' },
@@ -83,6 +110,49 @@ describe('useMessages', () => {
     });
   });
 
+  it('uses default limit and handles messages without text', async () => {
+    mockGetMessages.mockResolvedValueOnce({
+      messages: [
+        {
+          id: '2',
+          text: undefined,
+          sentAt: '2023-01-01T01:00:00Z',
+          sender: { did: 'did:me' },
+        },
+      ],
+      cursor: null,
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMessages('convo'), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockGetMessages).toHaveBeenCalledWith('token', 'convo', 50, undefined);
+
+    const timestamp = new Date('2023-01-01T01:00:00Z').toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+
+    expect(result.current.data?.pages[0]).toEqual({
+      messages: [
+        {
+          id: '2',
+          text: '',
+          timestamp,
+          isFromMe: true,
+          sentAt: '2023-01-01T01:00:00Z',
+        },
+      ],
+      cursor: null,
+    });
+  });
+
   it('returns permission error when API responds 401', async () => {
     mockGetMessages.mockRejectedValueOnce({ response: { status: 401 } });
 
@@ -121,12 +191,135 @@ describe('useMessages', () => {
     });
   });
 
+  it('returns permission error when API responds 403', async () => {
+    mockGetMessages.mockRejectedValueOnce({ response: { status: 403 } });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMessages('convo', 10), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mockGetMessages).toHaveBeenCalledTimes(1);
+    expect(result.current.error).toEqual({
+      type: 'permission',
+      message: 'Access to messages is not allowed with this app password',
+    });
+  });
+
+  it('returns permission error when app password lacks chat scope', async () => {
+    mockGetMessages.mockRejectedValueOnce({ message: 'Bad token scope: chat' });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMessages('convo', 10), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mockGetMessages).toHaveBeenCalledTimes(1);
+    expect(result.current.error).toEqual({
+      type: 'permission',
+      message:
+        "Your app password doesn't have chat permissions. Please create a new app password with chat access in your Bluesky settings.",
+    });
+  });
+
+  it('returns server error message for 5xx responses', async () => {
+    mockGetMessages.mockRejectedValue({ response: { status: 503 } });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMessages('convo', 10), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mockGetMessages).toHaveBeenCalledTimes(4);
+    expect(result.current.error).toEqual({
+      type: 'network',
+      message: 'Server error. Please try again later',
+    });
+  });
+
+  it('returns unknown error for unexpected status codes', async () => {
+    mockGetMessages.mockRejectedValue({ response: { status: 404 } });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMessages('convo', 10), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mockGetMessages).toHaveBeenCalledTimes(4);
+    expect(result.current.error).toEqual({
+      type: 'unknown',
+      message: 'Failed to load messages',
+    });
+  });
+
   it('does not run query when token is missing', () => {
     (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
 
     const { wrapper } = createWrapper();
     renderHook(() => useMessages('convo', 10), { wrapper });
 
+    expect(mockGetMessages).not.toHaveBeenCalled();
+  });
+
+  it('throws when refetching without a token', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+
+    const { wrapper } = createWrapper();
+    renderHook(() => useMessages('convo', 10), { wrapper });
+
+    const options = getLastInfiniteQueryOptions() as {
+      queryFn: ({ pageParam }: { pageParam?: string }) => Promise<unknown>;
+    };
+
+    await expect(options.queryFn({ pageParam: undefined })).rejects.toThrow('No access token');
+    expect(mockGetMessages).not.toHaveBeenCalled();
+  });
+
+  it('throws when refetching without a conversation id', async () => {
+    const { wrapper } = createWrapper();
+    renderHook(() => useMessages(undefined, 10), {
+      wrapper,
+    });
+
+    const options = getLastInfiniteQueryOptions() as {
+      queryFn: ({ pageParam }: { pageParam?: string }) => Promise<unknown>;
+    };
+
+    await expect(options.queryFn({ pageParam: undefined })).rejects.toThrow(
+      'No conversation ID provided',
+    );
+    expect(mockGetMessages).not.toHaveBeenCalled();
+  });
+
+  it('throws when refetching without a PDS url', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did:me' },
+    });
+
+    const { wrapper } = createWrapper();
+    renderHook(() => useMessages('convo', 10), { wrapper });
+
+    const options = getLastInfiniteQueryOptions() as {
+      queryFn: ({ pageParam }: { pageParam?: string }) => Promise<unknown>;
+    };
+
+    await expect(options.queryFn({ pageParam: undefined })).rejects.toThrow('No PDS URL available');
     expect(mockGetMessages).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- wrap `useInfiniteQuery` in the hook test to capture query options and exercise guard branches
- cover default limit handling along with additional permission and network error scenarios for `useMessages`

## Testing
- npm run test -- --coverage --collectCoverageFrom=hooks/queries/useMessages.ts --testPathPattern=__tests__/hooks/queries/useMessages.test.tsx
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68c899178a0c832b83fe217bf4425aea