### PR TITLE
fix: add background for incoming messages

### DIFF
--- a/apps/akari/__tests__/app/tabs/messages-handle.test.tsx
+++ b/apps/akari/__tests__/app/tabs/messages-handle.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react-native';
-import { FlatList, Keyboard, KeyboardAvoidingView, Platform, TouchableOpacity } from 'react-native';
+import { FlatList, Keyboard, KeyboardAvoidingView, Platform, StyleSheet, TouchableOpacity } from 'react-native';
 
 import ConversationScreen from '@/app/(tabs)/messages/[handle]';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -293,6 +293,38 @@ describe('ConversationScreen', () => {
     const { getByText } = render(<ConversationScreen />);
 
     expect(getByText('Loading messages...')).toBeTruthy();
+  });
+
+  it('applies distinct backgrounds to incoming and outgoing messages', () => {
+    const conversation = { handle: 'alice', convoId: '1' };
+    const messages: Message[] = [
+      { id: 'incoming', text: 'incoming message', timestamp: '10:00', isFromMe: false, sentAt: '' },
+      { id: 'outgoing', text: 'outgoing message', timestamp: '10:05', isFromMe: true, sentAt: '' },
+    ];
+    mockUseConversations.mockReturnValue({ data: { pages: [{ conversations: [conversation] }] } });
+    mockUseMessages.mockReturnValue({
+      data: { pages: [{ messages }] },
+      isLoading: false,
+      error: null,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    mockUseSendMessage.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+
+    const { getByText } = render(<ConversationScreen />);
+
+    const incomingNode = getByText('incoming message');
+    const outgoingNode = getByText('outgoing message');
+
+    const incomingBubble = incomingNode.parent?.parent?.parent as any;
+    const outgoingBubble = outgoingNode.parent?.parent?.parent as any;
+
+    const incomingStyles = StyleSheet.flatten(incomingBubble?.props.style);
+    const outgoingStyles = StyleSheet.flatten(outgoingBubble?.props.style);
+
+    expect(incomingStyles?.backgroundColor).toBe('#F3F4F6');
+    expect(outgoingStyles?.backgroundColor).toBe('#007AFF');
   });
 
   it('renders outgoing messages and updates keyboard spacing', () => {

--- a/apps/akari/app/(tabs)/messages/[handle].tsx
+++ b/apps/akari/app/(tabs)/messages/[handle].tsx
@@ -40,6 +40,10 @@ export default function ConversationScreen() {
   const backgroundColor = useThemeColor({}, 'background');
   const textColor = useThemeColor({}, 'text');
   const iconColor = useThemeColor({}, 'icon');
+  const incomingMessageBackground = useThemeColor(
+    { light: '#F3F4F6', dark: '#1E2537' },
+    'background',
+  );
 
   // Keyboard state
   useEffect(() => {
@@ -98,7 +102,7 @@ export default function ConversationScreen() {
           styles.messageBubble,
           item.isFromMe ? styles.myBubble : styles.theirBubble,
           {
-            backgroundColor: item.isFromMe ? '#007AFF' : backgroundColor,
+            backgroundColor: item.isFromMe ? '#007AFF' : incomingMessageBackground,
           },
         ]}
       >


### PR DESCRIPTION
## Summary
- add a dedicated themed background color for incoming message bubbles so they stand out against the conversation surface
- add a regression test that ensures incoming and outgoing messages render with the expected backgrounds

## Testing
- npm --prefix apps/akari run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68d08072975c832b9bc2357a8204f3f6