### PR TITLE
feat: unify app theming for light mode

### DIFF
--- a/apps/akari/__tests__/components/ProfileDropdown.test.tsx
+++ b/apps/akari/__tests__/components/ProfileDropdown.test.tsx
@@ -2,23 +2,29 @@ import { fireEvent, render } from '@testing-library/react-native';
 
 import { ProfileDropdown } from '@/components/ProfileDropdown';
 import { useTranslation } from '@/hooks/useTranslation';
-import { useThemeColor } from '@/hooks/useThemeColor';
 import { useBorderColor } from '@/hooks/useBorderColor';
+import { useAppTheme, themes } from '@/theme';
 
 jest.mock('@/hooks/useTranslation');
-jest.mock('@/hooks/useThemeColor');
 jest.mock('@/hooks/useBorderColor');
+jest.mock('@/theme', () => {
+  const actual = jest.requireActual('@/theme');
+  return {
+    ...actual,
+    useAppTheme: jest.fn(),
+  };
+});
 
 const mockUseTranslation = useTranslation as jest.Mock;
-const mockUseThemeColor = useThemeColor as jest.Mock;
 const mockUseBorderColor = useBorderColor as jest.Mock;
+const mockUseAppTheme = useAppTheme as jest.Mock;
 
 describe('ProfileDropdown', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseTranslation.mockReturnValue({ t: (key: string) => key });
-    mockUseThemeColor.mockReturnValue('#fff');
     mockUseBorderColor.mockReturnValue('#ccc');
+    mockUseAppTheme.mockReturnValue(themes.light);
   });
 
   it('does not render when not visible', () => {

--- a/apps/akari/__tests__/components/ProfileHeader.test.tsx
+++ b/apps/akari/__tests__/components/ProfileHeader.test.tsx
@@ -12,6 +12,7 @@ import { router } from 'expo-router';
 import { HandleHistoryModal } from '@/components/HandleHistoryModal';
 import { ProfileEditModal } from '@/components/ProfileEditModal';
 import { showAlert } from '@/utils/alert';
+import { useAppTheme, themes } from '@/theme';
 
 jest.mock('@/hooks/useTranslation');
 jest.mock('@/contexts/LanguageContext');
@@ -26,6 +27,13 @@ jest.mock('@/components/RichText', () => ({ RichText: jest.fn(() => null) }));
 jest.mock('@/components/HandleHistoryModal', () => ({ HandleHistoryModal: jest.fn(() => null) }));
 jest.mock('@/components/ProfileEditModal', () => ({ ProfileEditModal: jest.fn(() => null) }));
 jest.mock('@/utils/alert', () => ({ showAlert: jest.fn() }));
+jest.mock('@/theme', () => {
+  const actual = jest.requireActual('@/theme');
+  return {
+    ...actual,
+    useAppTheme: jest.fn(),
+  };
+});
 jest.mock('@/components/ui/IconSymbol', () => {
   const React = require('react');
   const { Text } = require('react-native');
@@ -43,6 +51,7 @@ const mockUseUpdateProfile = useUpdateProfile as jest.Mock;
 const mockHandleHistoryModal = HandleHistoryModal as jest.Mock;
 const mockProfileEditModal = ProfileEditModal as jest.Mock;
 const mockShowAlert = showAlert as jest.Mock;
+const mockUseAppTheme = useAppTheme as jest.Mock;
 
 const baseProfile = {
   handle: 'alice',
@@ -62,6 +71,7 @@ describe('ProfileHeader', () => {
     mockUseBlockUser.mockReturnValue({ mutateAsync: jest.fn() });
     mockUseUpdateProfile.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
     mockShowAlert.mockReset();
+    mockUseAppTheme.mockReturnValue(themes.light);
   });
 
   it('opens handle history modal when handle is pressed', () => {

--- a/apps/akari/__tests__/components/RichText.test.tsx
+++ b/apps/akari/__tests__/components/RichText.test.tsx
@@ -87,7 +87,16 @@ describe('RichText', () => {
       { type: 'autolink', url: 'https://example.com', raw: 'https://example.com' },
     ]);
     render(<RichText text="@user https://example.com" />);
-    const tintCalls = mockUseThemeColor.mock.calls.filter(([, key]) => key === 'tint');
-    expect(tintCalls).toHaveLength(2);
+    const tintPaletteCalls = mockUseThemeColor.mock.calls.filter(([palette, key]) => {
+      return (
+        key === 'tint' &&
+        palette &&
+        typeof palette === 'object' &&
+        'light' in palette &&
+        (palette as any).light === '#007AFF' &&
+        (palette as any).dark === '#0A84FF'
+      );
+    });
+    expect(tintPaletteCalls.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/apps/akari/__tests__/components/TabBadge.test.tsx
+++ b/apps/akari/__tests__/components/TabBadge.test.tsx
@@ -73,12 +73,13 @@ describe('TabBadge', () => {
   it('uses theme colors for background and text', () => {
     const TabBadge = loadTabBadge();
 
-    const { getByText } = render(<TabBadge count={1} />);
-    const textInstance = getByText('1');
-    const badgeInstance = textInstance.parent as { props: { style?: unknown } } | null;
-    expect(badgeInstance).toBeTruthy();
-    const badgeStyle = StyleSheet.flatten(badgeInstance?.props.style);
-    const textStyle = StyleSheet.flatten((textInstance as any).props.style);
+    const { toJSON } = render(<TabBadge count={1} />);
+    const tree = toJSON() as { props: { style?: unknown }; children?: any[] } | null;
+    expect(tree).not.toBeNull();
+
+    const badgeStyle = StyleSheet.flatten(tree?.props.style);
+    const textElement = tree?.children?.[0] as { props?: { style?: unknown } } | undefined;
+    const textStyle = StyleSheet.flatten(textElement?.props?.style);
 
     expect(badgeStyle.backgroundColor).toBe('#ff3b30');
     expect(textStyle.color).toBe('#ffffff');

--- a/apps/akari/__tests__/components/TabBadge.test.tsx
+++ b/apps/akari/__tests__/components/TabBadge.test.tsx
@@ -1,10 +1,10 @@
 import { render } from '@testing-library/react-native';
 import { StyleSheet } from 'react-native';
 
-import { useThemeColor } from '@/hooks/useThemeColor';
+import { useAppTheme } from '@/theme';
 
-jest.mock('@/hooks/useThemeColor');
-const mockUseThemeColor = useThemeColor as jest.Mock;
+jest.mock('@/theme');
+const mockUseAppTheme = useAppTheme as jest.Mock;
 
 const loadTabBadge = () => {
   let TabBadge: any;
@@ -23,7 +23,12 @@ const loadTabBadge = () => {
 describe('TabBadge', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseThemeColor.mockImplementation((colors) => colors.light);
+    mockUseAppTheme.mockReturnValue({
+      colors: {
+        danger: '#ff3b30',
+        inverseText: '#ffffff',
+      },
+    });
   });
 
   it('returns null when count is zero', () => {
@@ -65,20 +70,18 @@ describe('TabBadge', () => {
     expect(style.height).toBe(20);
   });
 
-  it('calls useThemeColor for background and text colors', () => {
+  it('uses theme colors for background and text', () => {
     const TabBadge = loadTabBadge();
 
-    render(<TabBadge count={1} />);
-    expect(mockUseThemeColor).toHaveBeenNthCalledWith(
-      1,
-      { light: '#ff3b30', dark: '#ff453a' },
-      'tint',
-    );
-    expect(mockUseThemeColor).toHaveBeenNthCalledWith(
-      2,
-      { light: '#ffffff', dark: '#ffffff' },
-      'text',
-    );
+    const { getByText } = render(<TabBadge count={1} />);
+    const textInstance = getByText('1');
+    const badgeInstance = textInstance.parent as { props: { style?: unknown } } | null;
+    expect(badgeInstance).toBeTruthy();
+    const badgeStyle = StyleSheet.flatten(badgeInstance?.props.style);
+    const textStyle = StyleSheet.flatten((textInstance as any).props.style);
+
+    expect(badgeStyle.backgroundColor).toBe('#ff3b30');
+    expect(textStyle.color).toBe('#ffffff');
   });
 
   it('uses Android offsets for badge positioning', () => {

--- a/apps/akari/__tests__/components/TabBar.test.tsx
+++ b/apps/akari/__tests__/components/TabBar.test.tsx
@@ -2,21 +2,27 @@ import { fireEvent, render } from '@testing-library/react-native';
 
 import { TabBar } from '@/components/TabBar';
 import { useBorderColor } from '@/hooks/useBorderColor';
-import { useThemeColor } from '@/hooks/useThemeColor';
+import { useAppTheme } from '@/theme';
 
 jest.mock('@/hooks/useBorderColor');
-jest.mock('@/hooks/useThemeColor');
+jest.mock('@/theme');
 
 const mockUseBorderColor = useBorderColor as jest.Mock;
-const mockUseThemeColor = useThemeColor as jest.Mock;
+const mockUseAppTheme = useAppTheme as jest.Mock;
 
 describe('TabBar', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseBorderColor.mockReturnValue('#ccc');
-    mockUseThemeColor.mockImplementation(
-      (props: { light?: string; dark?: string }) => props?.light ?? props?.dark ?? '#000'
-    );
+    mockUseAppTheme.mockReturnValue({
+      colors: {
+        surface: '#FFFFFF',
+        textMuted: '#6B7280',
+        text: '#111827',
+        accent: '#7C8CF9',
+        shadow: 'rgba(0, 0, 0, 0.1)',
+      },
+    });
   });
 
   const flattenStyles = (style: unknown): any[] =>

--- a/apps/akari/__tests__/components/ThemedText.test.tsx
+++ b/apps/akari/__tests__/components/ThemedText.test.tsx
@@ -10,7 +10,13 @@ const mockUseThemeColor = useThemeColor as jest.Mock;
 describe('ThemedText', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseThemeColor.mockImplementation((colors) => colors.light ?? '#fff');
+    mockUseThemeColor.mockImplementation((colors, colorName) => {
+      if (colorName === 'tint') {
+        return '#0a7ea4';
+      }
+
+      return colors.light ?? '#fff';
+    });
   });
 
   it('renders with default style', () => {

--- a/apps/akari/__tests__/components/profile/FeedsTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/FeedsTab.test.tsx
@@ -3,14 +3,20 @@ import { FlatList, Text } from 'react-native';
 
 import { FeedsTab } from '@/components/profile/FeedsTab';
 import { useAuthorFeeds } from '@/hooks/queries/useAuthorFeeds';
-import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useAppTheme, themes } from '@/theme';
 
 jest.mock('@/hooks/queries/useAuthorFeeds');
 
 jest.mock('@/hooks/useTranslation');
 
-jest.mock('@/hooks/useThemeColor');
+jest.mock('@/theme', () => {
+  const actual = jest.requireActual('@/theme');
+  return {
+    ...actual,
+    useAppTheme: jest.fn(),
+  };
+});
 
 jest.mock('@/components/skeletons', () => {
   const { Text } = require('react-native');
@@ -24,15 +30,13 @@ jest.mock('@/components/ui/IconSymbol', () => {
 
 const mockUseAuthorFeeds = useAuthorFeeds as jest.Mock;
 const mockUseTranslation = useTranslation as jest.Mock;
-const mockUseThemeColor = useThemeColor as jest.Mock;
+const mockUseAppTheme = useAppTheme as jest.Mock;
 
 describe('FeedsTab', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseTranslation.mockReturnValue({ t: (k: string) => k });
-    mockUseThemeColor.mockImplementation((colors) =>
-      typeof colors === 'string' ? colors : colors.light,
-    );
+    mockUseAppTheme.mockReturnValue(themes.light);
   });
 
   it('shows skeleton while loading', () => {

--- a/apps/akari/__tests__/components/profile/StarterpacksTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/StarterpacksTab.test.tsx
@@ -3,26 +3,32 @@ import { FlatList, Text } from 'react-native';
 
 import { StarterpacksTab } from '@/components/profile/StarterpacksTab';
 import { useAuthorStarterpacks } from '@/hooks/queries/useAuthorStarterpacks';
-import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useAppTheme, themes } from '@/theme';
 
 jest.mock('@/hooks/queries/useAuthorStarterpacks');
-jest.mock('@/hooks/useThemeColor');
 jest.mock('@/hooks/useTranslation');
+jest.mock('@/theme', () => {
+  const actual = jest.requireActual('@/theme');
+  return {
+    ...actual,
+    useAppTheme: jest.fn(),
+  };
+});
 jest.mock('@/components/skeletons', () => {
   const { Text } = require('react-native');
   return { FeedSkeleton: () => <Text>feed skeleton</Text> };
 });
 
 const mockUseAuthorStarterpacks = useAuthorStarterpacks as jest.Mock;
-const mockUseThemeColor = useThemeColor as jest.Mock;
 const mockUseTranslation = useTranslation as jest.Mock;
+const mockUseAppTheme = useAppTheme as jest.Mock;
 
 describe('StarterpacksTab', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseThemeColor.mockImplementation((colors) => colors.light);
     mockUseTranslation.mockReturnValue({ t: (key: string) => key });
+    mockUseAppTheme.mockReturnValue(themes.light);
   });
 
   it('shows loading skeleton while fetching data', () => {

--- a/apps/akari/__tests__/hooks/useBorderColor.test.ts
+++ b/apps/akari/__tests__/hooks/useBorderColor.test.ts
@@ -1,38 +1,34 @@
 import { renderHook } from '@testing-library/react-native';
 
 import { useBorderColor } from '@/hooks/useBorderColor';
-import { useThemeColor } from '@/hooks/useThemeColor';
+import { useAppTheme } from '@/theme';
 
-jest.mock('@/hooks/useThemeColor', () => ({
-  useThemeColor: jest.fn(),
+jest.mock('@/theme', () => ({
+  useAppTheme: jest.fn(),
 }));
 
-const mockUseThemeColor = useThemeColor as jest.Mock;
+const mockUseAppTheme = useAppTheme as jest.Mock;
 
 describe('useBorderColor', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseAppTheme.mockReturnValue({
+      colors: {
+        border: '#e5e7eb',
+        borderMuted: '#d1d5db',
+      },
+    });
   });
 
-  it('returns the value from useThemeColor', () => {
-    mockUseThemeColor.mockReturnValue('border-value');
-
+  it('returns the default border color', () => {
     const { result } = renderHook(() => useBorderColor());
 
-    expect(result.current).toBe('border-value');
+    expect(result.current).toBe('#e5e7eb');
   });
 
-  it('delegates to useThemeColor with the border palette', () => {
-    mockUseThemeColor.mockReturnValue('border-value');
+  it('returns the muted border color when requested', () => {
+    const { result } = renderHook(() => useBorderColor('muted'));
 
-    renderHook(() => useBorderColor());
-
-    expect(mockUseThemeColor).toHaveBeenCalledWith(
-      {
-        light: '#e8eaed',
-        dark: '#2d3133',
-      },
-      'background',
-    );
+    expect(result.current).toBe('#d1d5db');
   });
 });

--- a/apps/akari/__tests__/hooks/useColorScheme.web.test.tsx
+++ b/apps/akari/__tests__/hooks/useColorScheme.web.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, waitFor } from '@testing-library/react-native';
+import { act, render, waitFor } from '@testing-library/react-native';
 
 jest.mock('react-native/Libraries/Utilities/useColorScheme', () => ({
   __esModule: true,
@@ -13,6 +13,45 @@ type ColorScheme = ReturnType<typeof useColorScheme>;
 
 const mockUseNativeColorScheme = nativeUseColorScheme as jest.Mock;
 
+type MatchMediaController = {
+  dispatchChange: (matches: boolean) => void;
+};
+
+function createMatchMedia(matches: boolean): MatchMediaController {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+
+  const query = {
+    matches,
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addListener: jest.fn((listener: (event: MediaQueryListEvent) => void) => {
+      listeners.add(listener);
+    }),
+    removeListener: jest.fn((listener: (event: MediaQueryListEvent) => void) => {
+      listeners.delete(listener);
+    }),
+    addEventListener: jest.fn((_, listener: (event: MediaQueryListEvent) => void) => {
+      listeners.add(listener);
+    }),
+    removeEventListener: jest.fn((_, listener: (event: MediaQueryListEvent) => void) => {
+      listeners.delete(listener);
+    }),
+    dispatchEvent: jest.fn(),
+  } as unknown as MediaQueryList;
+
+  const dispatchChange = (nextMatches: boolean) => {
+    (query as unknown as { matches: boolean }).matches = nextMatches;
+    const event = { matches: nextMatches } as MediaQueryListEvent;
+    listeners.forEach((listener) => listener(event));
+  };
+
+  (window as unknown as { matchMedia: (query: string) => MediaQueryList }).matchMedia = jest
+    .fn(() => query)
+    .mockName('matchMedia');
+
+  return { dispatchChange: (nextMatches: boolean) => act(() => dispatchChange(nextMatches)) };
+}
+
 function TestComponent({ onRender }: { onRender: (value: ColorScheme) => void }) {
   const scheme = useColorScheme();
   onRender(scheme);
@@ -20,12 +59,19 @@ function TestComponent({ onRender }: { onRender: (value: ColorScheme) => void })
 }
 
 describe('useColorScheme (web)', () => {
+  const originalMatchMedia = window.matchMedia;
+
   afterEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: originalMatchMedia,
+    });
     jest.clearAllMocks();
   });
 
   it('returns light before hydration when effects have not run', () => {
     mockUseNativeColorScheme.mockReturnValue('dark');
+    createMatchMedia(true);
 
     const renders: ColorScheme[] = [];
 
@@ -34,8 +80,9 @@ describe('useColorScheme (web)', () => {
     expect(renders[0]).toBe('light');
   });
 
-  it('returns the native color scheme after hydration', async () => {
-    mockUseNativeColorScheme.mockReturnValue('dark');
+  it('syncs with the browser color scheme after hydration', async () => {
+    mockUseNativeColorScheme.mockReturnValue('light');
+    createMatchMedia(true);
 
     const renders: ColorScheme[] = [];
 
@@ -46,15 +93,39 @@ describe('useColorScheme (web)', () => {
     });
   });
 
-  it('passes through null from the native hook once hydrated', async () => {
-    mockUseNativeColorScheme.mockReturnValue(null);
+  it('updates when the browser color scheme changes', async () => {
+    mockUseNativeColorScheme.mockReturnValue('light');
+    const controller = createMatchMedia(false);
 
     const renders: ColorScheme[] = [];
 
     render(<TestComponent onRender={(value) => renders.push(value)} />);
 
     await waitFor(() => {
-      expect(renders[renders.length - 1]).toBeNull();
+      expect(renders[renders.length - 1]).toBe('light');
+    });
+
+    controller.dispatchChange(true);
+
+    await waitFor(() => {
+      expect(renders[renders.length - 1]).toBe('dark');
+    });
+  });
+
+  it('falls back to the native hook when matchMedia is unavailable', async () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: undefined,
+    });
+
+    mockUseNativeColorScheme.mockReturnValue('dark');
+
+    const renders: ColorScheme[] = [];
+
+    render(<TestComponent onRender={(value) => renders.push(value)} />);
+
+    await waitFor(() => {
+      expect(renders[renders.length - 1]).toBe('dark');
     });
   });
 });

--- a/apps/akari/app/(tabs)/_layout.tsx
+++ b/apps/akari/app/(tabs)/_layout.tsx
@@ -16,7 +16,7 @@ import { useUnreadNotificationsCount } from '@/hooks/queries/useUnreadNotificati
 import { useBorderColor } from '@/hooks/useBorderColor';
 import { usePushNotifications } from '@/hooks/usePushNotifications';
 import { useResponsive } from '@/hooks/useResponsive';
-import { useThemeColor } from '@/hooks/useThemeColor';
+import { useAppTheme } from '@/theme';
 import { tabScrollRegistry } from '@/utils/tabScrollRegistry';
 
 /**
@@ -59,10 +59,11 @@ export default function TabLayout() {
   const { data: unreadMessagesCount = 0 } = useUnreadMessagesCount();
   const { data: unreadNotificationsCount = 0 } = useUnreadNotificationsCount();
   const [isAccountSwitcherVisible, setAccountSwitcherVisible] = useState(false);
+  const { colors } = useAppTheme();
   const borderColor = useBorderColor();
-  const accentColor = useThemeColor({ light: '#7C8CF9', dark: '#7C8CF9' }, 'tint');
-  const inactiveTint = useThemeColor({ light: '#6B7280', dark: '#9CA3AF' }, 'text');
-  const tabBarSurface = useThemeColor({ light: '#F3F4F6', dark: '#0B0F19' }, 'background');
+  const accentColor = colors.accent;
+  const inactiveTint = colors.textMuted;
+  const tabBarSurface = colors.surface;
   const tabBarStyle = {
     borderTopWidth: StyleSheet.hairlineWidth,
     borderColor,
@@ -70,7 +71,7 @@ export default function TabLayout() {
     paddingTop: 8,
     paddingBottom: 18,
     height: 86,
-    shadowColor: 'rgba(12, 14, 24, 0.28)',
+    shadowColor: colors.shadow,
     shadowOffset: { width: 0, height: -8 },
     shadowOpacity: 0.18,
     shadowRadius: 20,

--- a/apps/akari/app/(tabs)/bookmarks.tsx
+++ b/apps/akari/app/(tabs)/bookmarks.tsx
@@ -1,5 +1,5 @@
 import { router } from 'expo-router';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { FlatList, RefreshControl, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -9,16 +9,18 @@ import { FeedSkeleton } from '@/components/skeletons';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { useBookmarks } from '@/hooks/queries/useBookmarks';
-import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useAppTheme, type AppThemeColors } from '@/theme';
 import { tabScrollRegistry } from '@/utils/tabScrollRegistry';
 import { formatRelativeTime } from '@/utils/timeUtils';
 
 export default function BookmarksScreen() {
   const insets = useSafeAreaInsets();
   const { t } = useTranslation();
+  const { colors } = useAppTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
   const flatListRef = useRef<FlatList<BlueskyBookmark>>(null);
-  const refreshTintColor = useThemeColor({ light: '#000000', dark: '#ffffff' }, 'text');
+  const refreshTintColor = colors.text;
 
   const scrollToTop = () => {
     flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
@@ -150,54 +152,66 @@ export default function BookmarksScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  header: {
-    paddingHorizontal: 24,
-    paddingBottom: 16,
-    gap: 4,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: '700',
-  },
-  subtitle: {
-    fontSize: 16,
-    opacity: 0.6,
-  },
-  listContent: {
-    paddingBottom: 32,
-  },
-  emptyListContent: {
-    flexGrow: 1,
-  },
-  postCardContainer: {
-    paddingHorizontal: 24,
-    marginBottom: 16,
-  },
-  emptyState: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 24,
-    paddingVertical: 64,
-  },
-  emptyStateText: {
-    fontSize: 16,
-    opacity: 0.6,
-    textAlign: 'center',
-  },
-  loadingMore: {
-    paddingVertical: 16,
-    alignItems: 'center',
-  },
-  loadingMoreText: {
-    fontSize: 14,
-    opacity: 0.6,
-  },
-  skeletonContainer: {
-    paddingHorizontal: 24,
-  },
-});
+function createStyles(colors: AppThemeColors) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    header: {
+      paddingHorizontal: 24,
+      paddingBottom: 16,
+      gap: 4,
+      backgroundColor: colors.surface,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: colors.border,
+    },
+    title: {
+      fontSize: 24,
+      fontWeight: '700',
+    },
+    subtitle: {
+      fontSize: 16,
+      opacity: 0.6,
+    },
+    listContent: {
+      paddingBottom: 32,
+      backgroundColor: colors.background,
+    },
+    emptyListContent: {
+      flexGrow: 1,
+    },
+    postCardContainer: {
+      paddingHorizontal: 24,
+      marginBottom: 16,
+    },
+    emptyState: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingHorizontal: 24,
+      paddingVertical: 64,
+      backgroundColor: colors.surface,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: colors.borderMuted,
+    },
+    emptyStateText: {
+      fontSize: 16,
+      opacity: 0.6,
+      textAlign: 'center',
+    },
+    loadingMore: {
+      paddingVertical: 16,
+      alignItems: 'center',
+      backgroundColor: colors.surface,
+    },
+    loadingMoreText: {
+      fontSize: 14,
+      opacity: 0.6,
+    },
+    skeletonContainer: {
+      paddingHorizontal: 24,
+      backgroundColor: colors.background,
+    },
+  });
+}

--- a/apps/akari/app/(tabs)/index.tsx
+++ b/apps/akari/app/(tabs)/index.tsx
@@ -1,6 +1,6 @@
 import { useResponsive } from '@/hooks/useResponsive';
 import { router } from 'expo-router';
-import React, { useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { FlatList, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -20,6 +20,7 @@ import { useSavedFeeds } from '@/hooks/queries/usePreferences';
 import { useSelectedFeed } from '@/hooks/queries/useSelectedFeed';
 import { useTimeline } from '@/hooks/queries/useTimeline';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useAppTheme, type AppThemeColors } from '@/theme';
 import { tabScrollRegistry } from '@/utils/tabScrollRegistry';
 import { formatRelativeTime } from '@/utils/timeUtils';
 
@@ -30,6 +31,8 @@ export default function HomeScreen() {
   const flatListRef = useRef<FlatList>(null);
   const insets = useSafeAreaInsets();
   const { isLargeScreen } = useResponsive();
+  const { colors } = useAppTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
 
   const { data: currentAccount } = useCurrentAccount();
 
@@ -246,8 +249,12 @@ export default function HomeScreen() {
       </ScrollView>
 
       {/* Floating Action Button for creating posts */}
-      <TouchableOpacity style={[styles.fab, { bottom: 20 }]} onPress={() => setShowPostComposer(true)} activeOpacity={0.8}>
-        <IconSymbol name="plus" size={24} color="white" />
+      <TouchableOpacity
+        style={[styles.fab, { bottom: 20 }]}
+        onPress={() => setShowPostComposer(true)}
+        activeOpacity={0.8}
+      >
+        <IconSymbol name="plus" size={24} color={colors.inverseText} />
       </TouchableOpacity>
 
       {/* Post Composer Modal */}
@@ -256,84 +263,98 @@ export default function HomeScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  scrollView: {
-    flex: 1,
-  },
-  scrollViewContent: {
-    paddingBottom: 100, // Account for tab bar
-  },
-  header: {
-    alignItems: 'center',
-    marginTop: 20,
-    marginBottom: 12,
-    paddingHorizontal: 16,
-    gap: 4,
-  },
-  title: {
-    fontSize: 32,
-    fontWeight: 'bold',
-  },
-  subtitle: {
-    fontSize: 14,
-    opacity: 0.8,
-    textAlign: 'center',
-  },
-  feedList: {
-    paddingBottom: 100, // Account for tab bar
-  },
-  feedListContent: {
-    paddingBottom: 100, // Account for tab bar
-  },
-  loadingMore: {
-    alignItems: 'center',
-    paddingVertical: 16,
-  },
-  loadingMoreText: {
-    fontSize: 14,
-    opacity: 0.6,
-  },
-  emptyState: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingVertical: 40,
-  },
-  emptyStateText: {
-    fontSize: 16,
-    opacity: 0.6,
-    textAlign: 'center',
-  },
-  selectFeedPrompt: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingVertical: 40,
-  },
-  selectFeedText: {
-    fontSize: 16,
-    opacity: 0.6,
-    textAlign: 'center',
-  },
-  fab: {
-    position: 'absolute',
-    right: 20,
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    backgroundColor: '#007AFF',
-    justifyContent: 'center',
-    alignItems: 'center',
-    elevation: 8,
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 4,
+function createStyles(colors: AppThemeColors) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
     },
-    shadowOpacity: 0.3,
-    shadowRadius: 8,
-  },
-});
+    scrollView: {
+      flex: 1,
+    },
+    scrollViewContent: {
+      paddingBottom: 100,
+    },
+    header: {
+      alignItems: 'center',
+      marginTop: 20,
+      marginBottom: 12,
+      paddingHorizontal: 16,
+      gap: 4,
+      backgroundColor: colors.surface,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: colors.borderMuted,
+    },
+    title: {
+      fontSize: 32,
+      fontWeight: 'bold',
+    },
+    subtitle: {
+      fontSize: 14,
+      opacity: 0.8,
+      textAlign: 'center',
+    },
+    feedList: {
+      paddingBottom: 100,
+      backgroundColor: colors.background,
+    },
+    feedListContent: {
+      paddingBottom: 100,
+    },
+    loadingMore: {
+      alignItems: 'center',
+      paddingVertical: 16,
+      backgroundColor: colors.surface,
+    },
+    loadingMoreText: {
+      fontSize: 14,
+      opacity: 0.6,
+    },
+    emptyState: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      paddingVertical: 40,
+      backgroundColor: colors.surface,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: colors.borderMuted,
+    },
+    emptyStateText: {
+      fontSize: 16,
+      opacity: 0.6,
+      textAlign: 'center',
+    },
+    selectFeedPrompt: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      paddingVertical: 40,
+      backgroundColor: colors.surface,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: colors.borderMuted,
+    },
+    selectFeedText: {
+      fontSize: 16,
+      opacity: 0.6,
+      textAlign: 'center',
+    },
+    fab: {
+      position: 'absolute',
+      right: 20,
+      width: 56,
+      height: 56,
+      borderRadius: 28,
+      backgroundColor: colors.accent,
+      justifyContent: 'center',
+      alignItems: 'center',
+      elevation: 8,
+      shadowColor: colors.shadow,
+      shadowOffset: {
+        width: 0,
+        height: 4,
+      },
+      shadowOpacity: 0.3,
+      shadowRadius: 8,
+    },
+  });
+}

--- a/apps/akari/app/(tabs)/messages/index.tsx
+++ b/apps/akari/app/(tabs)/messages/index.tsx
@@ -1,5 +1,5 @@
 import { router } from 'expo-router';
-import React, { useRef } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { FlatList, StyleSheet, TouchableOpacity } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -9,6 +9,7 @@ import { ConversationSkeleton } from '@/components/skeletons';
 import { useConversations } from '@/hooks/queries/useConversations';
 import { useBorderColor } from '@/hooks/useBorderColor';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useAppTheme, type AppThemeColors } from '@/theme';
 import { tabScrollRegistry } from '@/utils/tabScrollRegistry';
 import { Image } from 'expo-image';
 
@@ -29,6 +30,8 @@ export default function MessagesScreen() {
   const borderColor = useBorderColor();
   const flatListRef = useRef<FlatList>(null);
   const { t } = useTranslation();
+  const { colors } = useAppTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
 
   // Create scroll to top function
   const scrollToTop = () => {
@@ -158,180 +161,143 @@ export default function MessagesScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  header: {
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    borderBottomWidth: 0.5,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-  },
-  list: {
-    flex: 1,
-  },
-  conversationsContent: {
-    paddingBottom: 100, // Add extra padding to account for tab bar
-  },
-  conversationItem: {
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    borderBottomWidth: 0.5,
-  },
-  conversationContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  avatarContainer: {
-    marginRight: 12,
-  },
-  avatar: {
-    width: 50,
-    height: 50,
-    borderRadius: 25,
-    backgroundColor: '#007AFF',
-    alignItems: 'center',
-    justifyContent: 'center',
-    overflow: 'hidden',
-  },
-  avatarImage: {
-    width: 50,
-    height: 50,
-    borderRadius: 25,
-  },
-  avatarFallback: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    color: 'white',
-  },
-  conversationInfo: {
-    flex: 1,
-  },
-  conversationHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 4,
-  },
-  displayName: {
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  timestamp: {
-    fontSize: 12,
-    opacity: 0.6,
-  },
-  conversationFooter: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  lastMessage: {
-    fontSize: 14,
-    opacity: 0.7,
-    flex: 1,
-    marginRight: 8,
-  },
-  unreadBadge: {
-    backgroundColor: '#007AFF',
-    borderRadius: 10,
-    minWidth: 20,
-    height: 20,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 6,
-  },
-  unreadCount: {
-    fontSize: 12,
-    fontWeight: 'bold',
-    color: 'white',
-  },
-  statusBadge: {
-    backgroundColor: '#FF9500',
-    borderRadius: 8,
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    alignSelf: 'flex-start',
-    marginTop: 4,
-  },
-  statusText: {
-    fontSize: 10,
-    fontWeight: '600',
-    color: 'white',
-  },
-  loadingState: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  loadingFooter: {
-    paddingVertical: 20,
-    alignItems: 'center',
-  },
-  loadingText: {
-    fontSize: 16,
-    opacity: 0.6,
-  },
-  errorState: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 32,
-  },
-  errorTitle: {
-    fontSize: 20,
-    fontWeight: '600',
-    marginBottom: 8,
-  },
-  errorSubtitle: {
-    fontSize: 16,
-    opacity: 0.6,
-    textAlign: 'center',
-    marginBottom: 16,
-  },
-  errorHelp: {
-    fontSize: 14,
-    opacity: 0.7,
-    textAlign: 'center',
-    lineHeight: 20,
-  },
-  emptyState: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 32,
-  },
-  skeletonContainer: {
-    flex: 1,
-    paddingBottom: 100, // Account for tab bar
-  },
-  emptyTitle: {
-    fontSize: 20,
-    fontWeight: '600',
-    marginBottom: 8,
-  },
-  emptySubtitle: {
-    fontSize: 16,
-    opacity: 0.6,
-    textAlign: 'center',
-  },
-  emptyStateText: {
-    fontSize: 20,
-    fontWeight: '600',
-    marginBottom: 8,
-  },
-  errorLoadingConversations: {
-    fontSize: 20,
-    fontWeight: '600',
-    marginBottom: 8,
-  },
-  noConversations: {
-    fontSize: 20,
-    fontWeight: '600',
-    marginBottom: 8,
-  },
-});
+
+function createStyles(colors: AppThemeColors) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    header: {
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: colors.border,
+      backgroundColor: colors.surface,
+    },
+    title: {
+      fontSize: 24,
+      fontWeight: 'bold',
+    },
+    list: {
+      flex: 1,
+    },
+    conversationsContent: {
+      paddingBottom: 100,
+      backgroundColor: colors.background,
+    },
+    conversationItem: {
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      backgroundColor: colors.surface,
+    },
+    conversationContent: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    avatarContainer: {
+      marginRight: 12,
+    },
+    avatar: {
+      width: 50,
+      height: 50,
+      borderRadius: 25,
+      backgroundColor: colors.accent,
+      alignItems: 'center',
+      justifyContent: 'center',
+      overflow: 'hidden',
+    },
+    avatarImage: {
+      width: 50,
+      height: 50,
+      borderRadius: 25,
+    },
+    avatarFallback: {
+      fontSize: 20,
+      fontWeight: 'bold',
+      color: colors.inverseText,
+    },
+    conversationInfo: {
+      flex: 1,
+    },
+    conversationHeader: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: 4,
+    },
+    displayName: {
+      fontSize: 16,
+      fontWeight: '600',
+    },
+    timestamp: {
+      fontSize: 12,
+      opacity: 0.6,
+    },
+    conversationFooter: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    },
+    lastMessage: {
+      fontSize: 14,
+      opacity: 0.7,
+      flex: 1,
+      marginRight: 8,
+    },
+    unreadBadge: {
+      backgroundColor: colors.accent,
+      borderRadius: 10,
+      minWidth: 20,
+      height: 20,
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingHorizontal: 6,
+    },
+    unreadCount: {
+      fontSize: 12,
+      fontWeight: 'bold',
+      color: colors.inverseText,
+    },
+    statusBadge: {
+      backgroundColor: colors.warning,
+      borderRadius: 8,
+      paddingHorizontal: 8,
+      paddingVertical: 2,
+      alignSelf: 'flex-start',
+      marginTop: 4,
+    },
+    statusText: {
+      fontSize: 10,
+      fontWeight: '600',
+      color: colors.inverseText,
+    },
+    loadingFooter: {
+      paddingVertical: 20,
+      alignItems: 'center',
+      backgroundColor: colors.surface,
+    },
+    loadingText: {
+      fontSize: 16,
+      opacity: 0.6,
+    },
+    emptyState: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingHorizontal: 32,
+      backgroundColor: colors.surface,
+    },
+    skeletonContainer: {
+      flex: 1,
+      paddingBottom: 100,
+    },
+    emptyStateText: {
+      fontSize: 16,
+      opacity: 0.6,
+      textAlign: 'center',
+    },
+  });
+}
+

--- a/apps/akari/app/(tabs)/profile.tsx
+++ b/apps/akari/app/(tabs)/profile.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 
 import { ProfileDropdown } from '@/components/ProfileDropdown';
@@ -18,6 +18,7 @@ import { useProfile } from '@/hooks/queries/useProfile';
 import { useTranslation } from '@/hooks/useTranslation';
 import { tabScrollRegistry } from '@/utils/tabScrollRegistry';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useAppTheme, type AppThemeColors } from '@/theme';
 
 import type { ProfileTabType } from '@/types/profile';
 
@@ -29,6 +30,8 @@ export default function ProfileScreen() {
   const dropdownRef = useRef<View | null>(null);
   const scrollViewRef = useRef<ScrollView>(null);
   const { t } = useTranslation();
+  const { colors } = useAppTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
 
   // Create scroll to top function
   const scrollToTop = () => {
@@ -171,22 +174,30 @@ export default function ProfileScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  scrollView: {
-    flex: 1,
-  },
-  scrollViewContent: {
-    paddingBottom: 100, // Account for tab bar
-  },
-  emptyState: {
-    paddingVertical: 40,
-    alignItems: 'center',
-  },
-  emptyStateText: {
-    fontSize: 16,
-    opacity: 0.6,
-  },
-});
+function createStyles(colors: AppThemeColors) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    scrollView: {
+      flex: 1,
+    },
+    scrollViewContent: {
+      paddingBottom: 100, // Account for tab bar
+      backgroundColor: colors.background,
+    },
+    emptyState: {
+      paddingVertical: 40,
+      alignItems: 'center',
+      backgroundColor: colors.surface,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: colors.borderMuted,
+      marginHorizontal: 16,
+    },
+    emptyStateText: {
+      fontSize: 16,
+      opacity: 0.6,
+    },
+  });
+}

--- a/apps/akari/app/(tabs)/settings.tsx
+++ b/apps/akari/app/(tabs)/settings.tsx
@@ -1,7 +1,7 @@
 import Constants from 'expo-constants';
 import { Image } from 'expo-image';
 import { router } from 'expo-router';
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { ScrollView, StyleSheet, TouchableOpacity } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -21,6 +21,7 @@ import { useAccounts } from '@/hooks/queries/useAccounts';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useBorderColor } from '@/hooks/useBorderColor';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useAppTheme, type AppThemeColors } from '@/theme';
 import { Account } from '@/types/account';
 import { showAlert } from '@/utils/alert';
 import { tabScrollRegistry } from '@/utils/tabScrollRegistry';
@@ -32,6 +33,8 @@ export default function SettingsScreen() {
   const { data: accounts = [] } = useAccounts();
   const { data: currentAccount } = useCurrentAccount();
   const scrollViewRef = useRef<ScrollView>(null);
+  const { colors } = useAppTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
 
   const switchAccountMutation = useSwitchAccount();
   const removeAccountMutation = useRemoveAccount();
@@ -266,125 +269,141 @@ export default function SettingsScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  scrollView: {
-    flex: 1,
-  },
-  scrollViewContent: {
-    paddingBottom: 100, // Account for tab bar
-  },
-  header: {
-    paddingHorizontal: 16,
-    paddingVertical: 16,
-    paddingTop: 20,
-    borderBottomWidth: 0.5,
-  },
-  headerTitle: {
-    fontSize: 24,
-    fontWeight: '700',
-  },
-  section: {
-    marginTop: 20,
-  },
-  sectionTitle: {
-    fontSize: 18,
-    fontWeight: '600',
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    opacity: 0.8,
-  },
-  settingItem: {
-    paddingHorizontal: 16,
-    paddingVertical: 16,
-    borderBottomWidth: 0.5,
-  },
-  settingInfo: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  settingLabel: {
-    fontSize: 16,
-    fontWeight: '500',
-  },
-  settingValue: {
-    fontSize: 16,
-    opacity: 0.7,
-  },
-  accountInfo: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-  },
-  accountAvatarContainer: {
-    width: 40,
-    height: 40,
-  },
-  accountAvatar: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    overflow: 'hidden',
-  },
-  accountAvatarImage: {
-    width: 40,
-    height: 40,
-  },
-  accountAvatarFallback: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: '#007AFF',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  accountAvatarFallbackText: {
-    fontSize: 16,
-    fontWeight: 'bold',
-    color: 'white',
-  },
-  accountDetails: {
-    flex: 1,
-    gap: 4,
-  },
-  accountHandle: {
-    fontSize: 16,
-    fontWeight: '500',
-  },
-  accountDisplayName: {
-    fontSize: 14,
-    opacity: 0.7,
-  },
-  currentAccountBadge: {
-    fontSize: 12,
-    fontWeight: '600',
-    color: '#007AFF',
-    marginTop: 4,
-  },
-  accountActions: {
-    flexDirection: 'row',
-    gap: 8,
-  },
-  actionButton: {
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 6,
-    backgroundColor: '#007AFF',
-  },
-  actionButtonText: {
-    color: 'white',
-    fontSize: 14,
-    fontWeight: '600',
-  },
-  removeButton: {
-    backgroundColor: '#dc3545',
-  },
-  removeButtonText: {
-    color: 'white',
-    fontSize: 14,
-    fontWeight: '600',
-  },
-});
+
+function createStyles(colors: AppThemeColors) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    scrollView: {
+      flex: 1,
+    },
+    scrollViewContent: {
+      paddingBottom: 100,
+    },
+    header: {
+      paddingHorizontal: 16,
+      paddingVertical: 16,
+      paddingTop: 20,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: colors.border,
+      backgroundColor: colors.surface,
+    },
+    headerTitle: {
+      fontSize: 24,
+      fontWeight: '700',
+    },
+    section: {
+      marginTop: 20,
+      backgroundColor: colors.surface,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderTopColor: colors.borderMuted,
+    },
+    sectionTitle: {
+      fontSize: 18,
+      fontWeight: '600',
+      paddingHorizontal: 16,
+      paddingVertical: 8,
+      opacity: 0.8,
+    },
+    settingItem: {
+      paddingHorizontal: 16,
+      paddingVertical: 16,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: colors.borderMuted,
+      backgroundColor: colors.surface,
+    },
+    settingInfo: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    },
+    settingLabel: {
+      fontSize: 16,
+      fontWeight: '500',
+    },
+    settingValue: {
+      fontSize: 16,
+      opacity: 0.7,
+    },
+    accountInfo: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 12,
+    },
+    accountAvatarContainer: {
+      width: 40,
+      height: 40,
+    },
+    accountAvatar: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      overflow: 'hidden',
+      backgroundColor: colors.surfaceSecondary,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    accountAvatarImage: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+    },
+    accountAvatarFallback: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      backgroundColor: colors.accent,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    accountAvatarFallbackText: {
+      fontSize: 16,
+      fontWeight: 'bold',
+      color: colors.inverseText,
+    },
+    accountDetails: {
+      flex: 1,
+      gap: 4,
+    },
+    accountHandle: {
+      fontSize: 16,
+      fontWeight: '500',
+    },
+    accountDisplayName: {
+      fontSize: 14,
+      opacity: 0.7,
+    },
+    currentAccountBadge: {
+      fontSize: 12,
+      fontWeight: '600',
+      color: colors.accent,
+      marginTop: 4,
+    },
+    accountActions: {
+      flexDirection: 'row',
+      gap: 8,
+    },
+    actionButton: {
+      paddingHorizontal: 12,
+      paddingVertical: 6,
+      borderRadius: 6,
+      backgroundColor: colors.accent,
+    },
+    actionButtonText: {
+      color: colors.inverseText,
+      fontSize: 14,
+      fontWeight: '600',
+    },
+    removeButton: {
+      backgroundColor: colors.danger,
+    },
+    removeButtonText: {
+      color: colors.inverseText,
+      fontSize: 14,
+      fontWeight: '600',
+    },
+  });
+}
+

--- a/apps/akari/components/AccountSwitcherSheet.tsx
+++ b/apps/akari/components/AccountSwitcherSheet.tsx
@@ -21,7 +21,7 @@ import { useSwitchAccount } from '@/hooks/mutations/useSwitchAccount';
 import { useAccounts } from '@/hooks/queries/useAccounts';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useBorderColor } from '@/hooks/useBorderColor';
-import { useThemeColor } from '@/hooks/useThemeColor';
+import { useAppTheme } from '@/theme';
 import { useTranslation } from '@/hooks/useTranslation';
 import { Account } from '@/types/account';
 
@@ -38,13 +38,9 @@ export function AccountSwitcherSheet({ visible, onClose }: AccountSwitcherSheetP
   const switchAccountMutation = useSwitchAccount();
   const dialogManager = useDialogManager();
 
-  const sheetBackground = useThemeColor({ light: '#FFFFFF', dark: '#0F172A' }, 'background');
-  const backdropColor = 'rgba(12, 18, 32, 0.65)';
-  const secondaryTextColor = useThemeColor({ light: '#6B7280', dark: '#9CA3AF' }, 'text');
-  const accentColor = useThemeColor({ light: '#7C8CF9', dark: '#7C8CF9' }, 'tint');
-  const avatarBackground = useThemeColor({ light: '#E0E7FF', dark: '#1E2537' }, 'background');
-  const handleColor = useThemeColor({ light: '#E5E7EB', dark: '#1F2937' }, 'border');
+  const { colors } = useAppTheme();
   const borderColor = useBorderColor();
+  const handleColor = useBorderColor('muted');
 
   const activeAccount: Account | undefined = useMemo(
     () => currentAccount ?? accounts[0],
@@ -98,7 +94,7 @@ export function AccountSwitcherSheet({ visible, onClose }: AccountSwitcherSheetP
 
   return (
     <Modal visible transparent animationType="slide" onRequestClose={onClose}>
-      <View style={[styles.overlay, { backgroundColor: backdropColor }]}>
+      <View style={[styles.overlay, { backgroundColor: colors.overlayStrong }]}>
         <Pressable
           style={StyleSheet.absoluteFill}
           onPress={onClose}
@@ -109,7 +105,7 @@ export function AccountSwitcherSheet({ visible, onClose }: AccountSwitcherSheetP
           style={[
             styles.sheet,
             {
-              backgroundColor: sheetBackground,
+              backgroundColor: colors.surface,
               paddingBottom: bottom + 16,
               borderTopColor: borderColor,
             },
@@ -121,7 +117,7 @@ export function AccountSwitcherSheet({ visible, onClose }: AccountSwitcherSheetP
 
           <View style={styles.header}>
             <ThemedText type="defaultSemiBold">{t('common.switchAccount')}</ThemedText>
-            <ThemedText style={[styles.subtitle, { color: secondaryTextColor }]}>
+            <ThemedText style={[styles.subtitle, { color: colors.textMuted }]}>
               {t('common.accounts')} ({accounts.length})
             </ThemedText>
           </View>
@@ -133,7 +129,7 @@ export function AccountSwitcherSheet({ visible, onClose }: AccountSwitcherSheetP
           >
             {accounts.length === 0 ? (
               <View style={styles.emptyState}>
-                <ThemedText style={[styles.emptyStateText, { color: secondaryTextColor }]}>
+                <ThemedText style={[styles.emptyStateText, { color: colors.textMuted }]}>
                   {t('common.noAccounts')}
                 </ThemedText>
               </View>
@@ -151,13 +147,20 @@ export function AccountSwitcherSheet({ visible, onClose }: AccountSwitcherSheetP
                     accessibilityState={{ selected }}
                     accessibilityLabel={accessibilityLabel}
                     onPress={() => handleAccountSelect(account)}
-                    style={styles.accountOption}
+                    style={({ pressed }) => [
+                      styles.accountOption,
+                      (selected || pressed) && { backgroundColor: colors.surfaceActive },
+                    ]}
                   >
-                    <View style={[styles.avatar, { backgroundColor: avatarBackground }]}>
+                    <View style={[styles.avatar, { backgroundColor: colors.accentMuted }]}>
                       {account.avatar ? (
                         <Image source={{ uri: account.avatar }} style={styles.avatarImage} contentFit="cover" />
                       ) : (
-                        <ThemedText style={styles.avatarFallback} lightColor="#ffffff" darkColor="#ffffff">
+                        <ThemedText
+                          style={styles.avatarFallback}
+                          lightColor={colors.inverseText}
+                          darkColor={colors.inverseText}
+                        >
                           {getAccountInitial(account)}
                         </ThemedText>
                       )}
@@ -168,11 +171,11 @@ export function AccountSwitcherSheet({ visible, onClose }: AccountSwitcherSheetP
                         {account.displayName ?? account.handle}
                       </ThemedText>
                       {account.handle ? (
-                        <ThemedText style={[styles.accountHandle, { color: secondaryTextColor }]}>@{account.handle}</ThemedText>
+                        <ThemedText style={[styles.accountHandle, { color: colors.textMuted }]}>@{account.handle}</ThemedText>
                       ) : null}
                       {selected ? (
-                        <View style={[styles.currentBadge, { backgroundColor: avatarBackground }]}>
-                          <ThemedText style={[styles.currentBadgeText, { color: accentColor }]}>
+                        <View style={[styles.currentBadge, { backgroundColor: colors.accentMuted }]}>
+                          <ThemedText style={[styles.currentBadgeText, { color: colors.accent }]}>
                             {t('common.current')}
                           </ThemedText>
                         </View>
@@ -180,7 +183,7 @@ export function AccountSwitcherSheet({ visible, onClose }: AccountSwitcherSheetP
                     </View>
 
                     {selected ? (
-                      <IconSymbol name="checkmark.circle.fill" size={22} color={accentColor} />
+                      <IconSymbol name="checkmark.circle.fill" size={22} color={colors.accent} />
                     ) : (
                       <IconSymbol name="circle" size={22} color={handleColor} />
                     )}
@@ -195,8 +198,8 @@ export function AccountSwitcherSheet({ visible, onClose }: AccountSwitcherSheetP
             onPress={handleAddAccount}
             style={[styles.addAccountButton, { borderColor }]}
           >
-            <IconSymbol name="plus" size={18} color={accentColor} style={styles.addAccountIcon} />
-            <ThemedText style={[styles.addAccountText, { color: accentColor }]}>
+            <IconSymbol name="plus" size={18} color={colors.accent} style={styles.addAccountIcon} />
+            <ThemedText style={[styles.addAccountText, { color: colors.accent }]}>
               {t('common.addAccount')}
             </ThemedText>
           </TouchableOpacity>

--- a/apps/akari/components/HapticTab.tsx
+++ b/apps/akari/components/HapticTab.tsx
@@ -4,7 +4,7 @@ import * as Haptics from "expo-haptics";
 import { StyleSheet, View } from "react-native";
 
 import { useBorderColor } from "@/hooks/useBorderColor";
-import { useThemeColor } from "@/hooks/useThemeColor";
+import { useAppTheme } from "@/theme";
 
 type HapticTabProps = BottomTabBarButtonProps & {
   onTabPress?: () => void;
@@ -12,11 +12,12 @@ type HapticTabProps = BottomTabBarButtonProps & {
 
 export function HapticTab(props: HapticTabProps) {
   const { onTabPress, style, children, accessibilityState, ...restProps } = props;
+  const { colors } = useAppTheme();
   const borderColor = useBorderColor();
-  const inactiveBackground = useThemeColor({ light: "#F3F4F6", dark: "#111827" }, "background");
-  const activeBackground = useThemeColor({ light: "#FFFFFF", dark: "#1E2537" }, "background");
-  const pressedBackground = useThemeColor({ light: "#E5E7EB", dark: "#1B2332" }, "background");
-  const accentColor = useThemeColor({ light: "#7C8CF9", dark: "#7C8CF9" }, "tint");
+  const inactiveBackground = colors.surfaceSecondary;
+  const activeBackground = colors.surface;
+  const pressedBackground = colors.surfaceHover;
+  const accentColor = colors.accent;
   const isActive = accessibilityState?.selected ?? false;
 
   return (

--- a/apps/akari/components/PostCard.tsx
+++ b/apps/akari/components/PostCard.tsx
@@ -1,6 +1,6 @@
 import { Image } from 'expo-image';
 import { router } from 'expo-router';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { StyleSheet, TouchableOpacity } from 'react-native';
 
 import { BlueskyEmbed, BlueskyImage, BlueskyLabel } from '@/bluesky-api';
@@ -17,8 +17,8 @@ import { IconSymbol } from '@/components/ui/IconSymbol';
 import { VideoEmbed } from '@/components/VideoEmbed';
 import { YouTubeEmbed } from '@/components/YouTubeEmbed';
 import { useLikePost } from '@/hooks/mutations/useLikePost';
-import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useAppTheme, type AppThemeColors } from '@/theme';
 
 type PostCardProps = {
   post: {
@@ -78,24 +78,14 @@ export function PostCard({ post, onPress }: PostCardProps) {
   }>({});
   const { t } = useTranslation();
   const likeMutation = useLikePost();
+  const { colors } = useAppTheme();
+  const themedStyles = useMemo(() => createThemedStyles(colors), [colors]);
 
   const authorName = post.author.displayName || post.author.handle;
-
-  const borderColor = useThemeColor(
-    {
-      light: '#e8eaed',
-      dark: '#2d3133',
-    },
-    'background',
-  );
-
-  const iconColor = useThemeColor(
-    {
-      light: '#687076',
-      dark: '#9BA1A6',
-    },
-    'text',
-  );
+  const iconColor = colors.textSecondary;
+  const mutedIconColor = colors.textMuted;
+  const accentColor = colors.accent;
+  const dangerColor = colors.danger;
 
   const handleProfilePress = () => {
     router.push(`/profile/${encodeURIComponent(post.author.handle)}`);
@@ -485,8 +475,13 @@ export function PostCard({ post, onPress }: PostCardProps) {
     <>
       {/* Reply Context */}
       {post.replyTo && (
-        <ThemedView style={styles.replyContext}>
-          <IconSymbol name="arrowshape.turn.up.left" size={12} color={iconColor} style={styles.replyIcon} />
+        <ThemedView style={[styles.replyContext, themedStyles.replyContext]}>
+          <IconSymbol
+            name="arrowshape.turn.up.left"
+            size={12}
+            color={mutedIconColor}
+            style={styles.replyIcon}
+          />
           <ThemedText style={styles.replyText}>Replying to @{post.replyTo.author.handle}</ThemedText>
           <ThemedText style={styles.replyPreview} numberOfLines={1}>
             {post.replyTo.text}
@@ -579,7 +574,7 @@ export function PostCard({ post, onPress }: PostCardProps) {
                 >
                   <Image
                     source={{ uri: imageUrl }}
-                    style={[styles.image, { height: imageHeight }]}
+                    style={[styles.image, themedStyles.image, { height: imageHeight }]}
                     contentFit="contain"
                     placeholder={require('@/assets/images/partial-react-logo.png')}
                     onLoad={(event) => handleImageLoad(imageUrl, event.source.width, event.source.height)}
@@ -610,11 +605,11 @@ export function PostCard({ post, onPress }: PostCardProps) {
           accessibilityRole="button"
           accessibilityLabel={`Reply to post by ${authorName}`}
         >
-          <IconSymbol name="bubble.left" size={16} color={iconColor} style={styles.interactionIcon} />
+          <IconSymbol name="bubble.left" size={16} color={mutedIconColor} style={styles.interactionIcon} />
           <ThemedText style={styles.interactionCount}>{post.commentCount || 0}</ThemedText>
         </TouchableOpacity>
         <ThemedView style={styles.interactionItem}>
-          <IconSymbol name="arrow.2.squarepath" size={16} color={iconColor} style={styles.interactionIcon} />
+          <IconSymbol name="arrow.2.squarepath" size={16} color={accentColor} style={styles.interactionIcon} />
           <ThemedText style={styles.interactionCount}>{post.repostCount || 0}</ThemedText>
         </ThemedView>
         <TouchableOpacity
@@ -631,7 +626,7 @@ export function PostCard({ post, onPress }: PostCardProps) {
           <IconSymbol
             name={post.viewer?.like ? 'heart.fill' : 'heart'}
             size={16}
-            color={post.viewer?.like ? '#ff3b30' : iconColor}
+            color={post.viewer?.like ? dangerColor : iconColor}
             style={styles.interactionIcon}
           />
           <ThemedText style={styles.interactionCount}>{post.likeCount || 0}</ThemedText>
@@ -644,14 +639,14 @@ export function PostCard({ post, onPress }: PostCardProps) {
     <>
       {onPress ? (
         <TouchableOpacity
-          style={[styles.container, { borderBottomColor: borderColor }]}
+          style={[styles.container, themedStyles.container]}
           onPress={onPress}
           activeOpacity={0.7}
         >
           {postContent}
         </TouchableOpacity>
       ) : (
-        <ThemedView style={[styles.container, { borderBottomColor: borderColor }]}>{postContent}</ThemedView>
+        <ThemedView style={[styles.container, themedStyles.container]}>{postContent}</ThemedView>
       )}
 
       {/* Image Viewer Modal */}
@@ -763,7 +758,6 @@ const styles = StyleSheet.create({
   videoContainer: {
     marginTop: 8,
     padding: 16,
-    backgroundColor: 'rgba(0, 0, 0, 0.05)',
     borderRadius: 8,
     alignItems: 'center',
     justifyContent: 'center',
@@ -792,3 +786,22 @@ const styles = StyleSheet.create({
     opacity: 0.7,
   },
 });
+
+function createThemedStyles(colors: AppThemeColors) {
+  return StyleSheet.create({
+    container: {
+      backgroundColor: colors.surface,
+      borderBottomColor: colors.borderMuted,
+    },
+    replyContext: {
+      backgroundColor: colors.surfaceSecondary,
+    },
+    image: {
+      borderColor: colors.borderMuted,
+      backgroundColor: colors.surfaceSecondary,
+    },
+    videoContainer: {
+      backgroundColor: colors.surfaceSecondary,
+    },
+  });
+}

--- a/apps/akari/components/ProfileDropdown.tsx
+++ b/apps/akari/components/ProfileDropdown.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
 
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { useBorderColor } from '@/hooks/useBorderColor';
-import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useAppTheme, type AppThemeColors } from '@/theme';
 
 type ProfileDropdownProps = {
   isVisible: boolean;
@@ -38,19 +38,13 @@ export function ProfileDropdown({
 }: ProfileDropdownProps) {
   const { t } = useTranslation();
   const borderColor = useBorderColor();
-
-  const dropdownBackgroundColor = useThemeColor(
-    {
-      light: '#ffffff',
-      dark: '#1c1c1e',
-    },
-    'background',
-  );
+  const { colors } = useAppTheme();
+  const themedStyles = useMemo(() => createStyles(colors), [colors]);
 
   if (!isVisible) return null;
 
   return (
-    <ThemedView style={[styles.dropdown, { backgroundColor: dropdownBackgroundColor, borderColor: borderColor }, style]}>
+    <ThemedView style={[styles.dropdown, themedStyles.dropdown, { borderColor: borderColor }, style]}>
       {isOwnProfile ? (
         <>
           <TouchableOpacity style={styles.dropdownItem} onPress={onSearchPosts}>
@@ -76,12 +70,12 @@ export function ProfileDropdown({
             <ThemedText style={styles.dropdownText}>{isMuted ? t('common.unmute') : t('profile.muteAccount')}</ThemedText>
           </TouchableOpacity>
           <TouchableOpacity style={styles.dropdownItem} onPress={onBlockPress}>
-            <ThemedText style={[styles.dropdownText, styles.dropdownTextDestructive]}>
+            <ThemedText style={[styles.dropdownText, themedStyles.dropdownTextDestructive]}>
               {isBlocking ? t('common.unblock') : t('common.block')}
             </ThemedText>
           </TouchableOpacity>
           <TouchableOpacity style={styles.dropdownItem} onPress={onReportAccount}>
-            <ThemedText style={[styles.dropdownText, styles.dropdownTextDestructive]}>
+            <ThemedText style={[styles.dropdownText, themedStyles.dropdownTextDestructive]}>
               {t('profile.reportAccount')}
             </ThemedText>
           </TouchableOpacity>
@@ -95,14 +89,13 @@ const styles = StyleSheet.create({
   dropdown: {
     position: 'absolute',
     borderRadius: 8,
-    borderWidth: 1,
-    shadowColor: '#000',
+    borderWidth: StyleSheet.hairlineWidth,
     shadowOffset: {
       width: 0,
       height: 2,
     },
-    shadowOpacity: 0.25,
-    shadowRadius: 3.84,
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
     elevation: 5,
     minWidth: 140,
     zIndex: 9999999,
@@ -119,7 +112,17 @@ const styles = StyleSheet.create({
   dropdownText: {
     fontSize: 14,
   },
-  dropdownTextDestructive: {
-    color: '#c62828',
-  },
 });
+
+function createStyles(colors: AppThemeColors) {
+  return StyleSheet.create({
+    dropdown: {
+      backgroundColor: colors.surface,
+      shadowColor: colors.shadow,
+      borderColor: colors.borderMuted,
+    },
+    dropdownTextDestructive: {
+      color: colors.danger,
+    },
+  });
+}

--- a/apps/akari/components/ProfileHeader.tsx
+++ b/apps/akari/components/ProfileHeader.tsx
@@ -1,7 +1,7 @@
 import * as Clipboard from 'expo-clipboard';
 import { Image } from 'expo-image';
 import { router } from 'expo-router';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
 
 import { HandleHistoryModal } from '@/components/HandleHistoryModal';
@@ -18,6 +18,7 @@ import { useUpdateProfile } from '@/hooks/mutations/useUpdateProfile';
 import { useBorderColor } from '@/hooks/useBorderColor';
 import { useTranslation } from '@/hooks/useTranslation';
 import { showAlert } from '@/utils/alert';
+import { useAppTheme, type AppThemeColors } from '@/theme';
 
 type ProfileHeaderProps = {
   profile: {
@@ -73,6 +74,8 @@ export function ProfileHeader({ profile, isOwnProfile = false, onDropdownToggle,
   const followMutation = useFollowUser();
   const blockMutation = useBlockUser();
   const updateProfileMutation = useUpdateProfile();
+  const { colors } = useAppTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
 
   const isFollowing = !!profile.viewer?.following;
   const isBlocking = !!profile.viewer?.blocking;
@@ -319,9 +322,13 @@ export function ProfileHeader({ profile, isOwnProfile = false, onDropdownToggle,
           {/* Name and Handle */}
           <View style={styles.nameHandleSection}>
             <ThemedText style={styles.displayName}>{profile.displayName || profile.handle}</ThemedText>
-            <TouchableOpacity style={styles.handleContainer} onPress={() => setShowHandleHistory(true)} activeOpacity={0.7}>
+            <TouchableOpacity
+              style={styles.handleContainer}
+              onPress={() => setShowHandleHistory(true)}
+              activeOpacity={0.7}
+            >
               <ThemedText style={styles.handle}>@{profile.handle}</ThemedText>
-              <IconSymbol name="clock" size={14} color="#666" style={styles.handleHistoryIcon} />
+              <IconSymbol name="clock" size={14} color={colors.textMuted} style={styles.handleHistoryIcon} />
             </TouchableOpacity>
           </View>
 
@@ -334,19 +341,19 @@ export function ProfileHeader({ profile, isOwnProfile = false, onDropdownToggle,
                 </TouchableOpacity>
                 <View style={styles.moreButtonContainer} ref={dropdownRef}>
                   <TouchableOpacity style={styles.moreButton} onPress={handleDropdownToggle}>
-                    <IconSymbol name="ellipsis" size={20} color="#ffffff" />
+                    <IconSymbol name="ellipsis" size={20} color={colors.inverseText} />
                   </TouchableOpacity>
                 </View>
               </>
             ) : (
               <>
                 <TouchableOpacity style={styles.iconButton} onPress={handleSearchPosts}>
-                  <IconSymbol name="magnifyingglass" size={20} color="#007AFF" />
+                  <IconSymbol name="magnifyingglass" size={20} color={colors.accent} />
                 </TouchableOpacity>
                 {!isBlockedBy && (
                   <View style={styles.moreButtonContainer} ref={dropdownRef}>
                     <TouchableOpacity style={styles.iconButton} onPress={handleDropdownToggle}>
-                      <IconSymbol name="ellipsis" size={20} color="#007AFF" />
+                      <IconSymbol name="ellipsis" size={20} color={colors.accent} />
                     </TouchableOpacity>
                   </View>
                 )}
@@ -416,160 +423,169 @@ export function ProfileHeader({ profile, isOwnProfile = false, onDropdownToggle,
   );
 }
 
-const styles = StyleSheet.create({
-  banner: {
-    height: 150,
-    backgroundColor: '#f0f0f0',
-  },
-  bannerImage: {
-    flex: 1,
-  },
-  bannerPlaceholder: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#e0e0e0',
-  },
-  bannerPlaceholderText: {
-    fontSize: 16,
-    opacity: 0.6,
-  },
-  profileHeader: {
-    paddingHorizontal: 16,
-    paddingVertical: 20,
-    borderBottomWidth: 0.5,
-    position: 'relative',
-  },
-  avatarContainer: {
-    marginTop: -50,
-    marginBottom: 12,
-  },
-  avatar: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderWidth: 3,
-    borderColor: 'white',
-    overflow: 'hidden',
-    backgroundColor: 'transparent',
-  },
-  avatarImage: {
-    width: 74,
-    height: 74,
-    borderRadius: 37,
-  },
-  avatarFallbackContainer: {
-    width: 74,
-    height: 74,
-    borderRadius: 37,
-    backgroundColor: '#007AFF',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  avatarFallback: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    color: 'white',
-  },
-  profileInfoSection: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
-    marginBottom: 12,
-  },
-  nameHandleSection: {
-    flex: 1,
-    marginRight: 10,
-  },
-  displayName: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    marginBottom: 2,
-  },
-  handle: {
-    fontSize: 15,
-    opacity: 0.7,
-  },
-  handleContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  handleHistoryIcon: {
-    marginLeft: 6,
-    opacity: 0.5,
-  },
-  actionButtons: {
-    flexDirection: 'row',
-    gap: 8,
-  },
-  iconButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    borderWidth: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: 'rgba(0, 122, 255, 0.1)',
-  },
-  editButton: {
-    height: 32,
-    paddingHorizontal: 16,
-    borderRadius: 16,
-    borderWidth: 1,
-    borderColor: '#007AFF',
-    backgroundColor: '#007AFF',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  editButtonText: {
-    color: 'white',
-    fontSize: 14,
-    fontWeight: '600',
-  },
-  moreButtonContainer: {
-    position: 'relative',
-    zIndex: 999999,
-  },
-  moreButton: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
-    borderWidth: 1,
-    borderColor: 'rgba(255, 255, 255, 0.3)',
-    backgroundColor: 'rgba(255, 255, 255, 0.1)',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  statsContainer: {
-    marginBottom: 12,
-  },
-  statText: {
-    fontSize: 15,
-    lineHeight: 20,
-  },
-  statNumber: {
-    fontWeight: 'bold',
-  },
-  description: {
-    fontSize: 14,
-    lineHeight: 18,
-  },
-  descriptionContainer: {
-    marginBottom: 12,
-  },
-
-  blockedMessage: {
-    marginTop: 16,
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    backgroundColor: '#ffebee',
-    borderRadius: 8,
-  },
-  blockedText: {
-    fontSize: 14,
-    color: '#c62828',
-    textAlign: 'center',
-  },
-});
+function createStyles(colors: AppThemeColors) {
+  return StyleSheet.create({
+    banner: {
+      height: 150,
+      backgroundColor: colors.surfaceSecondary,
+    },
+    bannerImage: {
+      flex: 1,
+    },
+    bannerPlaceholder: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: colors.surfaceTertiary,
+    },
+    bannerPlaceholderText: {
+      fontSize: 16,
+      opacity: 0.6,
+      color: colors.textSecondary,
+    },
+    profileHeader: {
+      paddingHorizontal: 16,
+      paddingVertical: 20,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      position: 'relative',
+      backgroundColor: colors.surface,
+    },
+    avatarContainer: {
+      marginTop: -50,
+      marginBottom: 12,
+    },
+    avatar: {
+      width: 80,
+      height: 80,
+      borderRadius: 40,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderWidth: 3,
+      borderColor: colors.background,
+      overflow: 'hidden',
+      backgroundColor: colors.surfaceSecondary,
+    },
+    avatarImage: {
+      width: 74,
+      height: 74,
+      borderRadius: 37,
+    },
+    avatarFallbackContainer: {
+      width: 74,
+      height: 74,
+      borderRadius: 37,
+      backgroundColor: colors.accent,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    avatarFallback: {
+      fontSize: 24,
+      fontWeight: 'bold',
+      color: colors.inverseText,
+    },
+    profileInfoSection: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'flex-start',
+      marginBottom: 12,
+    },
+    nameHandleSection: {
+      flex: 1,
+      marginRight: 10,
+    },
+    displayName: {
+      fontSize: 20,
+      fontWeight: 'bold',
+      marginBottom: 2,
+    },
+    handle: {
+      fontSize: 15,
+      color: colors.textSecondary,
+    },
+    handleContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    handleHistoryIcon: {
+      marginLeft: 6,
+      opacity: 0.6,
+    },
+    actionButtons: {
+      flexDirection: 'row',
+      gap: 8,
+    },
+    iconButton: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      borderWidth: StyleSheet.hairlineWidth,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: colors.surfaceSecondary,
+      borderColor: colors.borderMuted,
+    },
+    editButton: {
+      height: 32,
+      paddingHorizontal: 16,
+      borderRadius: 16,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: colors.accent,
+      backgroundColor: colors.accent,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    editButtonText: {
+      color: colors.inverseText,
+      fontSize: 14,
+      fontWeight: '600',
+    },
+    moreButtonContainer: {
+      position: 'relative',
+      zIndex: 999999,
+    },
+    moreButton: {
+      width: 32,
+      height: 32,
+      borderRadius: 16,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: colors.borderMuted,
+      backgroundColor: colors.surfaceActive,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    statsContainer: {
+      marginBottom: 12,
+    },
+    statText: {
+      fontSize: 15,
+      lineHeight: 20,
+      color: colors.textSecondary,
+    },
+    statNumber: {
+      fontWeight: 'bold',
+      color: colors.text,
+    },
+    description: {
+      fontSize: 14,
+      lineHeight: 18,
+      color: colors.text,
+    },
+    descriptionContainer: {
+      marginBottom: 12,
+    },
+    blockedMessage: {
+      marginTop: 16,
+      paddingVertical: 12,
+      paddingHorizontal: 16,
+      backgroundColor: `${colors.danger}1A`,
+      borderRadius: 8,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: colors.danger,
+    },
+    blockedText: {
+      fontSize: 14,
+      color: colors.danger,
+      textAlign: 'center',
+    },
+  });
+}

--- a/apps/akari/components/Sidebar.tsx
+++ b/apps/akari/components/Sidebar.tsx
@@ -13,25 +13,11 @@ import { useAccounts } from '@/hooks/queries/useAccounts';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useUnreadMessagesCount } from '@/hooks/queries/useUnreadMessagesCount';
 import { useUnreadNotificationsCount } from '@/hooks/queries/useUnreadNotificationsCount';
+import { useAppTheme, type AppTheme } from '@/theme';
 import { Account } from '@/types/account';
 
 const COLLAPSED_WIDTH = 68;
 const EXPANDED_WIDTH = 264;
-
-const palette = {
-  background: '#0F1115',
-  border: '#1F212D',
-  headerBackground: '#151823',
-  textPrimary: '#F4F4F5',
-  textSecondary: '#A1A1AA',
-  textMuted: '#6B7280',
-  highlight: '#7C8CF9',
-  activeBackground: '#1E2537',
-  hover: '#1A1D27',
-  countAccent: '#EA580C',
-  activeCount: '#7C8CF9',
-  trendingAccent: '#38BDF8',
-} as const;
 
 const TRENDING_TAGS = [
   '#BlueskyMigration',
@@ -51,6 +37,9 @@ type NavigationItem = {
 export function Sidebar() {
   const router = useRouter();
   const pathname = usePathname();
+  const theme = useAppTheme();
+  const { colors } = theme;
+  const styles = useMemo(() => createStyles(theme), [theme]);
   const [collapsed, setCollapsed] = useState(false);
   const [showAccountSelector, setShowAccountSelector] = useState(false);
   const { data: accounts = [] } = useAccounts();
@@ -151,7 +140,10 @@ export function Sidebar() {
     }
 
     return (
-      <View style={[styles.badge, { backgroundColor: isActive ? palette.activeCount : palette.countAccent }]} pointerEvents="none">
+      <View
+        style={[styles.badge, { backgroundColor: isActive ? colors.badgeActive : colors.badge }]}
+        pointerEvents="none"
+      >
         <Text style={styles.badgeText}>{count}</Text>
       </View>
     );
@@ -167,7 +159,7 @@ export function Sidebar() {
           style={({ pressed }) => [
             styles.accountButton,
             collapsed && styles.accountButtonCollapsed,
-            pressed && { backgroundColor: palette.hover },
+            pressed && { backgroundColor: colors.surfaceHover },
           ]}
         >
           <View style={styles.avatar}>
@@ -188,7 +180,7 @@ export function Sidebar() {
             </View>
           ) : null}
           {!collapsed ? (
-            <IconSymbol name="chevron.down" size={16} color={palette.textSecondary} />
+            <IconSymbol name="chevron.down" size={16} color={colors.textSecondary} />
           ) : null}
         </Pressable>
       </View>
@@ -209,9 +201,9 @@ export function Sidebar() {
                   collapsed && styles.navItemCollapsed,
                   {
                     backgroundColor: active
-                      ? palette.activeBackground
+                      ? colors.surfaceActive
                       : pressed
-                      ? palette.hover
+                      ? colors.surfaceHover
                       : 'transparent',
                   },
                 ]}
@@ -221,7 +213,7 @@ export function Sidebar() {
                   <IconSymbol
                     name={item.icon}
                     size={18}
-                    color={active ? palette.highlight : palette.textSecondary}
+                    color={active ? colors.accent : colors.textSecondary}
                   />
                 </View>
                 {!collapsed ? (
@@ -230,7 +222,7 @@ export function Sidebar() {
                       style={[
                         styles.navLabel,
                         {
-                          color: active ? palette.highlight : palette.textSecondary,
+                          color: active ? colors.accent : colors.textSecondary,
                           fontWeight: active ? '600' : '500',
                         },
                       ]}
@@ -249,7 +241,7 @@ export function Sidebar() {
         {!collapsed ? (
           <View style={styles.trendingSection}>
             <View style={styles.trendingHeader}>
-              <IconSymbol name="sparkles" size={14} color={palette.trendingAccent} />
+              <IconSymbol name="sparkles" size={14} color={colors.info} />
               <Text style={styles.trendingLabel}>Trending</Text>
             </View>
             <View>
@@ -260,7 +252,7 @@ export function Sidebar() {
                   accessibilityLabel={tag}
                   style={({ pressed }) => [
                     styles.trendingItem,
-                    pressed && { backgroundColor: palette.hover },
+                    pressed && { backgroundColor: colors.surfaceHover },
                   ]}
                 >
                   <Text style={styles.trendingText}>{tag}</Text>
@@ -278,11 +270,11 @@ export function Sidebar() {
           onPress={() => setCollapsed((value) => !value)}
           style={({ pressed }) => [
             styles.collapseButton,
-            pressed && { backgroundColor: palette.hover },
+            pressed && { backgroundColor: colors.surfaceHover },
           ]}
         >
           {!collapsed ? <Text style={styles.collapseText}>Collapse</Text> : null}
-          <IconSymbol name="ellipsis" size={18} color={palette.textSecondary} />
+          <IconSymbol name="ellipsis" size={18} color={colors.textSecondary} />
         </Pressable>
       </View>
 
@@ -294,8 +286,9 @@ export function Sidebar() {
           ]}
         >
           <View style={styles.accountSelectorList}>
-              {accounts.map((account) => {
-                const selected = account.did === activeAccount?.did;
+            {accounts.map((account) => {
+              const selected = account.did === activeAccount?.did;
+
               return (
                 <Pressable
                   key={account.did}
@@ -304,7 +297,7 @@ export function Sidebar() {
                   onPress={() => handleAccountSelect(account)}
                   style={({ pressed }) => [
                     styles.accountOption,
-                    (selected || pressed) && { backgroundColor: palette.activeBackground },
+                    (selected || pressed) && { backgroundColor: colors.surfaceActive },
                   ]}
                 >
                   <View style={styles.avatarSmall}>
@@ -336,7 +329,7 @@ export function Sidebar() {
               onPress={handleAddAccount}
               style={({ pressed }) => [
                 styles.addAccountButton,
-                pressed && { backgroundColor: palette.hover },
+                pressed && { backgroundColor: colors.surfaceHover },
               ]}
             >
               <Text style={styles.addAccountText}>+ Add account</Text>
@@ -349,248 +342,252 @@ export function Sidebar() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    backgroundColor: palette.background,
-    borderColor: palette.border,
-    borderWidth: 1,
-    flexShrink: 0,
-    height: '100%',
-  },
-  header: {
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    borderBottomWidth: 1,
-    borderColor: palette.border,
-    backgroundColor: palette.headerBackground,
-  },
-  accountButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 6,
-    paddingHorizontal: 6,
-  },
-  accountButtonCollapsed: {
-    justifyContent: 'center',
-  },
-  avatar: {
-    width: 28,
-    height: 28,
-    borderRadius: 14,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginRight: 8,
-    backgroundColor: palette.highlight,
-  },
-  avatarSmall: {
-    width: 28,
-    height: 28,
-    borderRadius: 14,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginRight: 10,
-    backgroundColor: palette.highlight,
-  },
-  avatarText: {
-    color: '#ffffff',
-    fontSize: 14,
-  },
-  avatarImage: {
-    width: '100%',
-    height: '100%',
-    borderRadius: 14,
-  },
-  accountTextContainer: {
-    flex: 1,
-  },
-  accountName: {
-    color: palette.textPrimary,
-    fontSize: 14,
-    fontWeight: '600',
-  },
-  accountHandle: {
-    color: palette.textSecondary,
-    fontSize: 12,
-    marginTop: 2,
-  },
-  menu: {
-    flex: 1,
-    paddingHorizontal: 12,
-    paddingVertical: 12,
-  },
-  navigationList: {
-    flexGrow: 1,
-  },
-  navItem: {
-    position: 'relative',
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 10,
-    paddingHorizontal: 12,
-    marginBottom: 8,
-  },
-  navItemCollapsed: {
-    justifyContent: 'center',
-    paddingHorizontal: 0,
-  },
-  iconContainer: {
-    width: 28,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginRight: 12,
-  },
-  iconCollapsedSpacing: {
-    marginRight: 0,
-  },
-  navLabel: {
-    flex: 1,
-    fontSize: 14,
-  },
-  badge: {
-    borderRadius: 999,
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    marginLeft: 8,
-    minWidth: 26,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  badgeText: {
-    color: '#ffffff',
-    fontSize: 12,
-    fontWeight: '600',
-  },
-  collapsedBadge: {
-    position: 'absolute',
-    top: 4,
-    right: 4,
-    backgroundColor: palette.countAccent,
-    borderRadius: 999,
-    minWidth: 18,
-    height: 18,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 4,
-  },
-  collapsedBadgeText: {
-    color: '#ffffff',
-    fontSize: 11,
-    fontWeight: '700',
-  },
-  activeIndicator: {
-    position: 'absolute',
-    left: 0,
-    top: 4,
-    bottom: 4,
-    width: 3,
-    backgroundColor: palette.highlight,
-  },
-  trendingSection: {
-    borderTopWidth: 1,
-    borderColor: palette.border,
-    marginTop: 12,
-    paddingTop: 12,
-  },
-  trendingHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 8,
-  },
-  trendingLabel: {
-    color: palette.textMuted,
-    fontSize: 12,
-    marginLeft: 6,
-    fontWeight: '600',
-  },
-  trendingItem: {
-    paddingVertical: 6,
-    paddingHorizontal: 10,
-    marginBottom: 6,
-  },
-  trendingText: {
-    color: palette.textSecondary,
-    fontSize: 12,
-    fontWeight: '500',
-  },
-  footer: {
-    borderTopWidth: 1,
-    borderColor: palette.border,
-    paddingHorizontal: 12,
-    paddingVertical: 12,
-    backgroundColor: palette.headerBackground,
-  },
-  collapseButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 10,
-  },
-  collapseText: {
-    color: palette.textSecondary,
-    fontSize: 13,
-    fontWeight: '500',
-    marginRight: 8,
-  },
-  accountSelector: {
-    position: 'absolute',
-    left: 16,
-    right: 16,
-    top: 88,
-    backgroundColor: palette.headerBackground,
-    borderWidth: 1,
-    borderColor: palette.border,
-    shadowColor: '#000000',
-    shadowOpacity: 0.45,
-    shadowRadius: 20,
-    shadowOffset: { width: 0, height: 18 },
-    elevation: 16,
-    padding: 8,
-  },
-  accountSelectorCollapsed: {
-    left: 8,
-    right: 8,
-  },
-  accountSelectorList: {
-    paddingBottom: 8,
-  },
-  accountOption: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 8,
-    paddingHorizontal: 8,
-    marginBottom: 4,
-  },
-  accountDetails: {
-    flex: 1,
-  },
-  accountDisplay: {
-    color: palette.textPrimary,
-    fontSize: 14,
-    fontWeight: '500',
-  },
-  accountUsername: {
-    color: palette.textSecondary,
-    fontSize: 12,
-    marginTop: 2,
-  },
-  accountActiveDot: {
-    width: 8,
-    height: 8,
-    backgroundColor: palette.highlight,
-    marginLeft: 12,
-  },
-  accountSelectorFooter: {
-    borderTopWidth: 1,
-    borderColor: palette.border,
-    paddingTop: 8,
-  },
-  addAccountButton: {
-    paddingVertical: 8,
-    paddingHorizontal: 8,
-  },
-  addAccountText: {
-    color: palette.highlight,
-    fontSize: 13,
-    fontWeight: '600',
-  },
-});
+function createStyles(theme: AppTheme) {
+  const { colors } = theme;
+  return StyleSheet.create({
+    container: {
+      backgroundColor: colors.surface,
+      borderColor: colors.border,
+      borderWidth: 1,
+      flexShrink: 0,
+      height: '100%',
+    },
+    header: {
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+      borderBottomWidth: 1,
+      borderColor: colors.border,
+      backgroundColor: colors.surfaceSecondary,
+    },
+    accountButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: 6,
+      paddingHorizontal: 6,
+    },
+    accountButtonCollapsed: {
+      justifyContent: 'center',
+    },
+    avatar: {
+      width: 28,
+      height: 28,
+      borderRadius: 14,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginRight: 8,
+      backgroundColor: colors.accent,
+    },
+    avatarSmall: {
+      width: 28,
+      height: 28,
+      borderRadius: 14,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginRight: 10,
+      backgroundColor: colors.accent,
+    },
+    avatarText: {
+      color: colors.inverseText,
+      fontSize: 14,
+    },
+    avatarImage: {
+      width: '100%',
+      height: '100%',
+      borderRadius: 14,
+    },
+    accountTextContainer: {
+      flex: 1,
+    },
+    accountName: {
+      color: colors.text,
+      fontSize: 14,
+      fontWeight: '600',
+    },
+    accountHandle: {
+      color: colors.textSecondary,
+      fontSize: 12,
+      marginTop: 2,
+    },
+    menu: {
+      flex: 1,
+      paddingHorizontal: 12,
+      paddingVertical: 12,
+    },
+    navigationList: {
+      flexGrow: 1,
+    },
+    navItem: {
+      position: 'relative',
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: 10,
+      paddingHorizontal: 12,
+      marginBottom: 8,
+    },
+    navItemCollapsed: {
+      justifyContent: 'center',
+      paddingHorizontal: 0,
+    },
+    iconContainer: {
+      width: 28,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginRight: 12,
+    },
+    iconCollapsedSpacing: {
+      marginRight: 0,
+    },
+    navLabel: {
+      flex: 1,
+      fontSize: 14,
+    },
+    badge: {
+      borderRadius: 999,
+      paddingHorizontal: 8,
+      paddingVertical: 2,
+      marginLeft: 8,
+      minWidth: 26,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    badgeText: {
+      color: colors.inverseText,
+      fontSize: 12,
+      fontWeight: '600',
+    },
+    collapsedBadge: {
+      position: 'absolute',
+      top: 4,
+      right: 4,
+      backgroundColor: colors.badge,
+      borderRadius: 999,
+      minWidth: 18,
+      height: 18,
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingHorizontal: 4,
+    },
+    collapsedBadgeText: {
+      color: colors.inverseText,
+      fontSize: 11,
+      fontWeight: '700',
+    },
+    activeIndicator: {
+      position: 'absolute',
+      left: 0,
+      top: 4,
+      bottom: 4,
+      width: 3,
+      backgroundColor: colors.accent,
+    },
+    trendingSection: {
+      borderTopWidth: 1,
+      borderColor: colors.border,
+      marginTop: 12,
+      paddingTop: 12,
+    },
+    trendingHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: 8,
+    },
+    trendingLabel: {
+      color: colors.textMuted,
+      fontSize: 12,
+      marginLeft: 6,
+      fontWeight: '600',
+    },
+    trendingItem: {
+      paddingVertical: 6,
+      paddingHorizontal: 10,
+      marginBottom: 6,
+    },
+    trendingText: {
+      color: colors.textSecondary,
+      fontSize: 12,
+      fontWeight: '500',
+    },
+    footer: {
+      borderTopWidth: 1,
+      borderColor: colors.border,
+      paddingHorizontal: 12,
+      paddingVertical: 12,
+      backgroundColor: colors.surfaceSecondary,
+    },
+    collapseButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingVertical: 10,
+    },
+    collapseText: {
+      color: colors.textSecondary,
+      fontSize: 13,
+      fontWeight: '500',
+      marginRight: 8,
+    },
+    accountSelector: {
+      position: 'absolute',
+      left: 16,
+      right: 16,
+      top: 88,
+      backgroundColor: colors.surface,
+      borderWidth: 1,
+      borderColor: colors.border,
+      shadowColor: colors.shadow,
+      shadowOpacity: 0.45,
+      shadowRadius: 20,
+      shadowOffset: { width: 0, height: 18 },
+      elevation: 16,
+      padding: 8,
+    },
+    accountSelectorCollapsed: {
+      left: 8,
+      right: 8,
+    },
+    accountSelectorList: {
+      paddingBottom: 8,
+    },
+    accountOption: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: 8,
+      paddingHorizontal: 8,
+      marginBottom: 4,
+    },
+    accountDetails: {
+      flex: 1,
+    },
+    accountDisplay: {
+      color: colors.text,
+      fontSize: 14,
+      fontWeight: '500',
+    },
+    accountUsername: {
+      color: colors.textSecondary,
+      fontSize: 12,
+      marginTop: 2,
+    },
+    accountActiveDot: {
+      width: 8,
+      height: 8,
+      backgroundColor: colors.accent,
+      borderRadius: 4,
+      marginLeft: 12,
+    },
+    accountSelectorFooter: {
+      borderTopWidth: 1,
+      borderColor: colors.border,
+      paddingTop: 8,
+    },
+    addAccountButton: {
+      paddingVertical: 8,
+      paddingHorizontal: 8,
+    },
+    addAccountText: {
+      color: colors.accent,
+      fontSize: 13,
+      fontWeight: '600',
+    },
+  });
+}

--- a/apps/akari/components/TabBadge.tsx
+++ b/apps/akari/components/TabBadge.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 
 import { ThemedText } from '@/components/ThemedText';
-import { useThemeColor } from '@/hooks/useThemeColor';
+import { useAppTheme } from '@/theme';
 
 type TabBadgeProps = {
   count: number;
@@ -10,21 +10,9 @@ type TabBadgeProps = {
 };
 
 export function TabBadge({ count, size = 'medium' }: TabBadgeProps) {
-  const backgroundColor = useThemeColor(
-    {
-      light: '#ff3b30',
-      dark: '#ff453a',
-    },
-    'tint',
-  );
-
-  const textColor = useThemeColor(
-    {
-      light: '#ffffff',
-      dark: '#ffffff',
-    },
-    'text',
-  );
+  const { colors } = useAppTheme();
+  const backgroundColor = colors.danger;
+  const textColor = colors.inverseText;
 
   // Don't show badge if count is 0
   if (count === 0) {

--- a/apps/akari/components/TabBar.tsx
+++ b/apps/akari/components/TabBar.tsx
@@ -3,7 +3,7 @@ import { ScrollView, StyleSheet, TouchableOpacity } from "react-native";
 import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
 import { useBorderColor } from "@/hooks/useBorderColor";
-import { useThemeColor } from "@/hooks/useThemeColor";
+import { useAppTheme } from "@/theme";
 
 /**
  * Tab item configuration
@@ -33,11 +33,12 @@ export function TabBar<T extends string>({
   activeTab,
   onTabChange,
 }: TabBarProps<T>) {
+  const { colors } = useAppTheme();
   const borderColor = useBorderColor();
-  const surfaceColor = useThemeColor({ light: "#FFFFFF", dark: "#0F1115" }, "background");
-  const inactiveTextColor = useThemeColor({ light: "#6B7280", dark: "#9CA3AF" }, "text");
-  const activeTextColor = useThemeColor({ light: "#111827", dark: "#F4F4F5" }, "text");
-  const accentColor = useThemeColor({ light: "#7C8CF9", dark: "#7C8CF9" }, "tint");
+  const surfaceColor = colors.surface;
+  const inactiveTextColor = colors.textMuted;
+  const activeTextColor = colors.text;
+  const accentColor = colors.accent;
 
   return (
     <ThemedView
@@ -46,6 +47,7 @@ export function TabBar<T extends string>({
         {
           borderColor,
           backgroundColor: surfaceColor,
+          shadowColor: colors.shadow,
         },
       ]}
     >
@@ -99,7 +101,6 @@ const styles = StyleSheet.create({
     paddingBottom: 4,
     paddingHorizontal: 12,
     marginBottom: 12,
-    shadowColor: "rgba(0, 0, 0, 0.1)",
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.08,
     shadowRadius: 4,

--- a/apps/akari/components/ThemedText.tsx
+++ b/apps/akari/components/ThemedText.tsx
@@ -16,6 +16,7 @@ export function ThemedText({
   ...rest
 }: ThemedTextProps) {
   const color = useThemeColor({ light: lightColor, dark: darkColor }, 'text');
+  const linkColor = useThemeColor({}, 'tint');
 
   return (
     <Text
@@ -25,7 +26,7 @@ export function ThemedText({
         type === 'title' ? styles.title : undefined,
         type === 'defaultSemiBold' ? styles.defaultSemiBold : undefined,
         type === 'subtitle' ? styles.subtitle : undefined,
-        type === 'link' ? styles.link : undefined,
+        type === 'link' ? [styles.link, { color: linkColor }] : undefined,
         style,
       ]}
       {...rest}
@@ -55,6 +56,5 @@ const styles = StyleSheet.create({
   link: {
     lineHeight: 30,
     fontSize: 16,
-    color: '#0a7ea4',
   },
 });

--- a/apps/akari/components/profile/FeedsTab.tsx
+++ b/apps/akari/components/profile/FeedsTab.tsx
@@ -1,12 +1,13 @@
 import { FlatList, StyleSheet, TouchableOpacity } from 'react-native';
+import { useMemo } from 'react';
 
 import { FeedSkeleton } from '@/components/skeletons';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { useAuthorFeeds } from '@/hooks/queries/useAuthorFeeds';
-import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useAppTheme, type AppThemeColors } from '@/theme';
 import type { BlueskyFeed } from '@/bluesky-api';
 
 type FeedsTabProps = {
@@ -18,11 +19,9 @@ type FeedItemProps = {
 };
 
 function FeedItem({ feed }: FeedItemProps) {
-  const backgroundColor = useThemeColor({ light: '#ffffff', dark: '#1c1c1e' }, 'background');
-  const borderColor = useThemeColor({ light: '#f0f0f0', dark: '#2c2c2e' }, 'background');
-  const textColor = useThemeColor({ light: '#000000', dark: '#ffffff' }, 'text');
-  const secondaryTextColor = useThemeColor({ light: '#666666', dark: '#8e8e93' }, 'text');
-  const iconColor = useThemeColor({ light: '#007AFF', dark: '#0A84FF' }, 'text');
+  const { colors } = useAppTheme();
+  const themedStyles = useMemo(() => createThemedStyles(colors), [colors]);
+  const iconColor = colors.accent;
 
   const handlePinPress = () => {
     // TODO: Implement pin functionality
@@ -30,33 +29,33 @@ function FeedItem({ feed }: FeedItemProps) {
   };
 
   return (
-    <ThemedView style={[styles.feedContainer, { backgroundColor, borderColor }]}>
+    <ThemedView style={[styles.feedContainer, themedStyles.feedContainer]}>
       <ThemedView style={styles.feedContent}>
         <ThemedView style={styles.feedHeader}>
           <ThemedView style={styles.feedInfo}>
-            <ThemedText style={[styles.feedName, { color: textColor }]} numberOfLines={1}>
+            <ThemedText style={styles.feedName} numberOfLines={1}>
               {feed.displayName}
             </ThemedText>
-            <ThemedText style={[styles.feedCreator, { color: secondaryTextColor }]}>by @{feed.creator.handle}</ThemedText>
+            <ThemedText style={[styles.feedCreator, themedStyles.feedCreator]}>by @{feed.creator.handle}</ThemedText>
           </ThemedView>
 
-          <TouchableOpacity style={styles.pinButton} onPress={handlePinPress} activeOpacity={0.6}>
+          <TouchableOpacity style={[styles.pinButton, themedStyles.pinButton]} onPress={handlePinPress} activeOpacity={0.6}>
             <IconSymbol name="pin" size={18} color={iconColor} />
           </TouchableOpacity>
         </ThemedView>
 
         {feed.description && (
-          <ThemedText style={[styles.feedDescription, { color: secondaryTextColor }]} numberOfLines={2}>
+          <ThemedText style={[styles.feedDescription, themedStyles.feedDescription]} numberOfLines={2}>
             {feed.description}
           </ThemedText>
         )}
 
         <ThemedView style={styles.feedFooter}>
-          <ThemedText style={[styles.likeCount, { color: secondaryTextColor }]}>{feed.likeCount} likes</ThemedText>
+          <ThemedText style={[styles.likeCount, themedStyles.likeCount]}>{feed.likeCount} likes</ThemedText>
 
           {feed.acceptsInteractions && (
-            <ThemedView style={styles.interactionIndicator}>
-              <ThemedText style={styles.interactionText}>Interactive</ThemedText>
+            <ThemedView style={[styles.interactionIndicator, themedStyles.interactionIndicator]}>
+              <ThemedText style={[styles.interactionText, themedStyles.interactionText]}>Interactive</ThemedText>
             </ThemedView>
           )}
         </ThemedView>
@@ -137,8 +136,7 @@ const styles = StyleSheet.create({
     marginHorizontal: 16,
     marginVertical: 6,
     borderRadius: 12,
-    borderWidth: 1,
-    shadowColor: '#000',
+    borderWidth: StyleSheet.hairlineWidth,
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.05,
     shadowRadius: 2,
@@ -187,7 +185,6 @@ const styles = StyleSheet.create({
     fontWeight: '500',
   },
   interactionIndicator: {
-    backgroundColor: '#007AFF',
     paddingHorizontal: 8,
     paddingVertical: 4,
     borderRadius: 10,
@@ -195,6 +192,33 @@ const styles = StyleSheet.create({
   interactionText: {
     fontSize: 11,
     fontWeight: '600',
-    color: '#ffffff',
   },
 });
+
+function createThemedStyles(colors: AppThemeColors) {
+  return StyleSheet.create({
+    feedContainer: {
+      backgroundColor: colors.surface,
+      borderColor: colors.borderMuted,
+      shadowColor: colors.shadow,
+    },
+    pinButton: {
+      backgroundColor: colors.surfaceSecondary,
+    },
+    feedCreator: {
+      color: colors.textSecondary,
+    },
+    feedDescription: {
+      color: colors.textSecondary,
+    },
+    likeCount: {
+      color: colors.textMuted,
+    },
+    interactionIndicator: {
+      backgroundColor: colors.accent,
+    },
+    interactionText: {
+      color: colors.inverseText,
+    },
+  });
+}

--- a/apps/akari/components/profile/StarterpacksTab.tsx
+++ b/apps/akari/components/profile/StarterpacksTab.tsx
@@ -1,11 +1,12 @@
 import { FlatList, StyleSheet } from 'react-native';
+import { useMemo } from 'react';
 
 import { FeedSkeleton } from '@/components/skeletons';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { useAuthorStarterpacks } from '@/hooks/queries/useAuthorStarterpacks';
-import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useAppTheme, type AppThemeColors } from '@/theme';
 import type { BlueskyStarterPack } from '@/bluesky-api';
 
 type StarterpacksTabProps = {
@@ -17,27 +18,25 @@ type StarterpackItemProps = {
 };
 
 function StarterpackItem({ starterpack }: StarterpackItemProps) {
-  const backgroundColor = useThemeColor({ light: '#ffffff', dark: '#1c1c1e' }, 'background');
-  const borderColor = useThemeColor({ light: '#f0f0f0', dark: '#2c2c2e' }, 'background');
-  const textColor = useThemeColor({ light: '#000000', dark: '#ffffff' }, 'text');
-  const secondaryTextColor = useThemeColor({ light: '#666666', dark: '#8e8e93' }, 'text');
+  const { colors } = useAppTheme();
+  const themedStyles = useMemo(() => createThemedStyles(colors), [colors]);
 
   return (
-    <ThemedView style={[styles.starterpackContainer, { backgroundColor, borderColor }]}>
+    <ThemedView style={[styles.starterpackContainer, themedStyles.starterpackContainer]}>
       <ThemedView style={styles.starterpackContent}>
         <ThemedView style={styles.starterpackHeader}>
           <ThemedView style={styles.starterpackInfo}>
-            <ThemedText style={[styles.starterpackName, { color: textColor }]} numberOfLines={1}>
+            <ThemedText style={[styles.starterpackName, themedStyles.starterpackName]} numberOfLines={1}>
               {starterpack.record.name}
             </ThemedText>
-            <ThemedText style={[styles.starterpackCreator, { color: secondaryTextColor }]}>
+            <ThemedText style={[styles.starterpackCreator, themedStyles.starterpackCreator]}>
               by @{starterpack.creator.handle}
             </ThemedText>
           </ThemedView>
         </ThemedView>
 
         {starterpack.record.description && (
-          <ThemedText style={[styles.starterpackDescription, { color: secondaryTextColor }]} numberOfLines={2}>
+          <ThemedText style={[styles.starterpackDescription, themedStyles.starterpackDescription]} numberOfLines={2}>
             {starterpack.record.description}
           </ThemedText>
         )}
@@ -45,14 +44,14 @@ function StarterpackItem({ starterpack }: StarterpackItemProps) {
         <ThemedView style={styles.starterpackFooter}>
           <ThemedView style={styles.statsRow}>
             <ThemedView style={styles.statItem}>
-              <ThemedText style={[styles.statValue, { color: textColor }]}>{starterpack.joinedAllTimeCount}</ThemedText>
-              <ThemedText style={[styles.statLabel, { color: secondaryTextColor }]}>joined</ThemedText>
+              <ThemedText style={[styles.statValue, themedStyles.statValue]}>{starterpack.joinedAllTimeCount}</ThemedText>
+              <ThemedText style={[styles.statLabel, themedStyles.statLabel]}>joined</ThemedText>
             </ThemedView>
 
             {starterpack.joinedWeekCount > 0 && (
               <ThemedView style={styles.statItem}>
-                <ThemedText style={[styles.statValue, { color: textColor }]}>{starterpack.joinedWeekCount}</ThemedText>
-                <ThemedText style={[styles.statLabel, { color: secondaryTextColor }]}>this week</ThemedText>
+                <ThemedText style={[styles.statValue, themedStyles.statValue]}>{starterpack.joinedWeekCount}</ThemedText>
+                <ThemedText style={[styles.statLabel, themedStyles.statLabel]}>this week</ThemedText>
               </ThemedView>
             )}
           </ThemedView>
@@ -134,8 +133,7 @@ const styles = StyleSheet.create({
     marginHorizontal: 16,
     marginVertical: 6,
     borderRadius: 12,
-    borderWidth: 1,
-    shadowColor: '#000',
+    borderWidth: StyleSheet.hairlineWidth,
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.05,
     shadowRadius: 2,
@@ -191,3 +189,28 @@ const styles = StyleSheet.create({
     fontWeight: '500',
   },
 });
+
+function createThemedStyles(colors: AppThemeColors) {
+  return StyleSheet.create({
+    starterpackContainer: {
+      backgroundColor: colors.surface,
+      borderColor: colors.borderMuted,
+      shadowColor: colors.shadow,
+    },
+    starterpackName: {
+      color: colors.text,
+    },
+    starterpackCreator: {
+      color: colors.textSecondary,
+    },
+    starterpackDescription: {
+      color: colors.textSecondary,
+    },
+    statValue: {
+      color: colors.text,
+    },
+    statLabel: {
+      color: colors.textMuted,
+    },
+  });
+}

--- a/apps/akari/components/ui/DialogModal.tsx
+++ b/apps/akari/components/ui/DialogModal.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Modal, Pressable, StyleSheet, View } from 'react-native';
 
+import { useAppTheme } from '@/theme';
+
 type DialogModalProps = {
   children: React.ReactNode;
   isVisible?: boolean;
@@ -9,6 +11,7 @@ type DialogModalProps = {
 };
 
 export function DialogModal({ children, isVisible = true, onRequestClose, testID }: DialogModalProps) {
+  const { colors } = useAppTheme();
   const overlayProps = onRequestClose
     ? {
         accessibilityRole: 'button' as const,
@@ -27,7 +30,7 @@ export function DialogModal({ children, isVisible = true, onRequestClose, testID
       onRequestClose={onRequestClose}
       statusBarTranslucent
     >
-      <View style={styles.overlay} testID={testID}>
+      <View style={[styles.overlay, { backgroundColor: colors.overlay }]} testID={testID}>
         <Pressable style={StyleSheet.absoluteFill} {...overlayProps} />
         <View style={styles.centerContainer} pointerEvents="box-none">
           <Pressable style={styles.contentWrapper} onPress={() => {}}>
@@ -42,7 +45,6 @@ export function DialogModal({ children, isVisible = true, onRequestClose, testID
 const styles = StyleSheet.create({
   overlay: {
     flex: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.55)',
     justifyContent: 'center',
     alignItems: 'center',
     padding: 24,

--- a/apps/akari/components/ui/Panel.tsx
+++ b/apps/akari/components/ui/Panel.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 
 import { ThemedText } from '@/components/ThemedText';
-import { useThemeColor } from '@/hooks/useThemeColor';
+import { useAppTheme } from '@/theme';
 
 type PanelProps = {
   title: React.ReactNode;
@@ -25,10 +25,11 @@ export function Panel({
   contentStyle,
   footerStyle,
 }: PanelProps) {
-  const backgroundColor = useThemeColor({ light: '#ffffff', dark: '#0F1115' }, 'background');
-  const borderColor = useThemeColor({ light: '#E5E7EB', dark: '#1F212D' }, 'border');
-  const headerBackground = useThemeColor({ light: '#F9FAFB', dark: '#151823' }, 'background');
-  const titleColor = useThemeColor({ light: '#111827', dark: '#F4F4F5' }, 'text');
+  const { colors } = useAppTheme();
+  const backgroundColor = colors.surface;
+  const borderColor = colors.border;
+  const headerBackground = colors.surfaceSecondary;
+  const titleColor = colors.text;
 
   return (
     <View

--- a/apps/akari/constants/Colors.ts
+++ b/apps/akari/constants/Colors.ts
@@ -1,28 +1,71 @@
 /**
- * Below are the colors that are used in the app. The colors are defined in the light and dark mode.
- * There are many other ways to style your app. For example, [Nativewind](https://www.nativewind.dev/), [Tamagui](https://tamagui.dev/), [unistyles](https://reactnativeunistyles.vercel.app), etc.
+ * Application color tokens for light and dark modes.
+ * The values mirror the app theme so components using
+ * `useThemeColor` and the raw `Colors` map stay in sync.
  */
 
-const tintColorLight = '#0a7ea4';
-const tintColorDark = '#fff';
+import { themes } from '@/theme';
+
+const light = themes.light.colors;
+const dark = themes.dark.colors;
 
 export const Colors = {
   light: {
-    text: '#11181C',
-    background: '#fff',
-    tint: tintColorLight,
-    icon: '#687076',
-    tabIconDefault: '#687076',
-    tabIconSelected: tintColorLight,
-    border: '#E1E3E5',
+    text: light.text,
+    textSecondary: light.textSecondary,
+    textMuted: light.textMuted,
+    background: light.background,
+    surface: light.surface,
+    surfaceSecondary: light.surfaceSecondary,
+    surfaceTertiary: light.surfaceTertiary,
+    surfaceHover: light.surfaceHover,
+    surfaceActive: light.surfaceActive,
+    tint: light.accent,
+    accent: light.accent,
+    accentMuted: light.accentMuted,
+    icon: light.textSecondary,
+    tabIconDefault: light.textMuted,
+    tabIconSelected: light.accent,
+    border: light.border,
+    borderMuted: light.borderMuted,
+    badge: light.badge,
+    badgeActive: light.badgeActive,
+    overlay: light.overlay,
+    overlayStrong: light.overlayStrong,
+    inverseText: light.inverseText,
+    success: light.success,
+    warning: light.warning,
+    danger: light.danger,
+    info: light.info,
+    shadow: light.shadow,
   },
   dark: {
-    text: '#ECEDEE',
-    background: '#151718',
-    tint: tintColorDark,
-    icon: '#9BA1A6',
-    tabIconDefault: '#9BA1A6',
-    tabIconSelected: tintColorDark,
-    border: '#2A2D2E',
+    text: dark.text,
+    textSecondary: dark.textSecondary,
+    textMuted: dark.textMuted,
+    background: dark.background,
+    surface: dark.surface,
+    surfaceSecondary: dark.surfaceSecondary,
+    surfaceTertiary: dark.surfaceTertiary,
+    surfaceHover: dark.surfaceHover,
+    surfaceActive: dark.surfaceActive,
+    tint: dark.accent,
+    accent: dark.accent,
+    accentMuted: dark.accentMuted,
+    icon: dark.textSecondary,
+    tabIconDefault: dark.textMuted,
+    tabIconSelected: dark.accent,
+    border: dark.border,
+    borderMuted: dark.borderMuted,
+    badge: dark.badge,
+    badgeActive: dark.badgeActive,
+    overlay: dark.overlay,
+    overlayStrong: dark.overlayStrong,
+    inverseText: dark.inverseText,
+    success: dark.success,
+    warning: dark.warning,
+    danger: dark.danger,
+    info: dark.info,
+    shadow: dark.shadow,
   },
-};
+} as const;

--- a/apps/akari/hooks/useBorderColor.ts
+++ b/apps/akari/hooks/useBorderColor.ts
@@ -1,15 +1,12 @@
-import { useThemeColor } from "@/hooks/useThemeColor";
+import { useAppTheme } from '@/theme';
+
+type BorderVariant = 'default' | 'muted';
 
 /**
  * Hook for getting the adaptive border color used throughout the app
  * @returns The border color that adapts to light/dark mode
  */
-export function useBorderColor() {
-  return useThemeColor(
-    {
-      light: "#e8eaed",
-      dark: "#2d3133",
-    },
-    "background"
-  );
+export function useBorderColor(variant: BorderVariant = 'default') {
+  const { colors } = useAppTheme();
+  return variant === 'muted' ? colors.borderMuted : colors.border;
 }

--- a/apps/akari/hooks/useColorScheme.web.ts
+++ b/apps/akari/hooks/useColorScheme.web.ts
@@ -1,21 +1,84 @@
 import { useEffect, useState } from 'react';
 import { useColorScheme as useRNColorScheme } from 'react-native';
 
+type Scheme = 'light' | 'dark';
+
+const DEFAULT_SCHEME: Scheme = 'light';
+
 /**
- * To support static rendering, this value needs to be re-calculated on the client side for web
+ * Web implementation of the color scheme hook.
+ *
+ * React Native Web's `useColorScheme` hook doesn't broadcast updates when the
+ * system appearance changes after hydration. We subscribe to the browser
+ * `matchMedia` API so all themed components respond to system toggles in real
+ * time.
  */
-export function useColorScheme() {
+export function useColorScheme(): Scheme {
+  const supportsMatchMedia = typeof window !== 'undefined' && typeof window.matchMedia === 'function';
+  const nativeScheme = useRNColorScheme();
   const [hasHydrated, setHasHydrated] = useState(false);
+  const [browserScheme, setBrowserScheme] = useState<Scheme | null>(() => {
+    if (!supportsMatchMedia) {
+      return null;
+    }
+
+    try {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    } catch {
+      return null;
+    }
+  });
 
   useEffect(() => {
     setHasHydrated(true);
   }, []);
 
-  const colorScheme = useRNColorScheme();
+  useEffect(() => {
+    if (!supportsMatchMedia) {
+      return;
+    }
 
-  if (hasHydrated) {
-    return colorScheme;
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+    const updateScheme = (target: Pick<MediaQueryList, 'matches'>) => {
+      setBrowserScheme((previous) => {
+        const nextScheme: Scheme = target.matches ? 'dark' : 'light';
+        return previous === nextScheme ? previous : nextScheme;
+      });
+    };
+
+    updateScheme(mediaQuery);
+
+    const listener = (event: MediaQueryListEvent) => updateScheme(event);
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', listener);
+      return () => mediaQuery.removeEventListener('change', listener);
+    }
+
+    mediaQuery.addListener(listener);
+    return () => mediaQuery.removeListener(listener);
+  }, [supportsMatchMedia]);
+
+  useEffect(() => {
+    if (!nativeScheme || browserScheme || supportsMatchMedia) {
+      return;
+    }
+
+    setBrowserScheme(nativeScheme);
+  }, [browserScheme, nativeScheme, supportsMatchMedia]);
+
+  if (!hasHydrated) {
+    return DEFAULT_SCHEME;
   }
 
-  return 'light';
+  if (browserScheme) {
+    return browserScheme;
+  }
+
+  if (nativeScheme === 'dark') {
+    return 'dark';
+  }
+
+  return DEFAULT_SCHEME;
 }

--- a/apps/akari/theme/index.ts
+++ b/apps/akari/theme/index.ts
@@ -1,0 +1,108 @@
+import { useMemo } from 'react';
+import { StyleSheet } from 'react-native';
+
+import { useColorScheme } from '@/hooks/useColorScheme';
+
+export type AppThemeColors = {
+  background: string;
+  surface: string;
+  surfaceSecondary: string;
+  surfaceTertiary: string;
+  surfaceHover: string;
+  surfaceActive: string;
+  border: string;
+  borderMuted: string;
+  shadow: string;
+  text: string;
+  textSecondary: string;
+  textMuted: string;
+  accent: string;
+  accentMuted: string;
+  success: string;
+  warning: string;
+  danger: string;
+  info: string;
+  badge: string;
+  badgeActive: string;
+  inverseText: string;
+  overlay: string;
+  overlayStrong: string;
+};
+
+export type AppTheme = {
+  colors: AppThemeColors;
+};
+
+const lightTheme: AppTheme = {
+  colors: {
+    background: '#F3F4F6',
+    surface: '#FFFFFF',
+    surfaceSecondary: '#F9FAFB',
+    surfaceTertiary: '#EEF2FF',
+    surfaceHover: '#F3F4F6',
+    surfaceActive: '#EEF2FF',
+    border: '#E5E7EB',
+    borderMuted: '#E2E8F0',
+    shadow: 'rgba(15, 23, 42, 0.12)',
+    text: '#1F2937',
+    textSecondary: '#4B5563',
+    textMuted: '#6B7280',
+    accent: '#7C8CF9',
+    accentMuted: '#E0E7FF',
+    success: '#16A34A',
+    warning: '#F59E0B',
+    danger: '#EF4444',
+    info: '#0EA5E9',
+    badge: '#EA580C',
+    badgeActive: '#7C8CF9',
+    inverseText: '#FFFFFF',
+    overlay: 'rgba(15, 23, 42, 0.45)',
+    overlayStrong: 'rgba(15, 23, 42, 0.6)',
+  },
+};
+
+const darkTheme: AppTheme = {
+  colors: {
+    background: '#0F1115',
+    surface: '#151823',
+    surfaceSecondary: '#131722',
+    surfaceTertiary: '#1E2537',
+    surfaceHover: '#1A1D27',
+    surfaceActive: '#1E2537',
+    border: '#1F212D',
+    borderMuted: '#25283A',
+    shadow: 'rgba(2, 6, 23, 0.6)',
+    text: '#F4F4F5',
+    textSecondary: '#A1A1AA',
+    textMuted: '#6B7280',
+    accent: '#7C8CF9',
+    accentMuted: '#2F365F',
+    success: '#22C55E',
+    warning: '#F97316',
+    danger: '#F87171',
+    info: '#38BDF8',
+    badge: '#EA580C',
+    badgeActive: '#7C8CF9',
+    inverseText: '#FFFFFF',
+    overlay: 'rgba(12, 18, 32, 0.65)',
+    overlayStrong: 'rgba(2, 6, 23, 0.75)',
+  },
+};
+
+export const themes = {
+  light: lightTheme,
+  dark: darkTheme,
+} as const;
+
+export function useAppTheme(): AppTheme {
+  const scheme = useColorScheme() ?? 'light';
+
+  return useMemo(() => (scheme === 'dark' ? darkTheme : lightTheme), [scheme]);
+}
+
+export function useThemedStyles<T extends StyleSheet.NamedStyles<T> | StyleSheet.NamedStyles<any>>(
+  stylesFactory: (theme: AppTheme) => T,
+): T {
+  const theme = useAppTheme();
+  return useMemo(() => StyleSheet.create(stylesFactory(theme)), [stylesFactory, theme]);
+}


### PR DESCRIPTION
## Summary
- introduce a centralized light/dark theme module that drives the Colors map and border hook
- refactor sidebar, tab chrome, panels, and modal surfaces to consume the shared theme tokens
- update unit tests for tab chrome and badges to mock the new theme hook

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68cdba645c18832ba837ff18fbe8513d