### PR TITLE
feat: add mobile sidebar overlay

### DIFF
--- a/apps/akari/__tests__/app/tabs-layout.test.tsx
+++ b/apps/akari/__tests__/app/tabs-layout.test.tsx
@@ -167,7 +167,9 @@ describe('TabLayout', () => {
     render(<TabLayout />);
     const TabsModule = require('expo-router');
     const screenOptions = TabsModule.Tabs.mock.calls[0][0].screenOptions;
-    expect(screenOptions.headerTransparent).toBe(true);
+    expect(screenOptions.headerTransparent).toBe(false);
+    expect(screenOptions.headerTintColor).toBe(Colors.light.text);
+    expect(screenOptions.headerStyle).toMatchObject({ backgroundColor: Colors.light.background });
     expect(typeof screenOptions.headerLeft).toBe('function');
     const screens = (TabsModule.Tabs.Screen as jest.Mock).mock.calls.map((call: any[]) => call[0]);
     const screensWithIcons = screens.filter((screen) => typeof screen.options?.tabBarIcon === 'function');
@@ -196,7 +198,7 @@ describe('TabLayout', () => {
     const TabsModule = require('expo-router');
     const screenOptions = TabsModule.Tabs.mock.calls[0][0].screenOptions;
     expect(screenOptions.tabBarActiveTintColor).toBe(Colors.light.tint);
-    expect(screenOptions.headerTransparent).toBe(true);
+    expect(screenOptions.headerTransparent).toBe(false);
     const messagesOptions = (TabsModule.Tabs.Screen as jest.Mock).mock.calls[2][0].options;
     const notificationsOptions = (TabsModule.Tabs.Screen as jest.Mock).mock.calls[3][0].options;
     render(messagesOptions.tabBarIcon({ color: 'blue' }));

--- a/apps/akari/__tests__/app/tabs-layout.test.tsx
+++ b/apps/akari/__tests__/app/tabs-layout.test.tsx
@@ -16,7 +16,14 @@ import { tabScrollRegistry } from '@/utils/tabScrollRegistry';
 jest.mock('expo-router', () => {
   const React = require('react');
   const { Text } = require('react-native');
-  const Tabs = jest.fn(({ children }: { children: React.ReactNode }) => <>{children}</>);
+  const Tabs = jest.fn(
+    ({ children, screenOptions }: { children: React.ReactNode; screenOptions?: Record<string, unknown> }) => (
+      <>
+        {screenOptions?.headerLeft ? screenOptions.headerLeft() : null}
+        {children}
+      </>
+    ),
+  );
   const Screen = jest.fn(() => null);
   // @ts-ignore
   Tabs.Screen = Screen;
@@ -159,6 +166,9 @@ describe('TabLayout', () => {
     mockUseUnreadNotificationsCount.mockReturnValue({ data: 3 });
     render(<TabLayout />);
     const TabsModule = require('expo-router');
+    const screenOptions = TabsModule.Tabs.mock.calls[0][0].screenOptions;
+    expect(screenOptions.headerTransparent).toBe(true);
+    expect(typeof screenOptions.headerLeft).toBe('function');
     const screens = (TabsModule.Tabs.Screen as jest.Mock).mock.calls.map((call: any[]) => call[0]);
     const screensWithIcons = screens.filter((screen) => typeof screen.options?.tabBarIcon === 'function');
     const [indexOptions, searchOptions, messagesOptions, notificationsOptions, profileOptions, settingsOptions] =
@@ -186,6 +196,7 @@ describe('TabLayout', () => {
     const TabsModule = require('expo-router');
     const screenOptions = TabsModule.Tabs.mock.calls[0][0].screenOptions;
     expect(screenOptions.tabBarActiveTintColor).toBe(Colors.light.tint);
+    expect(screenOptions.headerTransparent).toBe(true);
     const messagesOptions = (TabsModule.Tabs.Screen as jest.Mock).mock.calls[2][0].options;
     const notificationsOptions = (TabsModule.Tabs.Screen as jest.Mock).mock.calls[3][0].options;
     render(messagesOptions.tabBarIcon({ color: 'blue' }));

--- a/apps/akari/__tests__/components/Sidebar.test.tsx
+++ b/apps/akari/__tests__/components/Sidebar.test.tsx
@@ -174,6 +174,21 @@ describe('Sidebar', () => {
     expect(getByText('Timeline')).toBeTruthy();
   });
 
+  it('renders a close button when provided and hides collapse controls', () => {
+    const handleClose = jest.fn();
+
+    const { getByLabelText, queryByText } = render(
+      <DialogProvider>
+        <Sidebar onClose={handleClose} />
+      </DialogProvider>,
+    );
+
+    const closeButton = getByLabelText('Close navigation menu');
+    fireEvent.press(closeButton);
+    expect(handleClose).toHaveBeenCalledTimes(1);
+    expect(queryByText('Collapse')).toBeNull();
+  });
+
   it('opens the account selector, allows switching accounts, and opens the add account panel', () => {
     const { getByText, getByPlaceholderText } = render(
       <DialogProvider>

--- a/apps/akari/app/(tabs)/_layout.tsx
+++ b/apps/akari/app/(tabs)/_layout.tsx
@@ -1,7 +1,7 @@
 import { useNavigationState } from '@react-navigation/native';
 import { Redirect, Tabs } from 'expo-router';
-import React, { useRef } from 'react';
-import { ActivityIndicator, Platform, View } from 'react-native';
+import React, { useRef, useState } from 'react';
+import { ActivityIndicator, Platform, Pressable, StyleSheet, View } from 'react-native';
 
 import { HapticTab } from '@/components/HapticTab';
 import { Sidebar } from '@/components/Sidebar';
@@ -17,6 +17,7 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 import { usePushNotifications } from '@/hooks/usePushNotifications';
 import { useResponsive } from '@/hooks/useResponsive';
 import { tabScrollRegistry } from '@/utils/tabScrollRegistry';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 /**
  * You can explore the built-in icon families and icons on the web at https://icons.expo.fyi/
@@ -58,6 +59,8 @@ export default function TabLayout() {
   const { data: authStatus, isLoading } = useAuthStatus();
   const { data: unreadMessagesCount = 0 } = useUnreadMessagesCount();
   const { data: unreadNotificationsCount = 0 } = useUnreadNotificationsCount();
+  const insets = useSafeAreaInsets();
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
   // Initialize push notifications
   usePushNotifications();
@@ -131,75 +134,161 @@ export default function TabLayout() {
   }
 
   // For mobile screens, show the traditional tab bar
+  const themeColors = Colors[colorScheme ?? 'light'];
+
+  const openSidebar = () => setIsSidebarOpen(true);
+  const closeSidebar = () => setIsSidebarOpen(false);
+
   return (
-    <Tabs
-      screenOptions={{
-        tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
-        headerShown: false,
-        tabBarButton: CustomTabButton,
-        tabBarBackground: TabBarBackground,
-        tabBarShowLabel: false,
-        tabBarStyle: Platform.select({
-          ios: {
-            // Use a transparent background on iOS to show the blur effect
-            position: 'absolute',
-          },
-          default: {},
-        }),
-      }}
-    >
-      <Tabs.Screen
-        name="index"
-        options={{
-          tabBarIcon: ({ color }) => <TabBarIcon name="house.fill" color={color} />,
+    <View style={{ flex: 1 }}>
+      <Tabs
+        screenOptions={{
+          tabBarActiveTintColor: themeColors.tint,
+          headerShown: false,
+          tabBarButton: CustomTabButton,
+          tabBarBackground: TabBarBackground,
+          tabBarShowLabel: false,
+          tabBarStyle: Platform.select({
+            ios: {
+              // Use a transparent background on iOS to show the blur effect
+              position: 'absolute',
+            },
+            default: {},
+          }),
         }}
-      />
-      <Tabs.Screen
-        name="search"
-        options={{
-          tabBarIcon: ({ color }) => <TabBarIcon name="magnifyingglass" color={color} />,
-        }}
-      />
-      <Tabs.Screen
-        name="messages"
-        options={{
-          tabBarIcon: ({ color }) => (
-            <View style={{ position: 'relative' }}>
-              <TabBarIcon name="message.fill" color={color} />
-              <TabBadge count={unreadMessagesCount} size="small" />
-            </View>
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="notifications"
-        options={{
-          tabBarIcon: ({ color }) => (
-            <View style={{ position: 'relative' }}>
-              <TabBarIcon name="bell.fill" color={color} />
-              <TabBadge count={unreadNotificationsCount} size="small" />
-            </View>
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="bookmarks"
-        options={{
-          href: null,
-        }}
-      />
-      <Tabs.Screen
-        name="profile"
-        options={{
-          tabBarIcon: ({ color }) => <TabBarIcon name="person.fill" color={color} />,
-        }}
-      />
-      <Tabs.Screen
-        name="settings"
-        options={{
-          tabBarIcon: ({ color }) => <TabBarIcon name="gearshape.fill" color={color} />,
-        }}
-      />
-    </Tabs>
+      >
+        <Tabs.Screen
+          name="index"
+          options={{
+            tabBarIcon: ({ color }) => <TabBarIcon name="house.fill" color={color} />,
+          }}
+        />
+        <Tabs.Screen
+          name="search"
+          options={{
+            tabBarIcon: ({ color }) => <TabBarIcon name="magnifyingglass" color={color} />,
+          }}
+        />
+        <Tabs.Screen
+          name="messages"
+          options={{
+            tabBarIcon: ({ color }) => (
+              <View style={{ position: 'relative' }}>
+                <TabBarIcon name="message.fill" color={color} />
+                <TabBadge count={unreadMessagesCount} size="small" />
+              </View>
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="notifications"
+          options={{
+            tabBarIcon: ({ color }) => (
+              <View style={{ position: 'relative' }}>
+                <TabBarIcon name="bell.fill" color={color} />
+                <TabBadge count={unreadNotificationsCount} size="small" />
+              </View>
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="bookmarks"
+          options={{
+            href: null,
+          }}
+        />
+        <Tabs.Screen
+          name="profile"
+          options={{
+            tabBarIcon: ({ color }) => <TabBarIcon name="person.fill" color={color} />,
+          }}
+        />
+        <Tabs.Screen
+          name="settings"
+          options={{
+            tabBarIcon: ({ color }) => <TabBarIcon name="gearshape.fill" color={color} />,
+          }}
+        />
+      </Tabs>
+
+      {!isSidebarOpen ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Open navigation menu"
+          onPress={openSidebar}
+          style={({ pressed }) => [
+            styles.mobileSidebarToggle,
+            {
+              top: insets.top + 12,
+              left: insets.left + 16,
+              backgroundColor: themeColors.background,
+              borderColor: themeColors.border,
+            },
+            pressed && { opacity: 0.8 },
+          ]}
+        >
+          <IconSymbol name="line.3.horizontal" size={20} color={themeColors.text} />
+        </Pressable>
+      ) : null}
+
+      {isSidebarOpen ? (
+        <View style={styles.mobileSidebarOverlay}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Dismiss navigation menu"
+            onPress={closeSidebar}
+            style={styles.mobileSidebarBackdrop}
+          />
+          <View
+            style={[
+              styles.mobileSidebarSheet,
+              {
+                paddingTop: insets.top + 12,
+                paddingBottom: Math.max(insets.bottom, 12),
+                paddingLeft: Math.max(insets.left, 12),
+                paddingRight: Math.max(insets.right, 12),
+              },
+            ]}
+          >
+            <Sidebar onClose={closeSidebar} />
+          </View>
+        </View>
+      ) : null}
+    </View>
   );
 }
+
+const styles = StyleSheet.create({
+  mobileSidebarToggle: {
+    position: 'absolute',
+    left: 16,
+    zIndex: 40,
+    borderRadius: 999,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderWidth: 1,
+    shadowColor: '#000',
+    shadowOpacity: 0.25,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 6,
+  },
+  mobileSidebarOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 50,
+  },
+  mobileSidebarBackdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(10, 10, 10, 0.55)',
+  },
+  mobileSidebarSheet: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    bottom: 0,
+    width: '82%',
+    maxWidth: 320,
+    minWidth: 264,
+    paddingHorizontal: 12,
+  },
+});

--- a/apps/akari/app/(tabs)/_layout.tsx
+++ b/apps/akari/app/(tabs)/_layout.tsx
@@ -139,12 +139,51 @@ export default function TabLayout() {
   const openSidebar = () => setIsSidebarOpen(true);
   const closeSidebar = () => setIsSidebarOpen(false);
 
+  const renderMobileSidebarToggle = () => {
+    if (isSidebarOpen) {
+      return null;
+    }
+
+    return (
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Open navigation menu"
+        onPress={openSidebar}
+        style={({ pressed }) => [
+          styles.mobileSidebarToggle,
+          {
+            backgroundColor: themeColors.background,
+            borderColor: themeColors.border,
+          },
+          pressed && { opacity: 0.8 },
+        ]}
+      >
+        <IconSymbol name="line.3.horizontal" size={20} color={themeColors.text} />
+      </Pressable>
+    );
+  };
+
   return (
     <View style={{ flex: 1 }}>
       <Tabs
         screenOptions={{
           tabBarActiveTintColor: themeColors.tint,
-          headerShown: false,
+          headerShown: true,
+          headerTransparent: true,
+          headerTitle: '',
+          headerShadowVisible: false,
+          headerStyle: {
+            backgroundColor: 'transparent',
+          },
+          headerLeft: renderMobileSidebarToggle,
+          headerLeftContainerStyle: {
+            paddingLeft: Math.max(insets.left, 16),
+            paddingTop: Math.max(insets.top, 12),
+          },
+          headerRightContainerStyle: {
+            paddingRight: Math.max(insets.right, 16),
+            paddingTop: Math.max(insets.top, 12),
+          },
           tabBarButton: CustomTabButton,
           tabBarBackground: TabBarBackground,
           tabBarShowLabel: false,
@@ -211,26 +250,6 @@ export default function TabLayout() {
         />
       </Tabs>
 
-      {!isSidebarOpen ? (
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Open navigation menu"
-          onPress={openSidebar}
-          style={({ pressed }) => [
-            styles.mobileSidebarToggle,
-            {
-              top: insets.top + 12,
-              left: insets.left + 16,
-              backgroundColor: themeColors.background,
-              borderColor: themeColors.border,
-            },
-            pressed && { opacity: 0.8 },
-          ]}
-        >
-          <IconSymbol name="line.3.horizontal" size={20} color={themeColors.text} />
-        </Pressable>
-      ) : null}
-
       {isSidebarOpen ? (
         <View style={styles.mobileSidebarOverlay}>
           <Pressable
@@ -260,9 +279,9 @@ export default function TabLayout() {
 
 const styles = StyleSheet.create({
   mobileSidebarToggle: {
-    position: 'absolute',
-    left: 16,
-    zIndex: 40,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
     borderRadius: 999,
     paddingVertical: 10,
     paddingHorizontal: 12,
@@ -286,9 +305,9 @@ const styles = StyleSheet.create({
     left: 0,
     top: 0,
     bottom: 0,
-    width: '82%',
-    maxWidth: 320,
-    minWidth: 264,
+    width: '92%',
+    maxWidth: 360,
+    minWidth: 280,
     paddingHorizontal: 12,
   },
 });

--- a/apps/akari/app/(tabs)/_layout.tsx
+++ b/apps/akari/app/(tabs)/_layout.tsx
@@ -139,7 +139,7 @@ export default function TabLayout() {
   const openSidebar = () => setIsSidebarOpen(true);
   const closeSidebar = () => setIsSidebarOpen(false);
 
-  const renderMobileSidebarToggle = () => {
+  const renderMobileSidebarToggle = ({ tintColor }: { tintColor?: string } = {}) => {
     if (isSidebarOpen) {
       return null;
     }
@@ -149,16 +149,10 @@ export default function TabLayout() {
         accessibilityRole="button"
         accessibilityLabel="Open navigation menu"
         onPress={openSidebar}
-        style={({ pressed }) => [
-          styles.mobileSidebarToggle,
-          {
-            backgroundColor: themeColors.background,
-            borderColor: themeColors.border,
-          },
-          pressed && { opacity: 0.8 },
-        ]}
+        hitSlop={10}
+        style={({ pressed }) => [styles.mobileSidebarToggle, pressed && styles.mobileSidebarTogglePressed]}
       >
-        <IconSymbol name="line.3.horizontal" size={20} color={themeColors.text} />
+        <IconSymbol name="line.3.horizontal" size={22} color={tintColor ?? themeColors.text} />
       </Pressable>
     );
   };
@@ -169,20 +163,19 @@ export default function TabLayout() {
         screenOptions={{
           tabBarActiveTintColor: themeColors.tint,
           headerShown: true,
-          headerTransparent: true,
+          headerTransparent: false,
           headerTitle: '',
           headerShadowVisible: false,
           headerStyle: {
-            backgroundColor: 'transparent',
+            backgroundColor: themeColors.background,
           },
+          headerTintColor: themeColors.text,
           headerLeft: renderMobileSidebarToggle,
           headerLeftContainerStyle: {
             paddingLeft: Math.max(insets.left, 16),
-            paddingTop: Math.max(insets.top, 12),
           },
           headerRightContainerStyle: {
             paddingRight: Math.max(insets.right, 16),
-            paddingTop: Math.max(insets.top, 12),
           },
           tabBarButton: CustomTabButton,
           tabBarBackground: TabBarBackground,
@@ -282,15 +275,12 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    borderRadius: 999,
-    paddingVertical: 10,
-    paddingHorizontal: 12,
-    borderWidth: 1,
-    shadowColor: '#000',
-    shadowOpacity: 0.25,
-    shadowRadius: 8,
-    shadowOffset: { width: 0, height: 4 },
-    elevation: 6,
+    minHeight: 44,
+    minWidth: 44,
+    paddingHorizontal: 8,
+  },
+  mobileSidebarTogglePressed: {
+    opacity: 0.5,
   },
   mobileSidebarOverlay: {
     ...StyleSheet.absoluteFillObject,

--- a/apps/akari/components/Sidebar.tsx
+++ b/apps/akari/components/Sidebar.tsx
@@ -161,8 +161,14 @@ export function Sidebar({ onClose }: SidebarProps = {}) {
     );
   };
 
+  const resolvedWidth: number | string = collapsed
+    ? COLLAPSED_WIDTH
+    : onClose
+    ? '100%'
+    : EXPANDED_WIDTH;
+
   return (
-    <View style={[styles.container, { width: collapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH }]}>
+    <View style={[styles.container, { width: resolvedWidth }]}>
       <View style={styles.header}>
         <Pressable
           accessibilityRole="button"

--- a/apps/akari/components/Sidebar.tsx
+++ b/apps/akari/components/Sidebar.tsx
@@ -48,7 +48,11 @@ type NavigationItem = {
   badge?: number | null;
 };
 
-export function Sidebar() {
+type SidebarProps = {
+  onClose?: () => void;
+};
+
+export function Sidebar({ onClose }: SidebarProps = {}) {
   const router = useRouter();
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(false);
@@ -167,6 +171,7 @@ export function Sidebar() {
           style={({ pressed }) => [
             styles.accountButton,
             collapsed && styles.accountButtonCollapsed,
+            onClose && styles.accountButtonWithClose,
             pressed && { backgroundColor: palette.hover },
           ]}
         >
@@ -191,6 +196,17 @@ export function Sidebar() {
             <IconSymbol name="chevron.down" size={16} color={palette.textSecondary} />
           ) : null}
         </Pressable>
+        {onClose ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Close navigation menu"
+            hitSlop={8}
+            onPress={onClose}
+            style={({ pressed }) => [styles.closeButton, pressed && { backgroundColor: palette.hover }]}
+          >
+            <IconSymbol name="xmark" size={16} color={palette.textSecondary} />
+          </Pressable>
+        ) : null}
       </View>
 
       <View style={styles.menu}>
@@ -271,20 +287,22 @@ export function Sidebar() {
         ) : null}
       </View>
 
-      <View style={styles.footer}>
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          onPress={() => setCollapsed((value) => !value)}
-          style={({ pressed }) => [
-            styles.collapseButton,
-            pressed && { backgroundColor: palette.hover },
-          ]}
-        >
-          {!collapsed ? <Text style={styles.collapseText}>Collapse</Text> : null}
-          <IconSymbol name="ellipsis" size={18} color={palette.textSecondary} />
-        </Pressable>
-      </View>
+      {!onClose ? (
+        <View style={styles.footer}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            onPress={() => setCollapsed((value) => !value)}
+            style={({ pressed }) => [
+              styles.collapseButton,
+              pressed && { backgroundColor: palette.hover },
+            ]}
+          >
+            {!collapsed ? <Text style={styles.collapseText}>Collapse</Text> : null}
+            <IconSymbol name="ellipsis" size={18} color={palette.textSecondary} />
+          </Pressable>
+        </View>
+      ) : null}
 
       {showAccountSelector ? (
         <View
@@ -370,6 +388,9 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
     paddingHorizontal: 6,
   },
+  accountButtonWithClose: {
+    paddingRight: 36,
+  },
   accountButtonCollapsed: {
     justifyContent: 'center',
   },
@@ -412,6 +433,16 @@ const styles = StyleSheet.create({
     color: palette.textSecondary,
     fontSize: 12,
     marginTop: 2,
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 12,
+    right: 12,
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   menu: {
     flex: 1,


### PR DESCRIPTION
## Summary
- allow the tab layout to open the sidebar in a mobile overlay with a safe-area-aware toggle and dismiss controls
- expose an optional close affordance on the Sidebar component and hide the collapse control when the overlay is used
- extend tab layout and sidebar tests to cover the new mobile behavior and the close button

## Testing
- npm run test -- tabs-layout
- npm run test -- Sidebar

------
https://chatgpt.com/codex/tasks/task_e_68c9e0abd7f4832b9ae757b150f8db7c