### PR TITLE
test: cover useNotifications edge cases

### DIFF
--- a/apps/akari/__tests__/hooks/queries/useNotifications.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useNotifications.test.tsx
@@ -25,12 +25,12 @@ jest.mock('@/bluesky-api', () => ({
 describe('useNotifications', () => {
   const createWrapper = () => {
     const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
+      defaultOptions: { queries: { retry: false, retryDelay: 0 } },
     });
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
-    return { wrapper };
+    return { wrapper, queryClient };
   };
 
   beforeEach(() => {
@@ -83,6 +83,19 @@ describe('useNotifications', () => {
             reason: 'mention',
             isRead: false,
             indexedAt: '2023-01-01T00:00:00Z',
+            record: undefined,
+          },
+          {
+            uri: 'notif3',
+            author: {
+              did: 'did:carol',
+              handle: 'carol',
+              displayName: 'Carol',
+              avatar: 'carol.jpg',
+            },
+            reason: 'like',
+            isRead: true,
+            indexedAt: '2023-01-02T00:00:00Z',
             record: {},
           },
         ],
@@ -144,6 +157,104 @@ describe('useNotifications', () => {
       type: 'permission',
       message: 'Authentication failed. Please sign in again.',
     });
+  });
+
+  it.each([
+    [
+      '403 permission error',
+      { response: { status: 403 } },
+      {
+        type: 'permission',
+        message: 'Access to notifications is not allowed',
+      },
+    ],
+    [
+      'network error by message',
+      new Error('network request failed'),
+      {
+        type: 'network',
+        message: 'Network error. Please check your connection and try again',
+      },
+    ],
+    [
+      'network error by code',
+      { code: 'NETWORK_ERROR' },
+      {
+        type: 'network',
+        message: 'Network error. Please check your connection and try again',
+      },
+    ],
+    [
+      'server error',
+      { response: { status: 503 } },
+      {
+        type: 'network',
+        message: 'Server error. Please try again later',
+      },
+    ],
+    [
+      'unknown error type',
+      { message: 'unhandled failure' },
+      {
+        type: 'unknown',
+        message: 'Failed to load notifications',
+      },
+    ],
+  ])('handles %s responses', async (_title, error, expectedError) => {
+    mockListNotifications.mockRejectedValue(error);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useNotifications(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toEqual(expectedError);
+  });
+
+  it('throws error when fetching without access token', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+
+    const { wrapper, queryClient } = createWrapper();
+    const { unmount } = renderHook(() => useNotifications(), { wrapper });
+
+    const query = queryClient.getQueryCache().find({
+      queryKey: ['notifications', 50, undefined, undefined, 'did:me'],
+    });
+    expect(query).toBeDefined();
+    await expect(query!.options.queryFn?.({ pageParam: undefined })).rejects.toThrow(
+      'No access token',
+    );
+
+    unmount();
+    queryClient.clear();
+  });
+
+  it('throws error when PDS URL is unavailable', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did:me' },
+    });
+
+    const { wrapper, queryClient } = createWrapper();
+    const { unmount } = renderHook(() => useNotifications(50, undefined, undefined, false), {
+      wrapper,
+    });
+
+    const query = queryClient.getQueryCache().find({
+      queryKey: ['notifications', 50, undefined, undefined, 'did:me'],
+    });
+    expect(query).toBeDefined();
+    await expect(query!.options.queryFn?.({ pageParam: undefined })).rejects.toThrow(
+      'No PDS URL available',
+    );
+    expect(mockListNotifications).not.toHaveBeenCalled();
+
+    unmount();
+    queryClient.clear();
   });
 
   it('does not run query without token', () => {


### PR DESCRIPTION
## Summary
- expand the useNotifications pagination fixture to include record-less notifications
- add matrixed assertions for permission, server, and network error branches
- invoke the query function directly to verify guards for missing tokens and PDS URLs

## Testing
- npm run test -- --runTestsByPath __tests__/hooks/queries/useNotifications.test.tsx
- npm run test:coverage *(fails: existing timeout in __tests__/app/tabs/messages-handle.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c899100ff8832b834e841a9073ddcc