### PR TITLE
feat: show clear sky block totals on profiles

### DIFF
--- a/apps/akari/__tests__/components/ProfileHeader.test.tsx
+++ b/apps/akari/__tests__/components/ProfileHeader.test.tsx
@@ -12,6 +12,7 @@ import { router } from 'expo-router';
 import { HandleHistoryModal } from '@/components/HandleHistoryModal';
 import { ProfileEditModal } from '@/components/ProfileEditModal';
 import { showAlert } from '@/utils/alert';
+import { useProfileBlocks } from '@/hooks/useProfileBlocks';
 
 jest.mock('@/hooks/useTranslation');
 jest.mock('@/contexts/LanguageContext');
@@ -19,6 +20,7 @@ jest.mock('@/hooks/useBorderColor');
 jest.mock('@/hooks/mutations/useFollowUser');
 jest.mock('@/hooks/mutations/useBlockUser');
 jest.mock('@/hooks/mutations/useUpdateProfile');
+jest.mock('@/hooks/useProfileBlocks');
 jest.mock('expo-router', () => ({ router: { push: jest.fn() } }));
 jest.mock('expo-image', () => ({ Image: jest.fn(() => null) }));
 jest.mock('@/components/Labels', () => ({ Labels: jest.fn(() => null) }));
@@ -43,6 +45,7 @@ const mockUseUpdateProfile = useUpdateProfile as jest.Mock;
 const mockHandleHistoryModal = HandleHistoryModal as jest.Mock;
 const mockProfileEditModal = ProfileEditModal as jest.Mock;
 const mockShowAlert = showAlert as jest.Mock;
+const mockUseProfileBlocks = useProfileBlocks as jest.Mock;
 
 const baseProfile = {
   handle: 'alice',
@@ -61,6 +64,11 @@ describe('ProfileHeader', () => {
     mockUseFollowUser.mockReturnValue({ mutateAsync: jest.fn() });
     mockUseBlockUser.mockReturnValue({ mutateAsync: jest.fn() });
     mockUseUpdateProfile.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+    mockUseProfileBlocks.mockReturnValue({
+      data: { blocking: 0, blocked: 0 },
+      isLoading: false,
+      isError: false,
+    });
     mockShowAlert.mockReset();
   });
 
@@ -94,6 +102,20 @@ describe('ProfileHeader', () => {
         }}
       />,
     );
+  });
+
+  it('renders block statistics from ClearSky', () => {
+    mockUseProfileBlocks.mockReturnValue({
+      data: { blocking: 12, blocked: 4 },
+      isLoading: false,
+      isError: false,
+    });
+
+    const { getByText } = render(<ProfileHeader profile={baseProfile} />);
+
+    expect(getByText('profile.blocksTitle')).toBeTruthy();
+    expect(getByText('profile.blockingLabel')).toBeTruthy();
+    expect(getByText('profile.blockedLabel')).toBeTruthy();
   });
 
   it('falls back to displayName and U when avatar missing', () => {

--- a/apps/akari/__tests__/components/ProfileHeader.test.tsx
+++ b/apps/akari/__tests__/components/ProfileHeader.test.tsx
@@ -113,9 +113,22 @@ describe('ProfileHeader', () => {
 
     const { getByText } = render(<ProfileHeader profile={baseProfile} />);
 
-    expect(getByText('profile.blocksTitle')).toBeTruthy();
-    expect(getByText('profile.blockingLabel')).toBeTruthy();
-    expect(getByText('profile.blockedLabel')).toBeTruthy();
+    const statsLine = getByText(/profile\.blocking/);
+
+    expect(statsLine.props.children).toContain('profile.blocking');
+    expect(statsLine.props.children).toContain('profile.blocked');
+  });
+
+  it('shows an error message when block totals fail to load', () => {
+    mockUseProfileBlocks.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    const { getByText } = render(<ProfileHeader profile={baseProfile} />);
+
+    expect(getByText('profile.blockStatsUnavailable')).toBeTruthy();
   });
 
   it('falls back to displayName and U when avatar missing', () => {

--- a/apps/akari/__tests__/hooks/useProfileBlocks.test.tsx
+++ b/apps/akari/__tests__/hooks/useProfileBlocks.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useProfileBlocks } from '@/hooks/useProfileBlocks';
+
+const mockGetBlocklistTotal = jest.fn();
+const mockGetSingleBlocklistTotal = jest.fn();
+
+jest.mock(
+  '@/clearsky-api',
+  () => ({
+    ClearSkyApi: jest.fn(() => ({
+      getBlocklistTotal: mockGetBlocklistTotal,
+      getSingleBlocklistTotal: mockGetSingleBlocklistTotal,
+    })),
+  }),
+  { virtual: true },
+);
+
+describe('useProfileBlocks', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fetches block totals from ClearSky', async () => {
+    mockGetBlocklistTotal.mockResolvedValue({
+      data: { count: 42 },
+    });
+    mockGetSingleBlocklistTotal.mockResolvedValue({
+      data: { count: 13 },
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useProfileBlocks('did:example:123'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockGetBlocklistTotal).toHaveBeenCalledWith('did:example:123');
+    expect(mockGetSingleBlocklistTotal).toHaveBeenCalledWith('did:example:123');
+    expect(result.current.data).toEqual({ blocking: 42, blocked: 13 });
+  });
+
+  it('throws an error when identifier is missing', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useProfileBlocks(undefined), { wrapper });
+
+    const fetchResult = await result.current.refetch();
+
+    expect(fetchResult.error).toBeInstanceOf(Error);
+    expect((fetchResult.error as Error).message).toBe('No identifier provided');
+    expect(mockGetBlocklistTotal).not.toHaveBeenCalled();
+    expect(mockGetSingleBlocklistTotal).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/components/ProfileHeader.tsx
+++ b/apps/akari/components/ProfileHeader.tsx
@@ -77,13 +77,37 @@ export function ProfileHeader({ profile, isOwnProfile = false, onDropdownToggle,
   const identifier = profile.did ?? profile.handle;
   const {
     data: blockTotals,
-    isLoading: isBlockTotalsLoading,
     isError: isBlockTotalsError,
   } = useProfileBlocks(identifier);
 
   const isFollowing = !!profile.viewer?.following;
   const isBlocking = !!profile.viewer?.blocking;
   const isBlockedBy = profile.viewer?.blockedBy;
+
+  const statsSegments = [
+    t('profile.posts', {
+      count: formatNumber(profile.postsCount || 0, currentLocale),
+    }),
+    t('profile.followers', {
+      count: formatNumber(profile.followersCount || 0, currentLocale),
+    }),
+    t('profile.following', {
+      count: formatNumber(profile.followsCount || 0, currentLocale),
+    }),
+  ];
+
+  if (blockTotals && !isBlockTotalsError) {
+    statsSegments.push(
+      t('profile.blocking', {
+        count: formatNumber(blockTotals.blocking, currentLocale),
+      }),
+      t('profile.blocked', {
+        count: formatNumber(blockTotals.blocked, currentLocale),
+      }),
+    );
+  }
+
+  const statsText = statsSegments.join(' • ');
 
   const handleFollow = async () => {
     if (!profile.did) return;
@@ -364,45 +388,11 @@ export function ProfileHeader({ profile, isOwnProfile = false, onDropdownToggle,
 
         {/* Stats */}
         <View style={styles.statsContainer}>
-          <ThemedText style={styles.statText}>
-            {t('profile.posts', {
-              count: formatNumber(profile.postsCount || 0, currentLocale),
-            })}{' '}
-            •{' '}
-            {t('profile.followers', {
-              count: formatNumber(profile.followersCount || 0, currentLocale),
-            })}{' '}
-            •{' '}
-            {t('profile.following', {
-              count: formatNumber(profile.followsCount || 0, currentLocale),
-            })}
-          </ThemedText>
-        </View>
-
-        <ThemedView style={[styles.blockStatsCard, { borderColor }]}>
-          <ThemedText style={styles.blockStatsTitle}>{t('profile.blocksTitle')}</ThemedText>
-          {isBlockTotalsLoading ? (
-            <ThemedText style={styles.blockStatsMessage}>{t('common.loading')}</ThemedText>
-          ) : isBlockTotalsError || !blockTotals ? (
+          <ThemedText style={styles.statText}>{statsText}</ThemedText>
+          {isBlockTotalsError ? (
             <ThemedText style={styles.blockStatsMessage}>{t('profile.blockStatsUnavailable')}</ThemedText>
-          ) : (
-            <View style={styles.blockStatsRow}>
-              <View style={styles.blockStatItem}>
-                <ThemedText style={styles.blockStatValue}>
-                  {formatNumber(blockTotals.blocking, currentLocale)}
-                </ThemedText>
-                <ThemedText style={styles.blockStatLabel}>{t('profile.blockingLabel')}</ThemedText>
-              </View>
-              <View style={[styles.blockStatDivider, { backgroundColor: borderColor }]} />
-              <View style={styles.blockStatItem}>
-                <ThemedText style={styles.blockStatValue}>
-                  {formatNumber(blockTotals.blocked, currentLocale)}
-                </ThemedText>
-                <ThemedText style={styles.blockStatLabel}>{t('profile.blockedLabel')}</ThemedText>
-              </View>
-            </View>
-          )}
-        </ThemedView>
+          ) : null}
+        </View>
 
         {/* Description */}
         {profile.description && (
@@ -577,52 +567,14 @@ const styles = StyleSheet.create({
   statsContainer: {
     marginBottom: 12,
   },
-  blockStatsCard: {
-    marginBottom: 12,
-    paddingVertical: 16,
-    paddingHorizontal: 20,
-    borderRadius: 12,
-    borderWidth: 1,
-  },
-  blockStatsTitle: {
-    fontSize: 16,
-    fontWeight: '600',
-  },
   blockStatsMessage: {
     fontSize: 14,
     opacity: 0.7,
-  },
-  blockStatsRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginTop: 8,
-  },
-  blockStatItem: {
-    flex: 1,
-    alignItems: 'center',
-  },
-  blockStatValue: {
-    fontSize: 20,
-    fontWeight: '600',
-  },
-  blockStatLabel: {
-    fontSize: 13,
-    opacity: 0.7,
     marginTop: 4,
-  },
-  blockStatDivider: {
-    width: 1,
-    alignSelf: 'stretch',
-    backgroundColor: 'rgba(0, 0, 0, 0.1)',
-    marginHorizontal: 16,
   },
   statText: {
     fontSize: 15,
     lineHeight: 20,
-  },
-  statNumber: {
-    fontWeight: 'bold',
   },
   description: {
     fontSize: 14,

--- a/apps/akari/components/ProfileHeader.tsx
+++ b/apps/akari/components/ProfileHeader.tsx
@@ -17,6 +17,7 @@ import { useFollowUser } from '@/hooks/mutations/useFollowUser';
 import { useUpdateProfile } from '@/hooks/mutations/useUpdateProfile';
 import { useBorderColor } from '@/hooks/useBorderColor';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useProfileBlocks } from '@/hooks/useProfileBlocks';
 import { showAlert } from '@/utils/alert';
 
 type ProfileHeaderProps = {
@@ -73,6 +74,12 @@ export function ProfileHeader({ profile, isOwnProfile = false, onDropdownToggle,
   const followMutation = useFollowUser();
   const blockMutation = useBlockUser();
   const updateProfileMutation = useUpdateProfile();
+  const identifier = profile.did ?? profile.handle;
+  const {
+    data: blockTotals,
+    isLoading: isBlockTotalsLoading,
+    isError: isBlockTotalsError,
+  } = useProfileBlocks(identifier);
 
   const isFollowing = !!profile.viewer?.following;
   const isBlocking = !!profile.viewer?.blocking;
@@ -372,6 +379,31 @@ export function ProfileHeader({ profile, isOwnProfile = false, onDropdownToggle,
           </ThemedText>
         </View>
 
+        <ThemedView style={[styles.blockStatsCard, { borderColor }]}>
+          <ThemedText style={styles.blockStatsTitle}>{t('profile.blocksTitle')}</ThemedText>
+          {isBlockTotalsLoading ? (
+            <ThemedText style={styles.blockStatsMessage}>{t('common.loading')}</ThemedText>
+          ) : isBlockTotalsError || !blockTotals ? (
+            <ThemedText style={styles.blockStatsMessage}>{t('profile.blockStatsUnavailable')}</ThemedText>
+          ) : (
+            <View style={styles.blockStatsRow}>
+              <View style={styles.blockStatItem}>
+                <ThemedText style={styles.blockStatValue}>
+                  {formatNumber(blockTotals.blocking, currentLocale)}
+                </ThemedText>
+                <ThemedText style={styles.blockStatLabel}>{t('profile.blockingLabel')}</ThemedText>
+              </View>
+              <View style={[styles.blockStatDivider, { backgroundColor: borderColor }]} />
+              <View style={styles.blockStatItem}>
+                <ThemedText style={styles.blockStatValue}>
+                  {formatNumber(blockTotals.blocked, currentLocale)}
+                </ThemedText>
+                <ThemedText style={styles.blockStatLabel}>{t('profile.blockedLabel')}</ThemedText>
+              </View>
+            </View>
+          )}
+        </ThemedView>
+
         {/* Description */}
         {profile.description && (
           <View style={styles.descriptionContainer}>
@@ -544,6 +576,46 @@ const styles = StyleSheet.create({
   },
   statsContainer: {
     marginBottom: 12,
+  },
+  blockStatsCard: {
+    marginBottom: 12,
+    paddingVertical: 16,
+    paddingHorizontal: 20,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  blockStatsTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  blockStatsMessage: {
+    fontSize: 14,
+    opacity: 0.7,
+  },
+  blockStatsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: 8,
+  },
+  blockStatItem: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  blockStatValue: {
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  blockStatLabel: {
+    fontSize: 13,
+    opacity: 0.7,
+    marginTop: 4,
+  },
+  blockStatDivider: {
+    width: 1,
+    alignSelf: 'stretch',
+    backgroundColor: 'rgba(0, 0, 0, 0.1)',
+    marginHorizontal: 16,
   },
   statText: {
     fontSize: 15,

--- a/apps/akari/hooks/useProfileBlocks.ts
+++ b/apps/akari/hooks/useProfileBlocks.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { ClearSkyApi } from '@/clearsky-api';
+
+type ProfileBlocks = {
+  blocking: number;
+  blocked: number;
+};
+
+/**
+ * Query hook for fetching ClearSky block totals for a user
+ */
+export function useProfileBlocks(identifier: string | undefined) {
+  return useQuery({
+    queryKey: ['profileBlocks', identifier],
+    queryFn: async (): Promise<ProfileBlocks> => {
+      if (!identifier) throw new Error('No identifier provided');
+
+      const api = new ClearSkyApi();
+      const [blocking, blocked] = await Promise.all([
+        api.getBlocklistTotal(identifier),
+        api.getSingleBlocklistTotal(identifier),
+      ]);
+
+      return {
+        blocking: blocking.data.count,
+        blocked: blocked.data.count,
+      };
+    },
+    enabled: !!identifier,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}

--- a/apps/akari/translations/ar.json
+++ b/apps/akari/translations/ar.json
@@ -174,8 +174,8 @@
       "posts": "المنشورات {{count}}",
       "followers": "المتابعون {{count}}",
       "following": "المتابَعون {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "الحسابات المحظورة {{count}}",
+      "blocked": "حسابات تحظرك {{count}}",
       "videos": "فيديوهات",
       "feeds": "التدفقات",
       "starterpacks": "حزم البداية",
@@ -204,7 +204,7 @@
       "handleHistory": "سجل المعرف",
       "noHandleHistory": "لا يوجد سجل للمعرف",
       "noHandleHistoryDescription": "لم يغيّر هذا المستخدم معرفه بعد.",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "تعذر تحميل بيانات الحظر"
     },
     "feed": {
       "loadingMorePosts": "جاري تحميل المزيد من المنشورات...",

--- a/apps/akari/translations/ar.json
+++ b/apps/akari/translations/ar.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "فشل في تحديث الملف الشخصي",
       "handleHistory": "سجل المعرف",
       "noHandleHistory": "لا يوجد سجل للمعرف",
-      "noHandleHistoryDescription": "لم يغيّر هذا المستخدم معرفه بعد."
+      "noHandleHistoryDescription": "لم يغيّر هذا المستخدم معرفه بعد.",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "جاري تحميل المزيد من المنشورات...",

--- a/apps/akari/translations/ar.json
+++ b/apps/akari/translations/ar.json
@@ -174,6 +174,8 @@
       "posts": "المنشورات {{count}}",
       "followers": "المتابعون {{count}}",
       "following": "المتابَعون {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "videos": "فيديوهات",
       "feeds": "التدفقات",
       "starterpacks": "حزم البداية",
@@ -202,9 +204,6 @@
       "handleHistory": "سجل المعرف",
       "noHandleHistory": "لا يوجد سجل للمعرف",
       "noHandleHistoryDescription": "لم يغيّر هذا المستخدم معرفه بعد.",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/cy.json
+++ b/apps/akari/translations/cy.json
@@ -174,8 +174,8 @@
       "posts": "Swyddi {{count}}",
       "followers": "Dilynwyr {{count}}",
       "following": "Dilyn {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "Yn blocio {{count}}",
+      "blocked": "Wedi'ch blocio gan {{count}}",
       "videos": "Fideos",
       "feeds": "Porthiant",
       "starterpacks": "Pecynnau Cychwyn",
@@ -204,7 +204,7 @@
       "handleHistory": "Hanes handlen",
       "noHandleHistory": "Dim hanes handlen",
       "noHandleHistoryDescription": "Nid yw'r defnyddiwr hwn wedi newid ei handlen eto.",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "Methu llwytho data blocio"
     },
     "feed": {
       "loadingMorePosts": "Wrth lwytho mwy o bostiadau...",

--- a/apps/akari/translations/cy.json
+++ b/apps/akari/translations/cy.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "Methu diweddaru proffil",
       "handleHistory": "Hanes handlen",
       "noHandleHistory": "Dim hanes handlen",
-      "noHandleHistoryDescription": "Nid yw'r defnyddiwr hwn wedi newid ei handlen eto."
+      "noHandleHistoryDescription": "Nid yw'r defnyddiwr hwn wedi newid ei handlen eto.",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "Wrth lwytho mwy o bostiadau...",

--- a/apps/akari/translations/cy.json
+++ b/apps/akari/translations/cy.json
@@ -174,6 +174,8 @@
       "posts": "Swyddi {{count}}",
       "followers": "Dilynwyr {{count}}",
       "following": "Dilyn {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "videos": "Fideos",
       "feeds": "Porthiant",
       "starterpacks": "Pecynnau Cychwyn",
@@ -202,9 +204,6 @@
       "handleHistory": "Hanes handlen",
       "noHandleHistory": "Dim hanes handlen",
       "noHandleHistoryDescription": "Nid yw'r defnyddiwr hwn wedi newid ei handlen eto.",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/de.json
+++ b/apps/akari/translations/de.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "Profil konnte nicht aktualisiert werden",
       "handleHistory": "Handle-Verlauf",
       "noHandleHistory": "Kein Handle-Verlauf",
-      "noHandleHistoryDescription": "Dieser Nutzer hat sein Handle noch nicht geändert."
+      "noHandleHistoryDescription": "Dieser Nutzer hat sein Handle noch nicht geändert.",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "Lade weitere Beiträge...",

--- a/apps/akari/translations/de.json
+++ b/apps/akari/translations/de.json
@@ -180,8 +180,8 @@
       "posts": "Beiträge {{count}}",
       "followers": "Follower {{count}}",
       "following": "Folgt {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "Blockierst {{count}}",
+      "blocked": "Blockiert von {{count}}",
       "youHaveBlockedUser": "Sie haben diesen Benutzer blockiert",
       "mutualBlock": "Sie haben sich gegenseitig blockiert",
       "copyLink": "Link kopieren",
@@ -204,7 +204,7 @@
       "handleHistory": "Handle-Verlauf",
       "noHandleHistory": "Kein Handle-Verlauf",
       "noHandleHistoryDescription": "Dieser Nutzer hat sein Handle noch nicht geändert.",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "Blockdaten konnten nicht geladen werden"
     },
     "feed": {
       "loadingMorePosts": "Lade weitere Beiträge...",

--- a/apps/akari/translations/de.json
+++ b/apps/akari/translations/de.json
@@ -180,6 +180,8 @@
       "posts": "Beiträge {{count}}",
       "followers": "Follower {{count}}",
       "following": "Folgt {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "youHaveBlockedUser": "Sie haben diesen Benutzer blockiert",
       "mutualBlock": "Sie haben sich gegenseitig blockiert",
       "copyLink": "Link kopieren",
@@ -202,9 +204,6 @@
       "handleHistory": "Handle-Verlauf",
       "noHandleHistory": "Kein Handle-Verlauf",
       "noHandleHistoryDescription": "Dieser Nutzer hat sein Handle noch nicht geändert.",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/en-US.json
+++ b/apps/akari/translations/en-US.json
@@ -174,6 +174,8 @@
       "posts": "Posts {{count}}",
       "followers": "Followers {{count}}",
       "following": "Following {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "videos": "Videos",
       "feeds": "Feeds",
       "starterpacks": "Starterpacks",
@@ -202,9 +204,6 @@
       "handleHistory": "Handle History",
       "noHandleHistory": "No handle history",
       "noHandleHistoryDescription": "This user hasn't changed their handle yet.",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/en-US.json
+++ b/apps/akari/translations/en-US.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "Failed to update profile",
       "handleHistory": "Handle History",
       "noHandleHistory": "No handle history",
-      "noHandleHistoryDescription": "This user hasn't changed their handle yet."
+      "noHandleHistoryDescription": "This user hasn't changed their handle yet.",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "Loading more posts...",

--- a/apps/akari/translations/en.json
+++ b/apps/akari/translations/en.json
@@ -166,6 +166,8 @@
       "posts": "Posts {{count}}",
       "followers": "Followers {{count}}",
       "following": "Following {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "noPosts": "No posts yet",
       "noLikes": "No likes yet",
       "noMedia": "No media yet",
@@ -202,9 +204,6 @@
       "handleHistory": "Handle History",
       "noHandleHistory": "No handle history",
       "noHandleHistoryDescription": "This user hasn't changed their handle yet.",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/en.json
+++ b/apps/akari/translations/en.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "Failed to update profile. Please try again.",
       "handleHistory": "Handle History",
       "noHandleHistory": "No handle history",
-      "noHandleHistoryDescription": "This user hasn't changed their handle yet."
+      "noHandleHistoryDescription": "This user hasn't changed their handle yet.",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "Loading more posts...",

--- a/apps/akari/translations/es.json
+++ b/apps/akari/translations/es.json
@@ -180,6 +180,8 @@
       "posts": "Publicaciones {{count}}",
       "followers": "Seguidores {{count}}",
       "following": "Siguiendo {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "youHaveBlockedUser": "Has bloqueado a este usuario",
       "mutualBlock": "Se han bloqueado mutuamente",
       "copyLink": "Copiar enlace",
@@ -202,9 +204,6 @@
       "handleHistory": "Historial del identificador",
       "noHandleHistory": "Sin historial de identificador",
       "noHandleHistoryDescription": "Este usuario aún no ha cambiado su identificador.",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/es.json
+++ b/apps/akari/translations/es.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "Error al actualizar perfil",
       "handleHistory": "Historial del identificador",
       "noHandleHistory": "Sin historial de identificador",
-      "noHandleHistoryDescription": "Este usuario aún no ha cambiado su identificador."
+      "noHandleHistoryDescription": "Este usuario aún no ha cambiado su identificador.",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "Cargando más publicaciones...",

--- a/apps/akari/translations/es.json
+++ b/apps/akari/translations/es.json
@@ -180,8 +180,8 @@
       "posts": "Publicaciones {{count}}",
       "followers": "Seguidores {{count}}",
       "following": "Siguiendo {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "Bloqueando {{count}}",
+      "blocked": "Bloqueado por {{count}}",
       "youHaveBlockedUser": "Has bloqueado a este usuario",
       "mutualBlock": "Se han bloqueado mutuamente",
       "copyLink": "Copiar enlace",
@@ -204,7 +204,7 @@
       "handleHistory": "Historial del identificador",
       "noHandleHistory": "Sin historial de identificador",
       "noHandleHistoryDescription": "Este usuario aún no ha cambiado su identificador.",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "No se pudieron cargar los datos de bloqueos"
     },
     "feed": {
       "loadingMorePosts": "Cargando más publicaciones...",

--- a/apps/akari/translations/fr.json
+++ b/apps/akari/translations/fr.json
@@ -180,8 +180,8 @@
       "posts": "Publications {{count}}",
       "followers": "Abonnés {{count}}",
       "following": "Abonnements {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "Comptes bloqués {{count}}",
+      "blocked": "Comptes qui vous bloquent {{count}}",
       "youHaveBlockedUser": "Vous avez bloqué cet utilisateur",
       "mutualBlock": "Vous vous êtes mutuellement bloqués",
       "copyLink": "Copier le lien",
@@ -204,7 +204,7 @@
       "handleHistory": "Historique du handle",
       "noHandleHistory": "Aucun historique de handle",
       "noHandleHistoryDescription": "Cet utilisateur n'a pas encore changé de handle.",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "Impossible de charger les données de blocage"
     },
     "feed": {
       "loadingMorePosts": "Chargement de plus de publications...",

--- a/apps/akari/translations/fr.json
+++ b/apps/akari/translations/fr.json
@@ -180,6 +180,8 @@
       "posts": "Publications {{count}}",
       "followers": "Abonnés {{count}}",
       "following": "Abonnements {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "youHaveBlockedUser": "Vous avez bloqué cet utilisateur",
       "mutualBlock": "Vous vous êtes mutuellement bloqués",
       "copyLink": "Copier le lien",
@@ -202,9 +204,6 @@
       "handleHistory": "Historique du handle",
       "noHandleHistory": "Aucun historique de handle",
       "noHandleHistoryDescription": "Cet utilisateur n'a pas encore changé de handle.",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/fr.json
+++ b/apps/akari/translations/fr.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "Échec de la mise à jour du profil",
       "handleHistory": "Historique du handle",
       "noHandleHistory": "Aucun historique de handle",
-      "noHandleHistoryDescription": "Cet utilisateur n'a pas encore changé de handle."
+      "noHandleHistoryDescription": "Cet utilisateur n'a pas encore changé de handle.",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "Chargement de plus de publications...",

--- a/apps/akari/translations/hi.json
+++ b/apps/akari/translations/hi.json
@@ -174,6 +174,8 @@
       "posts": "पोस्ट {{count}}",
       "followers": "फॉलोअर्स {{count}}",
       "following": "फॉलोइंग {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "videos": "वीडियो",
       "feeds": "फीड्स",
       "starterpacks": "स्टार्टरपैक्स",
@@ -202,9 +204,6 @@
       "handleHistory": "हैंडल इतिहास",
       "noHandleHistory": "कोई हैंडल इतिहास नहीं",
       "noHandleHistoryDescription": "इस उपयोगकर्ता ने अभी तक अपना हैंडल नहीं बदला है।",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/hi.json
+++ b/apps/akari/translations/hi.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "प्रोफ़ाइल अपडेट करने में विफल",
       "handleHistory": "हैंडल इतिहास",
       "noHandleHistory": "कोई हैंडल इतिहास नहीं",
-      "noHandleHistoryDescription": "इस उपयोगकर्ता ने अभी तक अपना हैंडल नहीं बदला है।"
+      "noHandleHistoryDescription": "इस उपयोगकर्ता ने अभी तक अपना हैंडल नहीं बदला है।",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "और पोस्ट लोड हो रही हैं...",

--- a/apps/akari/translations/hi.json
+++ b/apps/akari/translations/hi.json
@@ -174,8 +174,8 @@
       "posts": "पोस्ट {{count}}",
       "followers": "फॉलोअर्स {{count}}",
       "following": "फॉलोइंग {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "ब्लॉक किए गए खाते {{count}}",
+      "blocked": "आपको ब्लॉक करने वाले खाते {{count}}",
       "videos": "वीडियो",
       "feeds": "फीड्स",
       "starterpacks": "स्टार्टरपैक्स",
@@ -204,7 +204,7 @@
       "handleHistory": "हैंडल इतिहास",
       "noHandleHistory": "कोई हैंडल इतिहास नहीं",
       "noHandleHistoryDescription": "इस उपयोगकर्ता ने अभी तक अपना हैंडल नहीं बदला है।",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "ब्लॉक डेटा लोड नहीं हो सका"
     },
     "feed": {
       "loadingMorePosts": "और पोस्ट लोड हो रही हैं...",

--- a/apps/akari/translations/id.json
+++ b/apps/akari/translations/id.json
@@ -174,8 +174,8 @@
       "posts": "Postingan {{count}}",
       "followers": "Pengikut {{count}}",
       "following": "Mengikuti {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "Memblokir {{count}}",
+      "blocked": "Diblokir oleh {{count}}",
       "videos": "Video",
       "feeds": "Feed",
       "starterpacks": "Starterpacks",
@@ -204,7 +204,7 @@
       "handleHistory": "Riwayat handle",
       "noHandleHistory": "Tidak ada riwayat handle",
       "noHandleHistoryDescription": "Pengguna ini belum pernah mengganti handle-nya.",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "Tidak dapat memuat data blokir"
     },
     "feed": {
       "loadingMorePosts": "Memuat lebih banyak postingan...",

--- a/apps/akari/translations/id.json
+++ b/apps/akari/translations/id.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "Gagal memperbarui profil",
       "handleHistory": "Riwayat handle",
       "noHandleHistory": "Tidak ada riwayat handle",
-      "noHandleHistoryDescription": "Pengguna ini belum pernah mengganti handle-nya."
+      "noHandleHistoryDescription": "Pengguna ini belum pernah mengganti handle-nya.",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "Memuat lebih banyak postingan...",

--- a/apps/akari/translations/id.json
+++ b/apps/akari/translations/id.json
@@ -174,6 +174,8 @@
       "posts": "Postingan {{count}}",
       "followers": "Pengikut {{count}}",
       "following": "Mengikuti {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "videos": "Video",
       "feeds": "Feed",
       "starterpacks": "Starterpacks",
@@ -202,9 +204,6 @@
       "handleHistory": "Riwayat handle",
       "noHandleHistory": "Tidak ada riwayat handle",
       "noHandleHistoryDescription": "Pengguna ini belum pernah mengganti handle-nya.",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/it.json
+++ b/apps/akari/translations/it.json
@@ -174,8 +174,8 @@
       "posts": "Post {{count}}",
       "followers": "Follower {{count}}",
       "following": "Seguiti {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "Stai bloccando {{count}}",
+      "blocked": "Bloccato da {{count}}",
       "videos": "Video",
       "feeds": "Feed",
       "starterpacks": "Starterpacks",
@@ -204,7 +204,7 @@
       "handleHistory": "Cronologia dell'handle",
       "noHandleHistory": "Nessuna cronologia dell'handle",
       "noHandleHistoryDescription": "Questo utente non ha ancora cambiato handle.",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "Impossibile caricare i dati dei blocchi"
     },
     "feed": {
       "loadingMorePosts": "Caricamento di altri post...",

--- a/apps/akari/translations/it.json
+++ b/apps/akari/translations/it.json
@@ -174,6 +174,8 @@
       "posts": "Post {{count}}",
       "followers": "Follower {{count}}",
       "following": "Seguiti {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "videos": "Video",
       "feeds": "Feed",
       "starterpacks": "Starterpacks",
@@ -202,9 +204,6 @@
       "handleHistory": "Cronologia dell'handle",
       "noHandleHistory": "Nessuna cronologia dell'handle",
       "noHandleHistoryDescription": "Questo utente non ha ancora cambiato handle.",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/it.json
+++ b/apps/akari/translations/it.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "Errore nell'aggiornamento del profilo",
       "handleHistory": "Cronologia dell'handle",
       "noHandleHistory": "Nessuna cronologia dell'handle",
-      "noHandleHistoryDescription": "Questo utente non ha ancora cambiato handle."
+      "noHandleHistoryDescription": "Questo utente non ha ancora cambiato handle.",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "Caricamento di altri post...",

--- a/apps/akari/translations/ja.json
+++ b/apps/akari/translations/ja.json
@@ -174,8 +174,8 @@
       "posts": "投稿 {{count}}",
       "followers": "フォロワー {{count}}",
       "following": "フォロー中 {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "ブロック中 {{count}}",
+      "blocked": "あなたをブロックしている {{count}}",
       "videos": "動画",
       "feeds": "フィード",
       "starterpacks": "スターターパック",
@@ -204,7 +204,7 @@
       "handleHistory": "ハンドルの履歴",
       "noHandleHistory": "ハンドルの履歴はありません",
       "noHandleHistoryDescription": "このユーザーはまだハンドルを変更していません。",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "ブロックデータを読み込めませんでした"
     },
     "feed": {
       "loadingMorePosts": "さらに投稿を読み込み中...",

--- a/apps/akari/translations/ja.json
+++ b/apps/akari/translations/ja.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "プロフィールの更新に失敗しました",
       "handleHistory": "ハンドルの履歴",
       "noHandleHistory": "ハンドルの履歴はありません",
-      "noHandleHistoryDescription": "このユーザーはまだハンドルを変更していません。"
+      "noHandleHistoryDescription": "このユーザーはまだハンドルを変更していません。",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "さらに投稿を読み込み中...",

--- a/apps/akari/translations/ja.json
+++ b/apps/akari/translations/ja.json
@@ -174,6 +174,8 @@
       "posts": "投稿 {{count}}",
       "followers": "フォロワー {{count}}",
       "following": "フォロー中 {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "videos": "動画",
       "feeds": "フィード",
       "starterpacks": "スターターパック",
@@ -202,9 +204,6 @@
       "handleHistory": "ハンドルの履歴",
       "noHandleHistory": "ハンドルの履歴はありません",
       "noHandleHistoryDescription": "このユーザーはまだハンドルを変更していません。",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/ko.json
+++ b/apps/akari/translations/ko.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "프로필 업데이트에 실패했습니다",
       "handleHistory": "핸들 변경 기록",
       "noHandleHistory": "핸들 변경 기록이 없습니다",
-      "noHandleHistoryDescription": "이 사용자는 아직 핸들을 변경하지 않았습니다."
+      "noHandleHistoryDescription": "이 사용자는 아직 핸들을 변경하지 않았습니다.",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "더 많은 게시물 로딩 중...",

--- a/apps/akari/translations/ko.json
+++ b/apps/akari/translations/ko.json
@@ -174,6 +174,8 @@
       "posts": "게시물 {{count}}",
       "followers": "팔로워 {{count}}",
       "following": "팔로잉 {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "videos": "동영상",
       "feeds": "피드",
       "starterpacks": "스타터팩",
@@ -202,9 +204,6 @@
       "handleHistory": "핸들 변경 기록",
       "noHandleHistory": "핸들 변경 기록이 없습니다",
       "noHandleHistoryDescription": "이 사용자는 아직 핸들을 변경하지 않았습니다.",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/ko.json
+++ b/apps/akari/translations/ko.json
@@ -174,8 +174,8 @@
       "posts": "게시물 {{count}}",
       "followers": "팔로워 {{count}}",
       "following": "팔로잉 {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "차단한 계정 {{count}}",
+      "blocked": "나를 차단한 계정 {{count}}",
       "videos": "동영상",
       "feeds": "피드",
       "starterpacks": "스타터팩",
@@ -204,7 +204,7 @@
       "handleHistory": "핸들 변경 기록",
       "noHandleHistory": "핸들 변경 기록이 없습니다",
       "noHandleHistoryDescription": "이 사용자는 아직 핸들을 변경하지 않았습니다.",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "차단 데이터를 불러올 수 없습니다"
     },
     "feed": {
       "loadingMorePosts": "더 많은 게시물 로딩 중...",

--- a/apps/akari/translations/nl.json
+++ b/apps/akari/translations/nl.json
@@ -174,8 +174,8 @@
       "posts": "Berichten {{count}}",
       "followers": "Volgers {{count}}",
       "following": "Volgend {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "U blokkeert {{count}}",
+      "blocked": "Geblokkeerd door {{count}}",
       "videos": "Video's",
       "feeds": "Feeds",
       "starterpacks": "Starterpacks",
@@ -204,7 +204,7 @@
       "handleHistory": "Handle-geschiedenis",
       "noHandleHistory": "Geen handle-geschiedenis",
       "noHandleHistoryDescription": "Deze gebruiker heeft zijn handle nog niet gewijzigd.",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "Kan blokkeerdata niet laden"
     },
     "feed": {
       "loadingMorePosts": "Meer berichten laden...",

--- a/apps/akari/translations/nl.json
+++ b/apps/akari/translations/nl.json
@@ -174,6 +174,8 @@
       "posts": "Berichten {{count}}",
       "followers": "Volgers {{count}}",
       "following": "Volgend {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "videos": "Video's",
       "feeds": "Feeds",
       "starterpacks": "Starterpacks",
@@ -202,9 +204,6 @@
       "handleHistory": "Handle-geschiedenis",
       "noHandleHistory": "Geen handle-geschiedenis",
       "noHandleHistoryDescription": "Deze gebruiker heeft zijn handle nog niet gewijzigd.",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/nl.json
+++ b/apps/akari/translations/nl.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "Profiel kon niet worden bijgewerkt",
       "handleHistory": "Handle-geschiedenis",
       "noHandleHistory": "Geen handle-geschiedenis",
-      "noHandleHistoryDescription": "Deze gebruiker heeft zijn handle nog niet gewijzigd."
+      "noHandleHistoryDescription": "Deze gebruiker heeft zijn handle nog niet gewijzigd.",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "Meer berichten laden...",

--- a/apps/akari/translations/pl.json
+++ b/apps/akari/translations/pl.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "Nie udało się zaktualizować profilu",
       "handleHistory": "Historia handle'u",
       "noHandleHistory": "Brak historii handle'u",
-      "noHandleHistoryDescription": "Ten użytkownik jeszcze nie zmienił swojego handle'u."
+      "noHandleHistoryDescription": "Ten użytkownik jeszcze nie zmienił swojego handle'u.",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "Ładowanie większej liczby postów...",

--- a/apps/akari/translations/pl.json
+++ b/apps/akari/translations/pl.json
@@ -174,6 +174,8 @@
       "posts": "Posty {{count}}",
       "followers": "Obserwujący {{count}}",
       "following": "Obserwowani {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "videos": "Filmy",
       "feeds": "Kanały",
       "starterpacks": "Starterpacks",
@@ -202,9 +204,6 @@
       "handleHistory": "Historia handle'u",
       "noHandleHistory": "Brak historii handle'u",
       "noHandleHistoryDescription": "Ten użytkownik jeszcze nie zmienił swojego handle'u.",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/pl.json
+++ b/apps/akari/translations/pl.json
@@ -174,8 +174,8 @@
       "posts": "Posty {{count}}",
       "followers": "Obserwujący {{count}}",
       "following": "Obserwowani {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "Blokujesz {{count}}",
+      "blocked": "Blokują Cię {{count}}",
       "videos": "Filmy",
       "feeds": "Kanały",
       "starterpacks": "Starterpacks",
@@ -204,7 +204,7 @@
       "handleHistory": "Historia handle'u",
       "noHandleHistory": "Brak historii handle'u",
       "noHandleHistoryDescription": "Ten użytkownik jeszcze nie zmienił swojego handle'u.",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "Nie można wczytać danych blokowania"
     },
     "feed": {
       "loadingMorePosts": "Ładowanie większej liczby postów...",

--- a/apps/akari/translations/pt.json
+++ b/apps/akari/translations/pt.json
@@ -174,8 +174,8 @@
       "posts": "Publicações {{count}}",
       "followers": "Seguidores {{count}}",
       "following": "Seguindo {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "Bloqueando {{count}}",
+      "blocked": "Bloqueado por {{count}}",
       "videos": "Vídeos",
       "feeds": "Feeds",
       "starterpacks": "Starterpacks",
@@ -204,7 +204,7 @@
       "handleHistory": "Histórico do identificador",
       "noHandleHistory": "Nenhum histórico do identificador",
       "noHandleHistoryDescription": "Este usuário ainda não alterou o identificador.",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "Não foi possível carregar os dados de bloqueio"
     },
     "feed": {
       "loadingMorePosts": "Carregando mais publicações...",

--- a/apps/akari/translations/pt.json
+++ b/apps/akari/translations/pt.json
@@ -174,6 +174,8 @@
       "posts": "Publicações {{count}}",
       "followers": "Seguidores {{count}}",
       "following": "Seguindo {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "videos": "Vídeos",
       "feeds": "Feeds",
       "starterpacks": "Starterpacks",
@@ -202,9 +204,6 @@
       "handleHistory": "Histórico do identificador",
       "noHandleHistory": "Nenhum histórico do identificador",
       "noHandleHistoryDescription": "Este usuário ainda não alterou o identificador.",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/pt.json
+++ b/apps/akari/translations/pt.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "Erro ao atualizar perfil",
       "handleHistory": "Histórico do identificador",
       "noHandleHistory": "Nenhum histórico do identificador",
-      "noHandleHistoryDescription": "Este usuário ainda não alterou o identificador."
+      "noHandleHistoryDescription": "Este usuário ainda não alterou o identificador.",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "Carregando mais publicações...",

--- a/apps/akari/translations/ru.json
+++ b/apps/akari/translations/ru.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "Не удалось обновить профиль",
       "handleHistory": "История хэндла",
       "noHandleHistory": "Нет истории хэндла",
-      "noHandleHistoryDescription": "Этот пользователь ещё не менял свой хэндл."
+      "noHandleHistoryDescription": "Этот пользователь ещё не менял свой хэндл.",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "Загрузка дополнительных постов...",

--- a/apps/akari/translations/ru.json
+++ b/apps/akari/translations/ru.json
@@ -174,8 +174,8 @@
       "posts": "Посты {{count}}",
       "followers": "Подписчики {{count}}",
       "following": "Подписки {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "Блокируете {{count}}",
+      "blocked": "Вас блокируют {{count}}",
       "videos": "Видео",
       "feeds": "Ленты",
       "starterpacks": "Стартерпаки",
@@ -204,7 +204,7 @@
       "handleHistory": "История хэндла",
       "noHandleHistory": "Нет истории хэндла",
       "noHandleHistoryDescription": "Этот пользователь ещё не менял свой хэндл.",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "Не удалось загрузить данные блокировок"
     },
     "feed": {
       "loadingMorePosts": "Загрузка дополнительных постов...",

--- a/apps/akari/translations/ru.json
+++ b/apps/akari/translations/ru.json
@@ -174,6 +174,8 @@
       "posts": "Посты {{count}}",
       "followers": "Подписчики {{count}}",
       "following": "Подписки {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "videos": "Видео",
       "feeds": "Ленты",
       "starterpacks": "Стартерпаки",
@@ -202,9 +204,6 @@
       "handleHistory": "История хэндла",
       "noHandleHistory": "Нет истории хэндла",
       "noHandleHistoryDescription": "Этот пользователь ещё не менял свой хэндл.",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/th.json
+++ b/apps/akari/translations/th.json
@@ -174,6 +174,8 @@
       "posts": "โพสต์ {{count}}",
       "followers": "ผู้ติดตาม {{count}}",
       "following": "กำลังติดตาม {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "videos": "วิดีโอ",
       "feeds": "ฟีด",
       "starterpacks": "สตาร์เตอร์แพ็ค",
@@ -202,9 +204,6 @@
       "handleHistory": "ประวัติแฮนเดิล",
       "noHandleHistory": "ไม่มีประวัติแฮนเดิล",
       "noHandleHistoryDescription": "ผู้ใช้นี้ยังไม่เคยเปลี่ยนแฮนเดิล",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/th.json
+++ b/apps/akari/translations/th.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "อัปเดตโปรไฟล์ไม่สำเร็จ",
       "handleHistory": "ประวัติแฮนเดิล",
       "noHandleHistory": "ไม่มีประวัติแฮนเดิล",
-      "noHandleHistoryDescription": "ผู้ใช้นี้ยังไม่เคยเปลี่ยนแฮนเดิล"
+      "noHandleHistoryDescription": "ผู้ใช้นี้ยังไม่เคยเปลี่ยนแฮนเดิล",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "กำลังโหลดโพสต์เพิ่มเติม...",

--- a/apps/akari/translations/th.json
+++ b/apps/akari/translations/th.json
@@ -174,8 +174,8 @@
       "posts": "โพสต์ {{count}}",
       "followers": "ผู้ติดตาม {{count}}",
       "following": "กำลังติดตาม {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "กำลังบล็อก {{count}}",
+      "blocked": "บัญชีที่บล็อกคุณ {{count}}",
       "videos": "วิดีโอ",
       "feeds": "ฟีด",
       "starterpacks": "สตาร์เตอร์แพ็ค",
@@ -204,7 +204,7 @@
       "handleHistory": "ประวัติแฮนเดิล",
       "noHandleHistory": "ไม่มีประวัติแฮนเดิล",
       "noHandleHistoryDescription": "ผู้ใช้นี้ยังไม่เคยเปลี่ยนแฮนเดิล",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "ไม่สามารถโหลดข้อมูลการบล็อกได้"
     },
     "feed": {
       "loadingMorePosts": "กำลังโหลดโพสต์เพิ่มเติม...",

--- a/apps/akari/translations/tr.json
+++ b/apps/akari/translations/tr.json
@@ -174,8 +174,8 @@
       "posts": "Gönderiler {{count}}",
       "followers": "Takipçiler {{count}}",
       "following": "Takip {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "Engellediğiniz {{count}}",
+      "blocked": "Sizi engelleyen {{count}}",
       "videos": "Videolar",
       "feeds": "Akışlar",
       "starterpacks": "Başlangıç Paketleri",
@@ -204,7 +204,7 @@
       "handleHistory": "Kullanıcı adı geçmişi",
       "noHandleHistory": "Kullanıcı adı geçmişi yok",
       "noHandleHistoryDescription": "Bu kullanıcı henüz kullanıcı adını değiştirmedi.",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "Engelleme verileri yüklenemedi"
     },
     "feed": {
       "loadingMorePosts": "Daha fazla gönderi yükleniyor...",

--- a/apps/akari/translations/tr.json
+++ b/apps/akari/translations/tr.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "Profil güncellenemedi",
       "handleHistory": "Kullanıcı adı geçmişi",
       "noHandleHistory": "Kullanıcı adı geçmişi yok",
-      "noHandleHistoryDescription": "Bu kullanıcı henüz kullanıcı adını değiştirmedi."
+      "noHandleHistoryDescription": "Bu kullanıcı henüz kullanıcı adını değiştirmedi.",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "Daha fazla gönderi yükleniyor...",

--- a/apps/akari/translations/tr.json
+++ b/apps/akari/translations/tr.json
@@ -174,6 +174,8 @@
       "posts": "Gönderiler {{count}}",
       "followers": "Takipçiler {{count}}",
       "following": "Takip {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "videos": "Videolar",
       "feeds": "Akışlar",
       "starterpacks": "Başlangıç Paketleri",
@@ -202,9 +204,6 @@
       "handleHistory": "Kullanıcı adı geçmişi",
       "noHandleHistory": "Kullanıcı adı geçmişi yok",
       "noHandleHistoryDescription": "Bu kullanıcı henüz kullanıcı adını değiştirmedi.",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/vi.json
+++ b/apps/akari/translations/vi.json
@@ -174,6 +174,8 @@
       "posts": "Bài viết {{count}}",
       "followers": "Người theo dõi {{count}}",
       "following": "Đang theo dõi {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "videos": "Video",
       "feeds": "Nguồn cấp",
       "starterpacks": "Gói khởi đầu",
@@ -202,9 +204,6 @@
       "handleHistory": "Lịch sử tên định danh",
       "noHandleHistory": "Chưa có lịch sử tên định danh",
       "noHandleHistoryDescription": "Người dùng này chưa từng đổi tên định danh.",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/vi.json
+++ b/apps/akari/translations/vi.json
@@ -174,8 +174,8 @@
       "posts": "Bài viết {{count}}",
       "followers": "Người theo dõi {{count}}",
       "following": "Đang theo dõi {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "Đang chặn {{count}}",
+      "blocked": "Bị chặn bởi {{count}}",
       "videos": "Video",
       "feeds": "Nguồn cấp",
       "starterpacks": "Gói khởi đầu",
@@ -204,7 +204,7 @@
       "handleHistory": "Lịch sử tên định danh",
       "noHandleHistory": "Chưa có lịch sử tên định danh",
       "noHandleHistoryDescription": "Người dùng này chưa từng đổi tên định danh.",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "Không thể tải dữ liệu chặn"
     },
     "feed": {
       "loadingMorePosts": "Đang tải thêm bài đăng...",

--- a/apps/akari/translations/vi.json
+++ b/apps/akari/translations/vi.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "Cập nhật hồ sơ thất bại",
       "handleHistory": "Lịch sử tên định danh",
       "noHandleHistory": "Chưa có lịch sử tên định danh",
-      "noHandleHistoryDescription": "Người dùng này chưa từng đổi tên định danh."
+      "noHandleHistoryDescription": "Người dùng này chưa từng đổi tên định danh.",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "Đang tải thêm bài đăng...",

--- a/apps/akari/translations/zh-CN.json
+++ b/apps/akari/translations/zh-CN.json
@@ -174,6 +174,8 @@
       "posts": "帖子 {{count}}",
       "followers": "关注者 {{count}}",
       "following": "关注 {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "videos": "视频",
       "feeds": "信息流",
       "starterpacks": "入门包",
@@ -202,9 +204,6 @@
       "handleHistory": "用户名历史记录",
       "noHandleHistory": "暂无用户名历史记录",
       "noHandleHistoryDescription": "该用户尚未更改过用户名。",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {

--- a/apps/akari/translations/zh-CN.json
+++ b/apps/akari/translations/zh-CN.json
@@ -174,8 +174,8 @@
       "posts": "帖子 {{count}}",
       "followers": "关注者 {{count}}",
       "following": "关注 {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "您屏蔽的 {{count}}",
+      "blocked": "屏蔽您的 {{count}}",
       "videos": "视频",
       "feeds": "信息流",
       "starterpacks": "入门包",
@@ -204,7 +204,7 @@
       "handleHistory": "用户名历史记录",
       "noHandleHistory": "暂无用户名历史记录",
       "noHandleHistoryDescription": "该用户尚未更改过用户名。",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "无法加载屏蔽数据"
     },
     "feed": {
       "loadingMorePosts": "加载更多帖子...",

--- a/apps/akari/translations/zh-CN.json
+++ b/apps/akari/translations/zh-CN.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "更新个人资料失败",
       "handleHistory": "用户名历史记录",
       "noHandleHistory": "暂无用户名历史记录",
-      "noHandleHistoryDescription": "该用户尚未更改过用户名。"
+      "noHandleHistoryDescription": "该用户尚未更改过用户名。",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "加载更多帖子...",

--- a/apps/akari/translations/zh-TW.json
+++ b/apps/akari/translations/zh-TW.json
@@ -174,8 +174,8 @@
       "posts": "貼文 {{count}}",
       "followers": "追蹤者 {{count}}",
       "following": "追蹤 {{count}}",
-      "blocking": "Blocking {{count}}",
-      "blocked": "Blocked {{count}}",
+      "blocking": "您封鎖的 {{count}}",
+      "blocked": "封鎖您的 {{count}}",
       "videos": "影片",
       "feeds": "動態",
       "starterpacks": "入門包",
@@ -204,7 +204,7 @@
       "handleHistory": "使用者代號歷程",
       "noHandleHistory": "沒有使用者代號歷程",
       "noHandleHistoryDescription": "此使用者尚未變更過代號。",
-      "blockStatsUnavailable": "Unable to load block data"
+      "blockStatsUnavailable": "無法載入封鎖資料"
     },
     "feed": {
       "loadingMorePosts": "載入更多貼文...",

--- a/apps/akari/translations/zh-TW.json
+++ b/apps/akari/translations/zh-TW.json
@@ -201,7 +201,11 @@
       "profileUpdateError": "更新個人資料失敗",
       "handleHistory": "使用者代號歷程",
       "noHandleHistory": "沒有使用者代號歷程",
-      "noHandleHistoryDescription": "此使用者尚未變更過代號。"
+      "noHandleHistoryDescription": "此使用者尚未變更過代號。",
+      "blocksTitle": "Blocks",
+      "blockingLabel": "Blocking",
+      "blockedLabel": "Blocked",
+      "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {
       "loadingMorePosts": "載入更多貼文...",

--- a/apps/akari/translations/zh-TW.json
+++ b/apps/akari/translations/zh-TW.json
@@ -174,6 +174,8 @@
       "posts": "貼文 {{count}}",
       "followers": "追蹤者 {{count}}",
       "following": "追蹤 {{count}}",
+      "blocking": "Blocking {{count}}",
+      "blocked": "Blocked {{count}}",
       "videos": "影片",
       "feeds": "動態",
       "starterpacks": "入門包",
@@ -202,9 +204,6 @@
       "handleHistory": "使用者代號歷程",
       "noHandleHistory": "沒有使用者代號歷程",
       "noHandleHistoryDescription": "此使用者尚未變更過代號。",
-      "blocksTitle": "Blocks",
-      "blockingLabel": "Blocking",
-      "blockedLabel": "Blocked",
       "blockStatsUnavailable": "Unable to load block data"
     },
     "feed": {


### PR DESCRIPTION
## Summary
- surface ClearSky block totals in the profile header so profiles show blocking and blocked counts
- add a dedicated React Query hook and accompanying tests for fetching ClearSky block totals
- extend translations with strings used by the new block totals card

## Testing
- npm run test:coverage
- npm run validate-translations --prefix apps/akari

------
https://chatgpt.com/codex/tasks/task_e_68cdad8cfcb0832b9581a359bbf009b0