### PR TITLE
fix: submit auth form with enter key

### DIFF
--- a/apps/akari/__tests__/app/(auth)/signin.test.tsx
+++ b/apps/akari/__tests__/app/(auth)/signin.test.tsx
@@ -209,6 +209,36 @@ describe('AuthScreen', () => {
     expect(mockRouterReplace).toHaveBeenCalledWith('/(tabs)');
   });
 
+  it('submits sign in when pressing enter on the password input', async () => {
+    const utils = renderScreen();
+
+    fillCredentials(utils);
+    fireEvent(utils.getByPlaceholderText(passwordPlaceholder), 'submitEditing');
+
+    await waitFor(() => {
+      expect(signInMutate).toHaveBeenCalledWith({
+        identifier: 'user',
+        password: 'password',
+        pdsUrl: 'https://pds',
+      });
+    });
+  });
+
+  it('submits sign in when pressing enter on the handle input', async () => {
+    const utils = renderScreen();
+
+    fillCredentials(utils);
+    fireEvent(utils.getByPlaceholderText(handlePlaceholder), 'submitEditing');
+
+    await waitFor(() => {
+      expect(signInMutate).toHaveBeenCalledWith({
+        identifier: 'user',
+        password: 'password',
+        pdsUrl: 'https://pds',
+      });
+    });
+  });
+
   it('signs in and routes to settings when adding an account', async () => {
     mockUseCurrentAccount.mockReturnValue({ data: { did: 'did:existing' } });
     const utils = renderScreen();

--- a/apps/akari/app/(auth)/signin.tsx
+++ b/apps/akari/app/(auth)/signin.tsx
@@ -181,6 +181,19 @@ export default function AuthScreen() {
   const isSignUp = mode === 'signup';
   const isLoading = signInMutation.isPending;
 
+  const submitAuth = () => {
+    if (isLoading) {
+      return;
+    }
+
+    if (isSignUp) {
+      void handleSignUp();
+      return;
+    }
+
+    void handleSignIn();
+  };
+
   const panelTitle = useMemo(() => {
     if (currentAccount) {
       return t('common.addAccount');
@@ -247,6 +260,8 @@ export default function AuthScreen() {
                   autoCapitalize="none"
                   autoCorrect={false}
                   autoComplete="off"
+                  returnKeyType="done"
+                  onSubmitEditing={submitAuth}
                 />
                 <ThemedText style={[styles.helperText, { color: helperColor }]}>
                   {t('auth.handleHelperText')}
@@ -265,6 +280,8 @@ export default function AuthScreen() {
                   autoCapitalize="none"
                   autoCorrect={false}
                   autoComplete="off"
+                  returnKeyType="done"
+                  onSubmitEditing={submitAuth}
                 />
                 <ThemedText style={[styles.helperText, { color: helperColor }]}>
                   {t('auth.appPasswordHelperText')}


### PR DESCRIPTION
## Summary
- allow the sign-in inputs to submit the form when pressing enter without moving focus to the next field
- cover the handle field submit flow with a dedicated sign-in test

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68cdac5542a8832bb2ab39c62ed99e8c