### PR TITLE
chore(workflow): add ci task for checking i18n files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,78 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - name: Validate translations
+        id: validate_translations
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          npm run validate-translations --workspace=akari | tee translation-validation.txt
+      - name: Comment translation validation results
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          VALIDATION_OUTCOME: ${{ steps.validate_translations.outcome }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require('fs');
+
+            const marker = '<!-- translation-validation -->';
+            const heading = '### Translation validation';
+            const outcome = process.env.VALIDATION_OUTCOME === 'success' ? 'success' : 'failure';
+
+            let output = '(no output captured)';
+            if (fs.existsSync('translation-validation.txt')) {
+              const raw = fs.readFileSync('translation-validation.txt', 'utf8').trim();
+              if (raw) {
+                output = raw.replace(/\r\n/g, '\n');
+              }
+            }
+
+            const summary =
+              outcome === 'success'
+                ? '✅ Translation validation passed'
+                : '❌ Translation validation failed';
+
+            const body = `${marker}\n${heading}\n\n<details><summary>${summary}</summary>\n\n\`\`\`\n${output}\n\`\`\`\n</details>`;
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+            });
+
+            const existing = comments.find((comment) =>
+              comment.body && comment.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+      - name: Fail if translation validation failed
+        if: steps.validate_translations.outcome == 'failure'
+        run: exit 1
       - run: npm run test:coverage --workspaces --if-present
+        if: steps.validate_translations.outcome == 'success'
       - name: Merge coverage reports
+        if: steps.validate_translations.outcome == 'success'
         run: node ./scripts/merge-coverage.cjs
       - name: Report coverage
+        if: steps.validate_translations.outcome == 'success'
         uses: vebr/jest-lcov-reporter@v0.2.0
         with:
           github-token: ${{ github.token }}

--- a/apps/akari/translations/ar.json
+++ b/apps/akari/translations/ar.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "أخبرنا عن نفسك",
       "noBanner": "لا يوجد شعار",
       "profileUpdated": "تم تحديث الملف الشخصي بنجاح",
-      "profileUpdateError": "فشل في تحديث الملف الشخصي"
+      "profileUpdateError": "فشل في تحديث الملف الشخصي",
+      "handleHistory": "سجل المعرف",
+      "noHandleHistory": "لا يوجد سجل للمعرف",
+      "noHandleHistoryDescription": "لم يغيّر هذا المستخدم معرفه بعد."
     },
     "feed": {
       "loadingMorePosts": "جاري تحميل المزيد من المنشورات...",
@@ -221,7 +224,10 @@
       "posting": "جاري النشر...",
       "replyingTo": "الرد على",
       "replyPlaceholder": "اكتب ردك...",
-      "postPlaceholder": "ماذا يحدث؟"
+      "postPlaceholder": "ماذا يحدث؟",
+      "addPhoto": "إضافة صورة",
+      "selectPhoto": "اختر صورة من المعرض",
+      "imageAltTextPlaceholder": "صف هذه الصورة لإمكانية الوصول..."
     },
     "messages": {
       "typeMessage": "اكتب رسالة...",

--- a/apps/akari/translations/cy.json
+++ b/apps/akari/translations/cy.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "Dywedwch wrthym amdanoch chi",
       "noBanner": "Dim Baner",
       "profileUpdated": "Proffil wedi ei ddiweddaru yn llwyddiannus",
-      "profileUpdateError": "Methu diweddaru proffil"
+      "profileUpdateError": "Methu diweddaru proffil",
+      "handleHistory": "Hanes handlen",
+      "noHandleHistory": "Dim hanes handlen",
+      "noHandleHistoryDescription": "Nid yw'r defnyddiwr hwn wedi newid ei handlen eto."
     },
     "feed": {
       "loadingMorePosts": "Wrth lwytho mwy o bostiadau...",
@@ -221,7 +224,10 @@
       "posting": "Postio...",
       "replyingTo": "Ateb i",
       "replyPlaceholder": "Ysgrifennwch eich ateb...",
-      "postPlaceholder": "Beth sy'n digwydd?"
+      "postPlaceholder": "Beth sy'n digwydd?",
+      "addPhoto": "Ychwanegu llun",
+      "selectPhoto": "Dewis llun o'r oriel",
+      "imageAltTextPlaceholder": "Disgrifiwch y ddelwedd hon ar gyfer hygyrchedd..."
     },
     "messages": {
       "typeMessage": "Teipiwch neges...",

--- a/apps/akari/translations/de.json
+++ b/apps/akari/translations/de.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "Erzählen Sie uns von sich",
       "noBanner": "Kein Banner",
       "profileUpdated": "Profil erfolgreich aktualisiert",
-      "profileUpdateError": "Profil konnte nicht aktualisiert werden"
+      "profileUpdateError": "Profil konnte nicht aktualisiert werden",
+      "handleHistory": "Handle-Verlauf",
+      "noHandleHistory": "Kein Handle-Verlauf",
+      "noHandleHistoryDescription": "Dieser Nutzer hat sein Handle noch nicht geändert."
     },
     "feed": {
       "loadingMorePosts": "Lade weitere Beiträge...",
@@ -221,7 +224,10 @@
       "posting": "Beitrag wird veröffentlicht...",
       "replyingTo": "Antworten auf",
       "replyPlaceholder": "Schreiben Sie Ihre Antwort...",
-      "postPlaceholder": "Was passiert?"
+      "postPlaceholder": "Was passiert?",
+      "addPhoto": "Foto hinzufügen",
+      "selectPhoto": "Foto aus der Galerie auswählen",
+      "imageAltTextPlaceholder": "Beschreiben Sie dieses Bild für die Barrierefreiheit..."
     },
     "messages": {
       "typeMessage": "Nachricht eingeben...",

--- a/apps/akari/translations/en-US.json
+++ b/apps/akari/translations/en-US.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "Tell us about yourself",
       "noBanner": "No Banner",
       "profileUpdated": "Profile updated successfully",
-      "profileUpdateError": "Failed to update profile"
+      "profileUpdateError": "Failed to update profile",
+      "handleHistory": "Handle History",
+      "noHandleHistory": "No handle history",
+      "noHandleHistoryDescription": "This user hasn't changed their handle yet."
     },
     "feed": {
       "loadingMorePosts": "Loading more posts...",
@@ -221,10 +224,14 @@
       "posting": "Posting...",
       "replyingTo": "Replying to",
       "replyPlaceholder": "Write your reply...",
-      "postPlaceholder": "What's happening?"
+      "postPlaceholder": "What's happening?",
+      "addPhoto": "Add photo",
+      "selectPhoto": "Select photo from gallery",
+      "imageAltTextPlaceholder": "Describe this image for accessibility..."
     },
     "messages": {
-      "typeMessage": "Type a message..."
+      "typeMessage": "Type a message...",
+      "errorSendingMessage": "Failed to send message. Please try again."
     },
     "settings": {
       "account": "Account",
@@ -234,6 +241,16 @@
       "checkMissingTranslations": "🔍 Check Missing Translations",
       "developmentTool": "Development tool",
       "notifications": "Notifications"
+    },
+    "gif": {
+      "selectGif": "Select GIF",
+      "searchPlaceholder": "Search GIFs...",
+      "loadingMore": "Loading more...",
+      "noResults": "No GIFs found",
+      "noTrending": "No trending GIFs available",
+      "addGif": "Add GIF",
+      "gifAltTextPlaceholder": "Describe this GIF for accessibility...",
+      "apiError": "Unable to load GIFs. Please check your internet connection."
     }
   }
 }

--- a/apps/akari/translations/es.json
+++ b/apps/akari/translations/es.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "Cuéntanos sobre ti",
       "noBanner": "Sin banner",
       "profileUpdated": "Perfil actualizado exitosamente",
-      "profileUpdateError": "Error al actualizar perfil"
+      "profileUpdateError": "Error al actualizar perfil",
+      "handleHistory": "Historial del identificador",
+      "noHandleHistory": "Sin historial de identificador",
+      "noHandleHistoryDescription": "Este usuario aún no ha cambiado su identificador."
     },
     "feed": {
       "loadingMorePosts": "Cargando más publicaciones...",
@@ -222,7 +225,9 @@
       "replyingTo": "Respondiendo a",
       "replyPlaceholder": "Escribe tu respuesta...",
       "postPlaceholder": "¿Qué está pasando?",
-      "imageAltTextPlaceholder": "Describe esta imagen para accesibilidad..."
+      "imageAltTextPlaceholder": "Describe esta imagen para la accesibilidad...",
+      "addPhoto": "Agregar foto",
+      "selectPhoto": "Seleccionar foto de la galería"
     },
     "gif": {
       "selectGif": "Seleccionar GIF",

--- a/apps/akari/translations/fr.json
+++ b/apps/akari/translations/fr.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "Parlez-nous de vous",
       "noBanner": "Pas de bannière",
       "profileUpdated": "Profil mis à jour avec succès",
-      "profileUpdateError": "Échec de la mise à jour du profil"
+      "profileUpdateError": "Échec de la mise à jour du profil",
+      "handleHistory": "Historique du handle",
+      "noHandleHistory": "Aucun historique de handle",
+      "noHandleHistoryDescription": "Cet utilisateur n'a pas encore changé de handle."
     },
     "feed": {
       "loadingMorePosts": "Chargement de plus de publications...",
@@ -222,7 +225,9 @@
       "replyingTo": "Répondre à",
       "replyPlaceholder": "Écrivez votre réponse...",
       "postPlaceholder": "Que se passe-t-il ?",
-      "imageAltTextPlaceholder": "Décrivez cette image pour l'accessibilité..."
+      "imageAltTextPlaceholder": "Décrivez cette image pour l'accessibilité...",
+      "addPhoto": "Ajouter une photo",
+      "selectPhoto": "Sélectionner une photo depuis la galerie"
     },
     "gif": {
       "selectGif": "Sélectionner GIF",

--- a/apps/akari/translations/hi.json
+++ b/apps/akari/translations/hi.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "हमें अपने बारे में बताएं",
       "noBanner": "कोई बैनर नहीं",
       "profileUpdated": "प्रोफ़ाइल सफलतापूर्वक अपडेट किया गया",
-      "profileUpdateError": "प्रोफ़ाइल अपडेट करने में विफल"
+      "profileUpdateError": "प्रोफ़ाइल अपडेट करने में विफल",
+      "handleHistory": "हैंडल इतिहास",
+      "noHandleHistory": "कोई हैंडल इतिहास नहीं",
+      "noHandleHistoryDescription": "इस उपयोगकर्ता ने अभी तक अपना हैंडल नहीं बदला है।"
     },
     "feed": {
       "loadingMorePosts": "और पोस्ट लोड हो रही हैं...",
@@ -221,7 +224,10 @@
       "posting": "पोस्ट हो रही है...",
       "replyingTo": "जवाब दे रहे हैं",
       "replyPlaceholder": "अपना जवाब लिखें...",
-      "postPlaceholder": "क्या हो रहा है?"
+      "postPlaceholder": "क्या हो रहा है?",
+      "addPhoto": "फ़ोटो जोड़ें",
+      "selectPhoto": "गैलरी से फ़ोटो चुनें",
+      "imageAltTextPlaceholder": "सुगम्यता के लिए इस छवि का वर्णन करें..."
     },
     "messages": {
       "typeMessage": "संदेश लिखें...",

--- a/apps/akari/translations/id.json
+++ b/apps/akari/translations/id.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "Ceritakan tentang diri Anda",
       "noBanner": "Tidak Ada Banner",
       "profileUpdated": "Profil berhasil diperbarui",
-      "profileUpdateError": "Gagal memperbarui profil"
+      "profileUpdateError": "Gagal memperbarui profil",
+      "handleHistory": "Riwayat handle",
+      "noHandleHistory": "Tidak ada riwayat handle",
+      "noHandleHistoryDescription": "Pengguna ini belum pernah mengganti handle-nya."
     },
     "feed": {
       "loadingMorePosts": "Memuat lebih banyak postingan...",
@@ -221,7 +224,10 @@
       "posting": "Mengirim...",
       "replyingTo": "Membalas",
       "replyPlaceholder": "Tulis balasan Anda...",
-      "postPlaceholder": "Apa yang sedang terjadi?"
+      "postPlaceholder": "Apa yang sedang terjadi?",
+      "addPhoto": "Tambah foto",
+      "selectPhoto": "Pilih foto dari galeri",
+      "imageAltTextPlaceholder": "Deskripsikan gambar ini untuk aksesibilitas..."
     },
     "messages": {
       "typeMessage": "Ketik pesan...",

--- a/apps/akari/translations/it.json
+++ b/apps/akari/translations/it.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "Parlaci di te",
       "noBanner": "Nessun banner",
       "profileUpdated": "Profilo aggiornato con successo",
-      "profileUpdateError": "Errore nell'aggiornamento del profilo"
+      "profileUpdateError": "Errore nell'aggiornamento del profilo",
+      "handleHistory": "Cronologia dell'handle",
+      "noHandleHistory": "Nessuna cronologia dell'handle",
+      "noHandleHistoryDescription": "Questo utente non ha ancora cambiato handle."
     },
     "feed": {
       "loadingMorePosts": "Caricamento di altri post...",
@@ -221,7 +224,10 @@
       "posting": "Pubblicazione...",
       "replyingTo": "Rispondendo a",
       "replyPlaceholder": "Scrivi la tua risposta...",
-      "postPlaceholder": "Cosa sta succedendo?"
+      "postPlaceholder": "Cosa sta succedendo?",
+      "addPhoto": "Aggiungi foto",
+      "selectPhoto": "Seleziona foto dalla galleria",
+      "imageAltTextPlaceholder": "Descrivi questa immagine per l'accessibilità..."
     },
     "messages": {
       "typeMessage": "Scrivi un messaggio...",

--- a/apps/akari/translations/ja.json
+++ b/apps/akari/translations/ja.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "あなたについて教えてください",
       "noBanner": "バナーなし",
       "profileUpdated": "プロフィールが正常に更新されました",
-      "profileUpdateError": "プロフィールの更新に失敗しました"
+      "profileUpdateError": "プロフィールの更新に失敗しました",
+      "handleHistory": "ハンドルの履歴",
+      "noHandleHistory": "ハンドルの履歴はありません",
+      "noHandleHistoryDescription": "このユーザーはまだハンドルを変更していません。"
     },
     "feed": {
       "loadingMorePosts": "さらに投稿を読み込み中...",
@@ -222,7 +225,9 @@
       "replyingTo": "返信中",
       "replyPlaceholder": "返信を書いてください...",
       "postPlaceholder": "何が起こっていますか？",
-      "imageAltTextPlaceholder": "アクセシビリティのため、この画像を説明してください..."
+      "imageAltTextPlaceholder": "アクセシビリティのため、この画像を説明してください...",
+      "addPhoto": "写真を追加",
+      "selectPhoto": "ギャラリーから写真を選択"
     },
     "messages": {
       "typeMessage": "メッセージを入力...",

--- a/apps/akari/translations/ko.json
+++ b/apps/akari/translations/ko.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "자신에 대해 알려주세요",
       "noBanner": "배너 없음",
       "profileUpdated": "프로필이 성공적으로 업데이트되었습니다",
-      "profileUpdateError": "프로필 업데이트에 실패했습니다"
+      "profileUpdateError": "프로필 업데이트에 실패했습니다",
+      "handleHistory": "핸들 변경 기록",
+      "noHandleHistory": "핸들 변경 기록이 없습니다",
+      "noHandleHistoryDescription": "이 사용자는 아직 핸들을 변경하지 않았습니다."
     },
     "feed": {
       "loadingMorePosts": "더 많은 게시물 로딩 중...",
@@ -221,7 +224,10 @@
       "posting": "게시 중...",
       "replyingTo": "답장 중",
       "replyPlaceholder": "답장을 작성하세요...",
-      "postPlaceholder": "무슨 일이 일어나고 있나요?"
+      "postPlaceholder": "무슨 일이 일어나고 있나요?",
+      "addPhoto": "사진 추가",
+      "selectPhoto": "갤러리에서 사진 선택",
+      "imageAltTextPlaceholder": "접근성을 위해 이 이미지를 설명해주세요..."
     },
     "messages": {
       "typeMessage": "메시지를 입력하세요...",

--- a/apps/akari/translations/nl.json
+++ b/apps/akari/translations/nl.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "Vertel ons over uzelf",
       "noBanner": "Geen banner",
       "profileUpdated": "Profiel succesvol bijgewerkt",
-      "profileUpdateError": "Profiel kon niet worden bijgewerkt"
+      "profileUpdateError": "Profiel kon niet worden bijgewerkt",
+      "handleHistory": "Handle-geschiedenis",
+      "noHandleHistory": "Geen handle-geschiedenis",
+      "noHandleHistoryDescription": "Deze gebruiker heeft zijn handle nog niet gewijzigd."
     },
     "feed": {
       "loadingMorePosts": "Meer berichten laden...",
@@ -221,7 +224,10 @@
       "posting": "Bericht plaatsen...",
       "replyingTo": "Beantwoorden aan",
       "replyPlaceholder": "Schrijf je antwoord...",
-      "postPlaceholder": "Wat gebeurt er?"
+      "postPlaceholder": "Wat gebeurt er?",
+      "addPhoto": "Foto toevoegen",
+      "selectPhoto": "Foto uit galerij selecteren",
+      "imageAltTextPlaceholder": "Beschrijf deze afbeelding voor toegankelijkheid..."
     },
     "messages": {
       "typeMessage": "Typ een bericht...",

--- a/apps/akari/translations/pl.json
+++ b/apps/akari/translations/pl.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "Opowiedz nam o sobie",
       "noBanner": "Brak banera",
       "profileUpdated": "Profil zaktualizowany pomyślnie",
-      "profileUpdateError": "Nie udało się zaktualizować profilu"
+      "profileUpdateError": "Nie udało się zaktualizować profilu",
+      "handleHistory": "Historia handle'u",
+      "noHandleHistory": "Brak historii handle'u",
+      "noHandleHistoryDescription": "Ten użytkownik jeszcze nie zmienił swojego handle'u."
     },
     "feed": {
       "loadingMorePosts": "Ładowanie większej liczby postów...",
@@ -221,7 +224,10 @@
       "posting": "Publikowanie...",
       "replyingTo": "Odpowiadanie na",
       "replyPlaceholder": "Napisz swoją odpowiedź...",
-      "postPlaceholder": "Co się dzieje?"
+      "postPlaceholder": "Co się dzieje?",
+      "addPhoto": "Dodaj zdjęcie",
+      "selectPhoto": "Wybierz zdjęcie z galerii",
+      "imageAltTextPlaceholder": "Opisz ten obraz dla dostępności..."
     },
     "messages": {
       "typeMessage": "Wpisz wiadomość...",

--- a/apps/akari/translations/pt.json
+++ b/apps/akari/translations/pt.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "Conte-nos sobre você",
       "noBanner": "Sem banner",
       "profileUpdated": "Perfil atualizado com sucesso",
-      "profileUpdateError": "Erro ao atualizar perfil"
+      "profileUpdateError": "Erro ao atualizar perfil",
+      "handleHistory": "Histórico do identificador",
+      "noHandleHistory": "Nenhum histórico do identificador",
+      "noHandleHistoryDescription": "Este usuário ainda não alterou o identificador."
     },
     "feed": {
       "loadingMorePosts": "Carregando mais publicações...",
@@ -221,7 +224,10 @@
       "posting": "Publicando...",
       "replyingTo": "Respondendo a",
       "replyPlaceholder": "Escreva sua resposta...",
-      "postPlaceholder": "O que está acontecendo?"
+      "postPlaceholder": "O que está acontecendo?",
+      "addPhoto": "Adicionar foto",
+      "selectPhoto": "Selecionar foto da galeria",
+      "imageAltTextPlaceholder": "Descreva esta imagem para acessibilidade..."
     },
     "messages": {
       "typeMessage": "Digite uma mensagem...",

--- a/apps/akari/translations/ru.json
+++ b/apps/akari/translations/ru.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "Расскажите о себе",
       "noBanner": "Без баннера",
       "profileUpdated": "Профиль успешно обновлен",
-      "profileUpdateError": "Не удалось обновить профиль"
+      "profileUpdateError": "Не удалось обновить профиль",
+      "handleHistory": "История хэндла",
+      "noHandleHistory": "Нет истории хэндла",
+      "noHandleHistoryDescription": "Этот пользователь ещё не менял свой хэндл."
     },
     "feed": {
       "loadingMorePosts": "Загрузка дополнительных постов...",
@@ -221,7 +224,10 @@
       "posting": "Публикация...",
       "replyingTo": "Ответ на",
       "replyPlaceholder": "Напишите ваш ответ...",
-      "postPlaceholder": "Что происходит?"
+      "postPlaceholder": "Что происходит?",
+      "addPhoto": "Добавить фото",
+      "selectPhoto": "Выбрать фото из галереи",
+      "imageAltTextPlaceholder": "Опишите это изображение для доступности..."
     },
     "messages": {
       "typeMessage": "Введите сообщение...",

--- a/apps/akari/translations/th.json
+++ b/apps/akari/translations/th.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "บอกเราเกี่ยวกับตัวคุณ",
       "noBanner": "ไม่มีแบนเนอร์",
       "profileUpdated": "อัปเดตโปรไฟล์สำเร็จแล้ว",
-      "profileUpdateError": "อัปเดตโปรไฟล์ไม่สำเร็จ"
+      "profileUpdateError": "อัปเดตโปรไฟล์ไม่สำเร็จ",
+      "handleHistory": "ประวัติแฮนเดิล",
+      "noHandleHistory": "ไม่มีประวัติแฮนเดิล",
+      "noHandleHistoryDescription": "ผู้ใช้นี้ยังไม่เคยเปลี่ยนแฮนเดิล"
     },
     "feed": {
       "loadingMorePosts": "กำลังโหลดโพสต์เพิ่มเติม...",
@@ -221,7 +224,10 @@
       "posting": "กำลังโพสต์...",
       "replyingTo": "ตอบกลับ",
       "replyPlaceholder": "เขียนคำตอบของคุณ...",
-      "postPlaceholder": "เกิดอะไรขึ้น?"
+      "postPlaceholder": "เกิดอะไรขึ้น?",
+      "addPhoto": "เพิ่มรูปภาพ",
+      "selectPhoto": "เลือกรูปจากแกลเลอรี",
+      "imageAltTextPlaceholder": "อธิบายรูปภาพนี้เพื่อการเข้าถึง..."
     },
     "messages": {
       "typeMessage": "พิมพ์ข้อความ...",

--- a/apps/akari/translations/tr.json
+++ b/apps/akari/translations/tr.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "Kendiniz hakkında bize anlatın",
       "noBanner": "Banner Yok",
       "profileUpdated": "Profil başarıyla güncellendi",
-      "profileUpdateError": "Profil güncellenemedi"
+      "profileUpdateError": "Profil güncellenemedi",
+      "handleHistory": "Kullanıcı adı geçmişi",
+      "noHandleHistory": "Kullanıcı adı geçmişi yok",
+      "noHandleHistoryDescription": "Bu kullanıcı henüz kullanıcı adını değiştirmedi."
     },
     "feed": {
       "loadingMorePosts": "Daha fazla gönderi yükleniyor...",
@@ -221,7 +224,10 @@
       "posting": "Gönderiliyor...",
       "replyingTo": "Yanıtlıyor",
       "replyPlaceholder": "Yanıtınızı yazın...",
-      "postPlaceholder": "Ne oluyor?"
+      "postPlaceholder": "Ne oluyor?",
+      "addPhoto": "Fotoğraf ekle",
+      "selectPhoto": "Galeriden fotoğraf seç",
+      "imageAltTextPlaceholder": "Erişilebilirlik için bu görseli açıklayın..."
     },
     "messages": {
       "typeMessage": "Mesaj yazın...",

--- a/apps/akari/translations/vi.json
+++ b/apps/akari/translations/vi.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "Kể cho chúng tôi về bạn",
       "noBanner": "Không Có Banner",
       "profileUpdated": "Cập nhật hồ sơ thành công",
-      "profileUpdateError": "Cập nhật hồ sơ thất bại"
+      "profileUpdateError": "Cập nhật hồ sơ thất bại",
+      "handleHistory": "Lịch sử tên định danh",
+      "noHandleHistory": "Chưa có lịch sử tên định danh",
+      "noHandleHistoryDescription": "Người dùng này chưa từng đổi tên định danh."
     },
     "feed": {
       "loadingMorePosts": "Đang tải thêm bài đăng...",
@@ -221,7 +224,10 @@
       "posting": "Đang đăng...",
       "replyingTo": "Trả lời",
       "replyPlaceholder": "Viết câu trả lời của bạn...",
-      "postPlaceholder": "Chuyện gì đang xảy ra?"
+      "postPlaceholder": "Chuyện gì đang xảy ra?",
+      "addPhoto": "Thêm ảnh",
+      "selectPhoto": "Chọn ảnh từ thư viện",
+      "imageAltTextPlaceholder": "Mô tả hình ảnh này để hỗ trợ khả năng tiếp cận..."
     },
     "messages": {
       "typeMessage": "Nhập tin nhắn...",

--- a/apps/akari/translations/zh-CN.json
+++ b/apps/akari/translations/zh-CN.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "告诉我们关于您自己",
       "noBanner": "无横幅",
       "profileUpdated": "个人资料更新成功",
-      "profileUpdateError": "更新个人资料失败"
+      "profileUpdateError": "更新个人资料失败",
+      "handleHistory": "用户名历史记录",
+      "noHandleHistory": "暂无用户名历史记录",
+      "noHandleHistoryDescription": "该用户尚未更改过用户名。"
     },
     "feed": {
       "loadingMorePosts": "加载更多帖子...",
@@ -221,7 +224,10 @@
       "posting": "发布中...",
       "replyingTo": "回复",
       "replyPlaceholder": "写下你的回复...",
-      "postPlaceholder": "发生了什么？"
+      "postPlaceholder": "发生了什么？",
+      "addPhoto": "添加照片",
+      "selectPhoto": "从相册选择照片",
+      "imageAltTextPlaceholder": "请为无障碍功能描述此图像..."
     },
     "messages": {
       "typeMessage": "输入消息...",

--- a/apps/akari/translations/zh-TW.json
+++ b/apps/akari/translations/zh-TW.json
@@ -198,7 +198,10 @@
       "descriptionPlaceholder": "告訴我們關於您自己",
       "noBanner": "無橫幅",
       "profileUpdated": "個人資料更新成功",
-      "profileUpdateError": "更新個人資料失敗"
+      "profileUpdateError": "更新個人資料失敗",
+      "handleHistory": "使用者代號歷程",
+      "noHandleHistory": "沒有使用者代號歷程",
+      "noHandleHistoryDescription": "此使用者尚未變更過代號。"
     },
     "feed": {
       "loadingMorePosts": "載入更多貼文...",
@@ -221,7 +224,10 @@
       "posting": "發布中...",
       "replyingTo": "回覆",
       "replyPlaceholder": "寫下你的回覆...",
-      "postPlaceholder": "發生了什麼？"
+      "postPlaceholder": "發生了什麼？",
+      "addPhoto": "新增照片",
+      "selectPhoto": "從相簿選擇照片",
+      "imageAltTextPlaceholder": "請描述此圖片以利無障礙使用..."
     },
     "messages": {
       "typeMessage": "輸入訊息...",


### PR DESCRIPTION
## Summary
- run the translation validation step with captured output, surface the results in a collapsible PR comment, and fail the workflow when validation breaks

## Testing
- npm run validate-translations --workspace=akari

------
https://chatgpt.com/codex/tasks/task_e_68c89f096bcc832bb8eff71506cb2b0f