### PR TITLE
docs: add outstanding app todos checklist

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,21 @@
+# Outstanding App TODOs
+
+This checklist aggregates the TODO comments currently in the Akari app so we can track unfinished functionality.
+
+## Profile header actions (`apps/akari/components/ProfileHeader.tsx`)
+
+- [ ] Replace the placeholder "Add to lists" alert with real list management UI or navigation.
+- [ ] Implement full mute/unmute handling, including wiring the confirmation alert to an actual API call.
+- [ ] Integrate the report account alert with the real reporting API.
+
+## Profile screens (`apps/akari/app/profile/[handle].tsx` and `apps/akari/app/(tabs)/profile.tsx`)
+
+- [ ] Implement the "Search posts" action exposed in the profile dropdown.
+- [ ] Implement the "Add to lists" action exposed in the profile dropdown.
+- [ ] Implement the mute/unmute action exposed in the profile dropdown.
+- [ ] Implement the block/unblock action exposed in the profile dropdown.
+- [ ] Implement the report account action exposed in the profile dropdown.
+
+## Feeds tab (`apps/akari/components/profile/FeedsTab.tsx`)
+
+- [ ] Implement pinning functionality for authored feeds.


### PR DESCRIPTION
## Summary
- add a repository-level TODO checklist that aggregates outstanding profile and feed interactions still marked as TODO in the app

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d076e98ff8832b81bbdc82ede3badd