### PR TITLE
feat: add conversation options menu

### DIFF
--- a/apps/akari/components/ui/IconSymbol.tsx
+++ b/apps/akari/components/ui/IconSymbol.tsx
@@ -48,6 +48,10 @@ const MAPPING = {
   'checkmark.circle.fill': 'check-circle',
   'info.circle.fill': 'info',
   'exclamationmark.triangle.fill': 'warning',
+  'speaker.slash.fill': 'volume-off',
+  'hand.raised.fill': 'block',
+  'flag.fill': 'flag',
+  'rectangle.portrait.and.arrow.right': 'logout',
 } as unknown as IconMapping;
 
 /**

--- a/apps/akari/translations/en-US.json
+++ b/apps/akari/translations/en-US.json
@@ -234,7 +234,15 @@
     },
     "messages": {
       "typeMessage": "Type a message...",
-      "errorSendingMessage": "Failed to send message. Please try again."
+      "errorSendingMessage": "Failed to send message. Please try again.",
+      "goToProfile": "Go to profile",
+      "muteConversation": "Mute conversation",
+      "unmuteConversation": "Unmute conversation",
+      "blockAccount": "Block account",
+      "reportConversation": "Report conversation",
+      "leaveConversation": "Leave conversation",
+      "actionUnavailable": "This action isn't available yet.",
+      "conversationOptions": "Conversation options"
     },
     "settings": {
       "account": "Account",

--- a/apps/akari/translations/en.json
+++ b/apps/akari/translations/en.json
@@ -244,7 +244,15 @@
     },
     "messages": {
       "typeMessage": "Type a message...",
-      "errorSendingMessage": "Failed to send message. Please try again."
+      "errorSendingMessage": "Failed to send message. Please try again.",
+      "goToProfile": "Go to profile",
+      "muteConversation": "Mute conversation",
+      "unmuteConversation": "Unmute conversation",
+      "blockAccount": "Block account",
+      "reportConversation": "Report conversation",
+      "leaveConversation": "Leave conversation",
+      "actionUnavailable": "This action isn't available yet.",
+      "conversationOptions": "Conversation options"
     },
     "settings": {
       "account": "Account",


### PR DESCRIPTION
## Summary
- add an overflow menu to chat conversations with navigation and placeholder actions
- extend IconSymbol mappings to cover the new conversation menu icons
- add conversation-related translations for the new menu entries

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0818614f8832b992db5bc83da5e93