### PR TITLE
fix: enable global scroll delegation for tab views

### DIFF
--- a/apps/akari/__tests__/app/tabs-profile.test.tsx
+++ b/apps/akari/__tests__/app/tabs-profile.test.tsx
@@ -264,10 +264,17 @@ describe('ProfileScreen', () => {
 
     expect(scrollToMock).toHaveBeenCalled();
 
-    expect(mockRegister).toHaveBeenCalledWith('profile', expect.any(Function));
-    const [, scrollHandler] = mockRegister.mock.calls[0];
+    expect(mockRegister).toHaveBeenCalledWith(
+      'profile',
+      expect.objectContaining({
+        scrollToTop: expect.any(Function),
+        scrollBy: expect.any(Function),
+        containsTarget: expect.any(Function),
+      }),
+    );
+    const [, scrollHandlers] = mockRegister.mock.calls[0];
     scrollToMock.mockClear();
-    scrollHandler();
+    scrollHandlers.scrollToTop();
     expect(scrollToMock).toHaveBeenCalledWith({ y: 0, animated: true });
   });
 

--- a/apps/akari/__tests__/app/tabs/index.test.tsx
+++ b/apps/akari/__tests__/app/tabs/index.test.tsx
@@ -155,7 +155,14 @@ describe('HomeScreen', () => {
     fireEvent.press(getByText('Feed Two'));
     expect(mutate).toHaveBeenCalledWith('feed2');
 
-    expect(tabScrollRegistry.register).toHaveBeenCalledWith('index', expect.any(Function));
+    expect(tabScrollRegistry.register).toHaveBeenCalledWith(
+      'index',
+      expect.objectContaining({
+        scrollToTop: expect.any(Function),
+        scrollBy: expect.any(Function),
+        containsTarget: expect.any(Function),
+      }),
+    );
   });
 
   it('prompts to select a feed when none is chosen', () => {

--- a/apps/akari/__tests__/app/tabs/messages-index.test.tsx
+++ b/apps/akari/__tests__/app/tabs/messages-index.test.tsx
@@ -91,7 +91,14 @@ describe('MessagesScreen', () => {
 
     const { getByText, UNSAFE_getAllByType, UNSAFE_getByType } = render(<MessagesScreen />);
 
-    expect(mockRegister).toHaveBeenCalledWith('messages', expect.any(Function));
+    expect(mockRegister).toHaveBeenCalledWith(
+      'messages',
+      expect.objectContaining({
+        scrollToTop: expect.any(Function),
+        scrollBy: expect.any(Function),
+        containsTarget: expect.any(Function),
+      }),
+    );
     expect(UNSAFE_getByType(FlatList).props.ListFooterComponent()).toBeNull();
     expect(getByText('3')).toBeTruthy();
     expect(getByText('Alice')).toBeTruthy();
@@ -136,10 +143,10 @@ describe('MessagesScreen', () => {
     const flatListInstance = UNSAFE_getByType(FlatList).instance as { scrollToOffset: jest.Mock };
     flatListInstance.scrollToOffset = jest.fn();
 
-    const scrollToTop = mockRegister.mock.calls[0][1];
+    const scrollHandlers = mockRegister.mock.calls[0][1];
 
     act(() => {
-      scrollToTop();
+      scrollHandlers.scrollToTop();
     });
 
     expect(flatListInstance.scrollToOffset).toHaveBeenCalledWith({ offset: 0, animated: true });

--- a/apps/akari/__tests__/app/tabs/notifications.test.tsx
+++ b/apps/akari/__tests__/app/tabs/notifications.test.tsx
@@ -122,7 +122,14 @@ describe('NotificationsScreen', () => {
 
     const { getByText } = render(<NotificationsScreen />);
 
-    expect(mockRegister).toHaveBeenCalledWith('notifications', expect.any(Function));
+    expect(mockRegister).toHaveBeenCalledWith(
+      'notifications',
+      expect.objectContaining({
+        scrollToTop: expect.any(Function),
+        scrollBy: expect.any(Function),
+        containsTarget: expect.any(Function),
+      }),
+    );
     expect(getByText('alice and bob')).toBeTruthy();
     expect(getByText('notifications.andOneOther')).toBeTruthy();
     expect(getByText('Carol')).toBeTruthy();
@@ -275,10 +282,10 @@ describe('NotificationsScreen', () => {
     const andOthersCall = tMock.mock.calls.find(([key]) => key === 'notifications.andOthers');
     expect(andOthersCall?.[1]).toMatchObject({ count: 4, action: 'notifications.likedYourPost' });
 
-    const scrollCallback = mockRegister.mock.calls[0][1];
-    expect(scrollCallback).toEqual(expect.any(Function));
+    const scrollHandlers = mockRegister.mock.calls[0][1];
+    expect(scrollHandlers.scrollToTop).toEqual(expect.any(Function));
     act(() => {
-      scrollCallback();
+      scrollHandlers.scrollToTop();
     });
   });
 

--- a/apps/akari/__tests__/app/tabs/settings.test.tsx
+++ b/apps/akari/__tests__/app/tabs/settings.test.tsx
@@ -124,7 +124,16 @@ describe('SettingsScreen', () => {
 
     const { getByText, getAllByText } = renderSettings();
 
-    await waitFor(() => expect(registerSpy).toHaveBeenCalledWith('settings', expect.any(Function)));
+    await waitFor(() =>
+      expect(registerSpy).toHaveBeenCalledWith(
+        'settings',
+        expect.objectContaining({
+          scrollToTop: expect.any(Function),
+          scrollBy: expect.any(Function),
+          containsTarget: expect.any(Function),
+        }),
+      ),
+    );
 
     expect(getAllByText('@user1').length).toBeGreaterThan(0);
     expect(getByText('@user2')).toBeTruthy();

--- a/apps/akari/__tests__/utils/tabScrollRegistry.test.ts
+++ b/apps/akari/__tests__/utils/tabScrollRegistry.test.ts
@@ -3,21 +3,35 @@ describe('tabScrollRegistry', () => {
     jest.resetModules();
   });
 
-  it('runs registered handler on tab press', () => {
+  it('runs registered scroll handlers', () => {
     const module = require('@/utils/tabScrollRegistry');
     const { tabScrollRegistry } = module;
-    const handler = jest.fn();
-    tabScrollRegistry.register('home', handler);
+
+    const scrollToTop = jest.fn();
+    const scrollBy = jest.fn();
+    const containsTarget = jest.fn(() => true);
+
+    tabScrollRegistry.register('home', { scrollToTop, scrollBy, containsTarget });
+
     tabScrollRegistry.handleTabPress('home');
-    expect(handler).toHaveBeenCalled();
+    expect(scrollToTop).toHaveBeenCalledTimes(1);
+
+    tabScrollRegistry.scrollBy('home', 120);
+    expect(scrollBy).toHaveBeenCalledWith(120);
+
+    expect(tabScrollRegistry.isEventWithinScrollArea('home', null)).toBe(true);
   });
 
   it('ignores unregistered tabs', () => {
     const module = require('@/utils/tabScrollRegistry');
     const { tabScrollRegistry } = module;
-    const handler = jest.fn();
-    tabScrollRegistry.register('home', handler);
+
+    const scrollToTop = jest.fn();
+    tabScrollRegistry.register('home', { scrollToTop });
     tabScrollRegistry.handleTabPress('other');
-    expect(handler).not.toHaveBeenCalled();
+    expect(scrollToTop).not.toHaveBeenCalled();
+
+    tabScrollRegistry.scrollBy('other', 10);
+    expect(tabScrollRegistry.isEventWithinScrollArea('other', null)).toBe(false);
   });
 });

--- a/apps/akari/app/(tabs)/index.tsx
+++ b/apps/akari/app/(tabs)/index.tsx
@@ -37,11 +37,17 @@ export default function HomeScreen() {
 
   // Create scroll to top function
   const scrollToTop = useCallback(() => {
+    scrollOffsetRef.current = 0;
     scrollViewRef.current?.scrollTo({ y: 0, animated: true });
   }, []);
 
   const scrollBy = useCallback((deltaY: number) => {
+    if (!Number.isFinite(deltaY) || deltaY === 0) {
+      return;
+    }
+
     const nextOffset = Math.max(0, scrollOffsetRef.current + deltaY);
+    scrollOffsetRef.current = nextOffset;
     scrollViewRef.current?.scrollTo({ y: nextOffset, animated: false });
   }, []);
 

--- a/apps/akari/app/(tabs)/messages/index.tsx
+++ b/apps/akari/app/(tabs)/messages/index.tsx
@@ -34,11 +34,17 @@ export default function MessagesScreen() {
 
   // Create scroll to top function
   const scrollToTop = useCallback(() => {
+    scrollOffsetRef.current = 0;
     flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
   }, []);
 
   const scrollBy = useCallback((deltaY: number) => {
+    if (!Number.isFinite(deltaY) || deltaY === 0) {
+      return;
+    }
+
     const nextOffset = Math.max(0, scrollOffsetRef.current + deltaY);
+    scrollOffsetRef.current = nextOffset;
     flatListRef.current?.scrollToOffset({ offset: nextOffset, animated: false });
   }, []);
 

--- a/apps/akari/app/(tabs)/notifications.tsx
+++ b/apps/akari/app/(tabs)/notifications.tsx
@@ -341,11 +341,17 @@ export default function NotificationsScreen() {
 
   // Create scroll to top function
   const scrollToTop = useCallback(() => {
+    scrollOffsetRef.current = 0;
     scrollViewRef.current?.scrollTo({ y: 0, animated: true });
   }, []);
 
   const scrollBy = useCallback((deltaY: number) => {
+    if (!Number.isFinite(deltaY) || deltaY === 0) {
+      return;
+    }
+
     const nextOffset = Math.max(0, scrollOffsetRef.current + deltaY);
+    scrollOffsetRef.current = nextOffset;
     scrollViewRef.current?.scrollTo({ y: nextOffset, animated: false });
   }, []);
 

--- a/apps/akari/app/(tabs)/profile.tsx
+++ b/apps/akari/app/(tabs)/profile.tsx
@@ -34,11 +34,17 @@ export default function ProfileScreen() {
 
   // Create scroll to top function
   const scrollToTop = useCallback(() => {
+    scrollOffsetRef.current = 0;
     scrollViewRef.current?.scrollTo({ y: 0, animated: true });
   }, []);
 
   const scrollBy = useCallback((deltaY: number) => {
+    if (!Number.isFinite(deltaY) || deltaY === 0) {
+      return;
+    }
+
     const nextOffset = Math.max(0, scrollOffsetRef.current + deltaY);
+    scrollOffsetRef.current = nextOffset;
     scrollViewRef.current?.scrollTo({ y: nextOffset, animated: false });
   }, []);
 

--- a/apps/akari/app/(tabs)/search.tsx
+++ b/apps/akari/app/(tabs)/search.tsx
@@ -37,11 +37,17 @@ export default function SearchScreen() {
 
   // Create scroll to top function
   const scrollToTop = useCallback(() => {
+    scrollOffsetRef.current = 0;
     flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
   }, []);
 
   const scrollBy = useCallback((deltaY: number) => {
+    if (!Number.isFinite(deltaY) || deltaY === 0) {
+      return;
+    }
+
     const nextOffset = Math.max(0, scrollOffsetRef.current + deltaY);
+    scrollOffsetRef.current = nextOffset;
     flatListRef.current?.scrollToOffset({ offset: nextOffset, animated: false });
   }, []);
 

--- a/apps/akari/app/(tabs)/settings.tsx
+++ b/apps/akari/app/(tabs)/settings.tsx
@@ -41,13 +41,19 @@ export default function SettingsScreen() {
 
   // Create scroll to top function
   const handleScrollToTop = useCallback(() => {
+    scrollOffsetRef.current = 0;
     if (scrollViewRef.current) {
       scrollViewRef.current.scrollTo({ y: 0, animated: true });
     }
   }, []);
 
   const scrollBy = useCallback((deltaY: number) => {
+    if (!Number.isFinite(deltaY) || deltaY === 0) {
+      return;
+    }
+
     const nextOffset = Math.max(0, scrollOffsetRef.current + deltaY);
+    scrollOffsetRef.current = nextOffset;
     scrollViewRef.current?.scrollTo({ y: nextOffset, animated: false });
   }, []);
 

--- a/apps/akari/utils/scrollHelpers.ts
+++ b/apps/akari/utils/scrollHelpers.ts
@@ -1,0 +1,46 @@
+import type { MutableRefObject } from 'react';
+
+type ScrollableRef = {
+  getScrollableNode?: () => HTMLElement | null;
+  getInnerViewNode?: () => HTMLElement | null;
+  getNativeScrollRef?: () => { getScrollableNode?: () => HTMLElement | null } | HTMLElement | null;
+};
+
+export function createContainsTarget(ref: MutableRefObject<any>) {
+  return (target: EventTarget | null) => {
+    if (!target || typeof (target as any).nodeType !== 'number') {
+      return false;
+    }
+
+    const scrollView = ref.current as ScrollableRef | null | undefined;
+
+    if (!scrollView) {
+      return true;
+    }
+
+    const potentialNodes: (HTMLElement | null | undefined)[] = [];
+
+    if (typeof scrollView.getScrollableNode === 'function') {
+      potentialNodes.push(scrollView.getScrollableNode());
+    }
+
+    if (typeof scrollView.getInnerViewNode === 'function') {
+      potentialNodes.push(scrollView.getInnerViewNode());
+    }
+
+    if (typeof scrollView.getNativeScrollRef === 'function') {
+      const nativeRef = scrollView.getNativeScrollRef();
+      if (nativeRef && typeof nativeRef === 'object') {
+        if ('getScrollableNode' in nativeRef && typeof nativeRef.getScrollableNode === 'function') {
+          potentialNodes.push(nativeRef.getScrollableNode());
+        }
+      }
+    }
+
+    if (potentialNodes.length === 0) {
+      return true;
+    }
+
+    return potentialNodes.some((node) => node && typeof node.contains === 'function' && node.contains(target as Node));
+  };
+}

--- a/apps/akari/utils/tabScrollRegistry.ts
+++ b/apps/akari/utils/tabScrollRegistry.ts
@@ -1,17 +1,31 @@
-type ScrollToTopHandler = () => void;
+type TabScrollHandler = {
+  scrollToTop?: () => void;
+  scrollBy?: (deltaY: number) => void;
+  containsTarget?: (target: EventTarget | null) => boolean;
+};
 
 class TabScrollRegistry {
-  private handlers: Record<string, ScrollToTopHandler> = {};
+  private handlers: Record<string, TabScrollHandler> = {};
 
-  register(tabName: string, handler: ScrollToTopHandler) {
+  register(tabName: string, handler: TabScrollHandler | (() => void)) {
+    if (typeof handler === 'function') {
+      this.handlers[tabName] = { scrollToTop: handler };
+      return;
+    }
+
     this.handlers[tabName] = handler;
   }
 
   handleTabPress(tabName: string) {
-    const handler = this.handlers[tabName];
-    if (handler) {
-      handler();
-    }
+    this.handlers[tabName]?.scrollToTop?.();
+  }
+
+  scrollBy(tabName: string, deltaY: number) {
+    this.handlers[tabName]?.scrollBy?.(deltaY);
+  }
+
+  isEventWithinScrollArea(tabName: string, target: EventTarget | null) {
+    return this.handlers[tabName]?.containsTarget?.(target) ?? false;
   }
 }
 


### PR DESCRIPTION
## Summary
- extend the tab scroll registry with `scrollBy` support and add helpers to detect whether wheel events originate inside a tab's scroll container
- hook the large-screen tab layout to delegate wheel scrolling and register each major tab screen with the enhanced registry
- update related unit tests to reflect the richer registration contract

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c9e18a5c10832ba2d4af1bca05d25b