### PR TITLE
feat: add bluesky ip config endpoint and hook

### DIFF
--- a/apps/akari/hooks/queries/useBlueskyIpConfig.ts
+++ b/apps/akari/hooks/queries/useBlueskyIpConfig.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getBlueskyIpConfig } from "@/bluesky-api";
+
+/**
+ * Query hook for fetching the Bluesky IP configuration used for age restrictions
+ */
+export function useBlueskyIpConfig() {
+  return useQuery({
+    queryKey: ["blueskyIpConfig"],
+    queryFn: getBlueskyIpConfig,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}

--- a/packages/bluesky-api/src/api.ts
+++ b/packages/bluesky-api/src/api.ts
@@ -4,6 +4,7 @@ import { BlueskyApiClient } from './client';
 import { BlueskyConversations } from './conversations';
 import { BlueskyFeeds } from './feeds';
 import { BlueskyGraph } from './graph';
+import { getBlueskyIpConfig } from './ip';
 import { BlueskyNotifications } from './notifications';
 import { BlueskySearch } from './search';
 import type {
@@ -16,6 +17,7 @@ import type {
   BlueskyPostView,
   BlueskyPreferencesResponse,
   BlueskyProfileResponse,
+  BlueskyIpConfigResponse,
   BlueskySearchActorsResponse,
   BlueskySearchPostsResponse,
   BlueskySendMessageResponse,
@@ -266,6 +268,11 @@ export class BlueskyApi extends BlueskyApiClient {
 
   async getUnreadNotificationsCount(accessJwt: string): Promise<{ count: number }> {
     return this.notifications.getUnreadCount(accessJwt);
+  }
+
+  // Public endpoints
+  async getIpConfig(): Promise<BlueskyIpConfigResponse> {
+    return getBlueskyIpConfig();
   }
 
   // Static factory method for custom PDS

--- a/packages/bluesky-api/src/index.ts
+++ b/packages/bluesky-api/src/index.ts
@@ -6,6 +6,7 @@ export * from './client';
 export * from './conversations';
 export * from './feeds';
 export * from './graph';
+export * from './ip';
 export * from './notifications';
 export * from './pds';
 export * from './search';

--- a/packages/bluesky-api/src/ip.test.ts
+++ b/packages/bluesky-api/src/ip.test.ts
@@ -1,0 +1,52 @@
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { getBlueskyIpConfig } from './ip';
+
+describe('getBlueskyIpConfig', () => {
+  const server = setupServer();
+
+  beforeAll(() => server.listen());
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  afterAll(() => server.close());
+
+  it('returns the IP configuration when the request succeeds', async () => {
+    const mockConfig = {
+      countryCode: 'GB',
+      regionCode: 'ENG',
+      ageRestrictedGeos: [
+        { countryCode: 'GB', regionCode: null },
+        { countryCode: 'US', regionCode: 'SD' },
+      ],
+      ageBlockedGeos: [{ countryCode: 'US', regionCode: 'MS' }],
+      isAgeRestrictedGeo: true,
+    };
+
+    server.use(
+      http.get('https://ip.bsky.app/config', () => HttpResponse.json(mockConfig)),
+    );
+
+    const result = await getBlueskyIpConfig();
+
+    expect(result).toEqual(mockConfig);
+  });
+
+  it('throws an error when the request fails', async () => {
+    server.use(
+      http.get(
+        'https://ip.bsky.app/config',
+        () =>
+          HttpResponse.json(
+            { message: 'error' },
+            { status: 500, statusText: 'Internal Server Error' },
+          ),
+      ),
+    );
+
+    await expect(getBlueskyIpConfig()).rejects.toThrow('Failed to fetch Bluesky IP config');
+  });
+});

--- a/packages/bluesky-api/src/ip.ts
+++ b/packages/bluesky-api/src/ip.ts
@@ -1,0 +1,19 @@
+import type { BlueskyIpConfigResponse } from './types';
+
+const BLUESKY_IP_CONFIG_URL = 'https://ip.bsky.app/config';
+
+/**
+ * Fetches geographic age restriction configuration for the current IP address
+ */
+export async function getBlueskyIpConfig(): Promise<BlueskyIpConfigResponse> {
+  const response = await fetch(BLUESKY_IP_CONFIG_URL);
+
+  if (!response.ok) {
+    const statusText = response.statusText ? ` ${response.statusText}` : '';
+    throw new Error(`Failed to fetch Bluesky IP config: HTTP ${response.status}${statusText}`);
+  }
+
+  const config = (await response.json()) as BlueskyIpConfigResponse;
+
+  return config;
+}

--- a/packages/bluesky-api/src/types.ts
+++ b/packages/bluesky-api/src/types.ts
@@ -813,10 +813,10 @@ export type BlueskyAppStatePref = {
   /** Type identifier */
   $type: 'app.bsky.actor.defs#bskyAppStatePref';
   /** NUX completion status */
-  nuxs?: Array<{
+  nuxs?: {
     id: string;
     completed: boolean;
-  }>;
+  }[];
 };
 
 /**
@@ -836,4 +836,30 @@ export type BlueskyPreference =
 export type BlueskyPreferencesResponse = {
   /** Array of user preferences */
   preferences: BlueskyPreference[];
+};
+
+/**
+ * Geographic restriction information for a specific country/region
+ */
+export type BlueskyGeoRestriction = {
+  /** ISO 3166-1 alpha-2 country code */
+  countryCode: string;
+  /** Optional ISO 3166-2 region code */
+  regionCode: string | null;
+};
+
+/**
+ * Response structure for the https://ip.bsky.app/config endpoint
+ */
+export type BlueskyIpConfigResponse = {
+  /** Country code detected for the current IP */
+  countryCode: string;
+  /** Region code detected for the current IP */
+  regionCode: string | null;
+  /** Geos where age restrictions apply */
+  ageRestrictedGeos: BlueskyGeoRestriction[];
+  /** Geos where access is fully blocked due to age restrictions */
+  ageBlockedGeos: BlueskyGeoRestriction[];
+  /** Whether the current geo is age restricted */
+  isAgeRestrictedGeo: boolean;
 };


### PR DESCRIPTION
## Summary
- add an IP configuration fetcher to the bluesky-api package with type definitions and tests
- expose the new endpoint through the main BlueskyApi client
- create a React Query hook for consumers to retrieve the configuration data

## Testing
- npm run test --workspace bluesky-api
- npm run lint --workspace bluesky-api

------
https://chatgpt.com/codex/tasks/task_e_68c9ab8a7168832baaf0ea4681007147