### PR TITLE
test: ensure usePushNotifications hook coverage

### DIFF
--- a/apps/akari/__tests__/hooks/usePushNotifications.test.ts
+++ b/apps/akari/__tests__/hooks/usePushNotifications.test.ts
@@ -42,12 +42,32 @@ const mockSetBadgeCountAsync = Notifications.setBadgeCountAsync as jest.Mock;
 
 const originalOS = Platform.OS;
 
+const createNotificationResponse = (data: Record<string, unknown>) =>
+  ({
+    notification: {
+      request: {
+        content: {
+          data,
+        },
+      },
+    },
+  } as unknown as Notifications.NotificationResponse);
+
+const renderPushNotificationsHook = async () => {
+  const rendered = renderHook(() => usePushNotifications());
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return rendered;
+};
+
 describe('usePushNotifications', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseRouter.mockReturnValue({ push: jest.fn() });
     mockAddNotificationReceivedListener.mockReturnValue({ remove: jest.fn() });
     mockAddNotificationResponseReceivedListener.mockReturnValue({ remove: jest.fn() });
+    mockGetPermissionsAsync.mockResolvedValue({ status: 'undetermined' });
     Object.defineProperty(Platform, 'OS', { value: 'android' });
   });
 
@@ -56,7 +76,7 @@ describe('usePushNotifications', () => {
   });
 
   it('initializes notification channels on Android', async () => {
-    renderHook(() => usePushNotifications());
+    await renderPushNotificationsHook();
 
     await waitFor(() => {
       expect(mockCreateNotificationChannels).toHaveBeenCalledWith(
@@ -65,10 +85,35 @@ describe('usePushNotifications', () => {
     });
   });
 
+  it('does not initialize notification channels on non-Android platforms', async () => {
+    Object.defineProperty(Platform, 'OS', { value: 'ios' });
+
+    await renderPushNotificationsHook();
+
+    expect(mockCreateNotificationChannels).not.toHaveBeenCalled();
+  });
+
+  it('logs an error if creating notification channels fails', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const failure = new Error('channels failed');
+    mockCreateNotificationChannels.mockRejectedValueOnce(failure);
+
+    await renderPushNotificationsHook();
+
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to create notification channels:',
+        failure,
+      );
+    });
+
+    consoleSpy.mockRestore();
+  });
+
   it('requests permissions successfully', async () => {
     mockRequestNotificationPermissions.mockResolvedValue('granted');
 
-    const { result } = renderHook(() => usePushNotifications());
+    const { result } = await renderPushNotificationsHook();
 
     let success: boolean | undefined;
     await act(async () => {
@@ -84,7 +129,7 @@ describe('usePushNotifications', () => {
   it('handles request permission errors', async () => {
     mockRequestNotificationPermissions.mockRejectedValue(new Error('fail'));
 
-    const { result } = renderHook(() => usePushNotifications());
+    const { result } = await renderPushNotificationsHook();
 
     let success: boolean | undefined;
     await act(async () => {
@@ -96,13 +141,41 @@ describe('usePushNotifications', () => {
     expect(result.current.isLoading).toBe(false);
   });
 
+  it('returns false when permissions are not granted', async () => {
+    mockRequestNotificationPermissions.mockResolvedValue('denied');
+
+    const { result } = await renderPushNotificationsHook();
+
+    let success: boolean | undefined;
+    await act(async () => {
+      success = await result.current.requestPermissions();
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.permissionStatus).toBe('denied');
+  });
+
+  it('handles non-Error permission rejections', async () => {
+    mockRequestNotificationPermissions.mockRejectedValue('nope');
+
+    const { result } = await renderPushNotificationsHook();
+
+    let success: boolean | undefined;
+    await act(async () => {
+      success = await result.current.requestPermissions();
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.error).toBe('Failed to request permissions');
+  });
+
   it('registers for push notifications successfully', async () => {
     mockRegisterForPushNotifications.mockResolvedValue({
       expoPushToken: 'expo-token',
       devicePushToken: 'device-token',
     });
 
-    const { result } = renderHook(() => usePushNotifications());
+    const { result } = await renderPushNotificationsHook();
 
     let success: boolean | undefined;
     await act(async () => {
@@ -118,7 +191,7 @@ describe('usePushNotifications', () => {
   it('handles failed registration', async () => {
     mockRegisterForPushNotifications.mockResolvedValue(null);
 
-    const { result } = renderHook(() => usePushNotifications());
+    const { result } = await renderPushNotificationsHook();
 
     let success: boolean | undefined;
     await act(async () => {
@@ -132,7 +205,7 @@ describe('usePushNotifications', () => {
   it('handles registration errors', async () => {
     mockRegisterForPushNotifications.mockRejectedValue(new Error('boom'));
 
-    const { result } = renderHook(() => usePushNotifications());
+    const { result } = await renderPushNotificationsHook();
 
     let success: boolean | undefined;
     await act(async () => {
@@ -143,13 +216,39 @@ describe('usePushNotifications', () => {
     expect(result.current.error).toBe('boom');
   });
 
+  it('sets a null device token when not provided', async () => {
+    mockRegisterForPushNotifications.mockResolvedValue({
+      expoPushToken: 'expo-token',
+    });
+
+    const { result } = await renderPushNotificationsHook();
+
+    await act(async () => {
+      await result.current.register();
+    });
+
+    expect(result.current.devicePushToken).toBeNull();
+  });
+
+  it('handles registration errors with non-Error values', async () => {
+    mockRegisterForPushNotifications.mockRejectedValue('kaboom');
+
+    const { result } = await renderPushNotificationsHook();
+
+    await act(async () => {
+      await result.current.register();
+    });
+
+    expect(result.current.error).toBe('Failed to register for push notifications');
+  });
+
   it('initializes push notifications when permissions are granted', async () => {
     mockRequestNotificationPermissions.mockResolvedValue('granted');
     mockRegisterForPushNotifications.mockResolvedValue({
       expoPushToken: 'expo-token',
     });
 
-    const { result } = renderHook(() => usePushNotifications());
+    const { result } = await renderPushNotificationsHook();
 
     let success: boolean | undefined;
     await act(async () => {
@@ -164,7 +263,7 @@ describe('usePushNotifications', () => {
   it('does not register when permissions are denied', async () => {
     mockRequestNotificationPermissions.mockResolvedValue('denied');
 
-    const { result } = renderHook(() => usePushNotifications());
+    const { result } = await renderPushNotificationsHook();
 
     let success: boolean | undefined;
     await act(async () => {
@@ -175,10 +274,154 @@ describe('usePushNotifications', () => {
     expect(mockRegisterForPushNotifications).not.toHaveBeenCalled();
   });
 
+  it('returns false when initialization fails during registration', async () => {
+    mockRequestNotificationPermissions.mockResolvedValue('granted');
+    mockRegisterForPushNotifications.mockResolvedValue(null);
+
+    const { result } = await renderPushNotificationsHook();
+
+    let success: boolean | undefined;
+    await act(async () => {
+      success = await result.current.initialize();
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.error).toBe('Failed to register for push notifications');
+  });
+
+  it('sets up notification listeners and cleans them up on unmount', async () => {
+    const removeNotification = jest.fn();
+    const removeResponse = jest.fn();
+    let notificationHandler: (notification: Notifications.Notification) => void = () => {};
+    let responseHandler: (response: Notifications.NotificationResponse) => void = () => {};
+
+    mockAddNotificationReceivedListener.mockImplementation((handler) => {
+      notificationHandler = handler;
+      return { remove: removeNotification };
+    });
+    mockAddNotificationResponseReceivedListener.mockImplementation((handler) => {
+      responseHandler = handler;
+      return { remove: removeResponse };
+    });
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { unmount } = await renderPushNotificationsHook();
+
+    await waitFor(() => {
+      expect(mockAddNotificationReceivedListener).toHaveBeenCalled();
+      expect(mockAddNotificationResponseReceivedListener).toHaveBeenCalled();
+    });
+
+    act(() => {
+      notificationHandler({} as Notifications.Notification);
+      responseHandler(createNotificationResponse({}));
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith('Notification received:', expect.any(Object));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Notification response:',
+      expect.objectContaining({ notification: expect.any(Object) }),
+    );
+
+    unmount();
+
+    expect(removeNotification).toHaveBeenCalled();
+    expect(removeResponse).toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+
+  it('cleans up safely when listeners are not registered', async () => {
+    mockAddNotificationReceivedListener.mockImplementation(() => null);
+    mockAddNotificationResponseReceivedListener.mockImplementation(() => null);
+
+    const { unmount } = await renderPushNotificationsHook();
+
+    expect(() => {
+      unmount();
+    }).not.toThrow();
+  });
+
+  it('navigates to the correct route based on notification type', async () => {
+    const push = jest.fn();
+    mockUseRouter.mockReturnValue({ push });
+
+    let responseHandler: (response: Notifications.NotificationResponse) => void = () => {};
+    mockAddNotificationResponseReceivedListener.mockImplementation((handler) => {
+      responseHandler = handler;
+      return { remove: jest.fn() };
+    });
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await renderPushNotificationsHook();
+
+    await waitFor(() => {
+      expect(mockAddNotificationResponseReceivedListener).toHaveBeenCalled();
+    });
+
+    const scenarios = [
+      { type: 'post', id: 'abc def', expected: '/post/abc%20def' },
+      { type: 'profile', id: 'user', expected: '/profile/user' },
+      { type: 'conversation', id: '42', expected: '/messages/42' },
+      { type: 'notification', id: 'any', expected: '/notifications' },
+      { type: 'unknown', id: '??', expected: '/notifications' },
+    ];
+
+    for (const scenario of scenarios) {
+      act(() => {
+        responseHandler(
+          createNotificationResponse({
+            type: scenario.type,
+            id: scenario.id,
+          }),
+        );
+      });
+
+      expect(push).toHaveBeenLastCalledWith(scenario.expected);
+    }
+
+    consoleSpy.mockRestore();
+  });
+
+  it('ignores notification responses without both type and id', async () => {
+    const push = jest.fn();
+    mockUseRouter.mockReturnValue({ push });
+
+    let responseHandler: (response: Notifications.NotificationResponse) => void = () => {};
+    mockAddNotificationResponseReceivedListener.mockImplementation((handler) => {
+      responseHandler = handler;
+      return { remove: jest.fn() };
+    });
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await renderPushNotificationsHook();
+
+    await waitFor(() => {
+      expect(mockAddNotificationResponseReceivedListener).toHaveBeenCalled();
+    });
+
+    act(() => {
+      responseHandler(createNotificationResponse({ type: 'post' }));
+    });
+
+    expect(push).not.toHaveBeenCalled();
+
+    act(() => {
+      responseHandler(createNotificationResponse({ id: '123' }));
+    });
+
+    expect(push).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+
   it('checks permission status', async () => {
     mockGetPermissionsAsync.mockResolvedValue({ status: 'denied' });
 
-    const { result } = renderHook(() => usePushNotifications());
+    const { result } = await renderPushNotificationsHook();
 
     await act(async () => {
       await result.current.checkPermissionStatus();
@@ -187,10 +430,28 @@ describe('usePushNotifications', () => {
     expect(result.current.permissionStatus).toBe('denied');
   });
 
+  it('handles permission status errors', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const failure = new Error('status failed');
+    mockGetPermissionsAsync.mockRejectedValue(failure);
+
+    const { result } = await renderPushNotificationsHook();
+
+    await act(async () => {
+      await result.current.checkPermissionStatus();
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to check permission status:',
+      failure,
+    );
+    consoleSpy.mockRestore();
+  });
+
   it('returns badge count', async () => {
     mockGetBadgeCountAsync.mockResolvedValue(3);
 
-    const { result } = renderHook(() => usePushNotifications());
+    const { result } = await renderPushNotificationsHook();
 
     let count = 0;
     await act(async () => {
@@ -204,7 +465,7 @@ describe('usePushNotifications', () => {
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     mockGetBadgeCountAsync.mockRejectedValue(new Error('fail'));
 
-    const { result } = renderHook(() => usePushNotifications());
+    const { result } = await renderPushNotificationsHook();
 
     let count = 0;
     await act(async () => {
@@ -219,7 +480,7 @@ describe('usePushNotifications', () => {
   it('sets badge count', async () => {
     mockSetBadgeCountAsync.mockResolvedValue(undefined);
 
-    const { result } = renderHook(() => usePushNotifications());
+    const { result } = await renderPushNotificationsHook();
 
     await act(async () => {
       await result.current.setBadgeCount(5);
@@ -232,7 +493,7 @@ describe('usePushNotifications', () => {
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     mockSetBadgeCountAsync.mockRejectedValue(new Error('fail'));
 
-    const { result } = renderHook(() => usePushNotifications());
+    const { result } = await renderPushNotificationsHook();
 
     await act(async () => {
       await result.current.setBadgeCount(5);
@@ -242,10 +503,27 @@ describe('usePushNotifications', () => {
     consoleSpy.mockRestore();
   });
 
+  it('handles clear badge errors', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockSetBadgeCountAsync.mockRejectedValue(new Error('clear failed'));
+
+    const { result } = await renderPushNotificationsHook();
+
+    await act(async () => {
+      await result.current.clearBadge();
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to clear badge:',
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
+  });
+
   it('clears badge', async () => {
     mockSetBadgeCountAsync.mockResolvedValue(undefined);
 
-    const { result } = renderHook(() => usePushNotifications());
+    const { result } = await renderPushNotificationsHook();
 
     await act(async () => {
       await result.current.clearBadge();


### PR DESCRIPTION
## Summary
- add a shared helper to render the push notification hook and seed default permission mocks for deterministic tests
- cover all permission, registration, initialization, and badge flows including non-Error rejections and missing device tokens
- verify listener cleanup, navigation routing, and missing-listener fallbacks to reach 100% coverage for the hook

## Testing
- npm run test -- --testPathPattern=usePushNotifications.test.ts
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68c89bda6ca0832b8ead2cbd83eb5f6f