### PR TITLE
feat: add mobile navigation to responsive layout

### DIFF
--- a/apps/akari/__tests__/app/post-id.test.tsx
+++ b/apps/akari/__tests__/app/post-id.test.tsx
@@ -13,6 +13,11 @@ jest.mock('expo-router', () => {
     Stack: { Screen: jest.fn(() => null) },
   };
 });
+jest.mock('@/components/ResponsiveLayout', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return { ResponsiveLayout: ({ children }: any) => <View>{children}</View> };
+});
 
 jest.mock('@/components/PostCard', () => {
   const React = require('react');

--- a/apps/akari/__tests__/app/profile/[handle].test.tsx
+++ b/apps/akari/__tests__/app/profile/[handle].test.tsx
@@ -20,6 +20,11 @@ jest.mock('@/contexts/ToastContext');
 jest.mock('expo-clipboard', () => ({
   setStringAsync: jest.fn(),
 }));
+jest.mock('@/components/ResponsiveLayout', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return { ResponsiveLayout: ({ children }: any) => <View>{children}</View> };
+});
 
 jest.mock('@/components/ProfileHeader', () => {
   const React = require('react');

--- a/apps/akari/__tests__/components/ResponsiveLayout.test.tsx
+++ b/apps/akari/__tests__/components/ResponsiveLayout.test.tsx
@@ -3,10 +3,8 @@ import { Text } from 'react-native';
 
 import { ResponsiveLayout } from '@/components/ResponsiveLayout';
 import { useResponsive } from '@/hooks/useResponsive';
-import { useThemeColor } from '@/hooks/useThemeColor';
 
 jest.mock('@/hooks/useResponsive');
-jest.mock('@/hooks/useThemeColor');
 jest.mock('@/components/Sidebar', () => {
   const React = require('react');
   const { View } = require('react-native');
@@ -16,28 +14,32 @@ jest.mock('@/components/ThemedView', () => {
   const { View } = require('react-native');
   return { ThemedView: ({ children, ...props }: any) => <View {...props}>{children}</View> };
 });
+jest.mock('@/components/MobileBottomNav', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return { MobileBottomNav: () => <View testID="mobile-nav" /> };
+});
 
 const mockUseResponsive = useResponsive as jest.Mock;
-const mockUseThemeColor = useThemeColor as jest.Mock;
 
 describe('ResponsiveLayout', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseThemeColor.mockReturnValue('#fff');
   });
 
   it('renders sidebar on large screens', () => {
     mockUseResponsive.mockReturnValue({ isLargeScreen: true });
-    const { getByTestId, getByText } = render(
+    const { getByTestId, getByText, queryByTestId } = render(
       <ResponsiveLayout>
         <Text>Child</Text>
       </ResponsiveLayout>,
     );
     expect(getByTestId('sidebar')).toBeTruthy();
     expect(getByText('Child')).toBeTruthy();
+    expect(queryByTestId('mobile-nav')).toBeNull();
   });
 
-  it('renders children only on small screens', () => {
+  it('renders mobile navigation on small screens', () => {
     mockUseResponsive.mockReturnValue({ isLargeScreen: false });
     const { queryByTestId, getByText } = render(
       <ResponsiveLayout>
@@ -46,5 +48,6 @@ describe('ResponsiveLayout', () => {
     );
     expect(getByText('Child')).toBeTruthy();
     expect(queryByTestId('sidebar')).toBeNull();
+    expect(queryByTestId('mobile-nav')).toBeTruthy();
   });
 });

--- a/apps/akari/app/profile/[handle].tsx
+++ b/apps/akari/app/profile/[handle].tsx
@@ -16,6 +16,7 @@ import { RepliesTab } from '@/components/profile/RepliesTab';
 import { StarterpacksTab } from '@/components/profile/StarterpacksTab';
 import { VideosTab } from '@/components/profile/VideosTab';
 import { ProfileHeaderSkeleton } from '@/components/skeletons';
+import { ResponsiveLayout } from '@/components/ResponsiveLayout';
 import { useToast } from '@/contexts/ToastContext';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useProfile } from '@/hooks/queries/useProfile';
@@ -36,14 +37,22 @@ export default function ProfileScreen() {
   const { data: profile, isLoading, error } = useProfile(handle);
 
   if (isLoading) {
-    return <ProfileHeaderSkeleton />;
+    return (
+      <ResponsiveLayout>
+        <ThemedView style={styles.container}>
+          <ProfileHeaderSkeleton />
+        </ThemedView>
+      </ResponsiveLayout>
+    );
   }
 
   if (error || !profile) {
     return (
-      <ThemedView style={styles.container}>
-        <ThemedText style={styles.errorText}>{t('common.noProfile')}</ThemedText>
-      </ThemedView>
+      <ResponsiveLayout>
+        <ThemedView style={styles.container}>
+          <ThemedText style={styles.errorText}>{t('common.noProfile')}</ThemedText>
+        </ThemedView>
+      </ResponsiveLayout>
     );
   }
 
@@ -147,57 +156,59 @@ export default function ProfileScreen() {
   };
 
   return (
-    <ThemedView style={styles.container}>
-      <ScrollView
-        style={styles.scrollView}
-        contentContainerStyle={styles.scrollViewContent}
-        showsVerticalScrollIndicator={false}
-      >
-        <ProfileHeader
-          profile={{
-            avatar: profile?.avatar,
-            displayName: profile?.displayName,
-            handle: profile?.handle,
-            description: profile?.description,
-            banner: profile?.banner,
-            did: profile?.did,
-            followersCount: profile?.followersCount,
-            followsCount: profile?.followsCount,
-            postsCount: profile?.postsCount,
-            viewer: profile?.viewer,
-            labels: profile?.labels,
-          }}
+    <ResponsiveLayout>
+      <ThemedView style={styles.container}>
+        <ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={styles.scrollViewContent}
+          showsVerticalScrollIndicator={false}
+        >
+          <ProfileHeader
+            profile={{
+              avatar: profile?.avatar,
+              displayName: profile?.displayName,
+              handle: profile?.handle,
+              description: profile?.description,
+              banner: profile?.banner,
+              did: profile?.did,
+              followersCount: profile?.followersCount,
+              followsCount: profile?.followsCount,
+              postsCount: profile?.postsCount,
+              viewer: profile?.viewer,
+              labels: profile?.labels,
+            }}
+            isOwnProfile={isOwnProfile}
+            onDropdownToggle={handleDropdownToggle}
+            dropdownRef={dropdownRef}
+          />
+
+          {/* Tabs */}
+          <ProfileTabs activeTab={activeTab} onTabChange={setActiveTab} profileHandle={profile.handle} />
+
+          {/* Content */}
+          {renderTabContent()}
+        </ScrollView>
+
+        {/* Dropdown rendered at root level */}
+        <ProfileDropdown
+          isVisible={showDropdown}
+          onCopyLink={handleCopyLink}
+          onSearchPosts={handleSearchPosts}
+          onAddToLists={handleAddToLists}
+          onMuteAccount={handleMuteAccount}
+          onBlockPress={handleBlockPress}
+          onReportAccount={handleReportAccount}
+          isFollowing={!!profile?.viewer?.following}
+          isBlocking={!!profile?.viewer?.blocking}
+          isMuted={!!profile?.viewer?.muted}
           isOwnProfile={isOwnProfile}
-          onDropdownToggle={handleDropdownToggle}
-          dropdownRef={dropdownRef}
+          style={{
+            top: dropdownPosition.top,
+            right: dropdownPosition.right,
+          }}
         />
-
-        {/* Tabs */}
-        <ProfileTabs activeTab={activeTab} onTabChange={setActiveTab} profileHandle={profile.handle} />
-
-        {/* Content */}
-        {renderTabContent()}
-      </ScrollView>
-
-      {/* Dropdown rendered at root level */}
-      <ProfileDropdown
-        isVisible={showDropdown}
-        onCopyLink={handleCopyLink}
-        onSearchPosts={handleSearchPosts}
-        onAddToLists={handleAddToLists}
-        onMuteAccount={handleMuteAccount}
-        onBlockPress={handleBlockPress}
-        onReportAccount={handleReportAccount}
-        isFollowing={!!profile?.viewer?.following}
-        isBlocking={!!profile?.viewer?.blocking}
-        isMuted={!!profile?.viewer?.muted}
-        isOwnProfile={isOwnProfile}
-        style={{
-          top: dropdownPosition.top,
-          right: dropdownPosition.right,
-        }}
-      />
-    </ThemedView>
+      </ThemedView>
+    </ResponsiveLayout>
   );
 }
 

--- a/apps/akari/components/MobileBottomNav.tsx
+++ b/apps/akari/components/MobileBottomNav.tsx
@@ -1,0 +1,197 @@
+import { usePathname, useRouter } from 'expo-router';
+import { useCallback, useMemo, useState } from 'react';
+import { Platform, Pressable, StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { AccountSwitcherSheet } from '@/components/AccountSwitcherSheet';
+import { IconSymbol } from '@/components/ui/IconSymbol';
+import { TabBadge } from '@/components/TabBadge';
+import { useBorderColor } from '@/hooks/useBorderColor';
+import { useResponsive } from '@/hooks/useResponsive';
+import { useThemeColor } from '@/hooks/useThemeColor';
+import { useUnreadMessagesCount } from '@/hooks/queries/useUnreadMessagesCount';
+import { useUnreadNotificationsCount } from '@/hooks/queries/useUnreadNotificationsCount';
+
+type NavKey = 'timeline' | 'search' | 'messages' | 'notifications' | 'profile' | 'settings';
+
+type NavItem = {
+  key: NavKey;
+  icon: React.ComponentProps<typeof IconSymbol>['name'];
+  route: string;
+  badge?: number | null;
+};
+
+export function MobileBottomNav() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { bottom } = useSafeAreaInsets();
+  const { isLargeScreen } = useResponsive();
+  const [isAccountSwitcherVisible, setAccountSwitcherVisible] = useState(false);
+
+  const borderColor = useBorderColor();
+  const tabBarSurface = useThemeColor({ light: '#F3F4F6', dark: '#0B0F19' }, 'background');
+  const inactiveTint = useThemeColor({ light: '#6B7280', dark: '#9CA3AF' }, 'text');
+  const accentColor = useThemeColor({ light: '#7C8CF9', dark: '#7C8CF9' }, 'tint');
+  const inactiveBackground = useThemeColor({ light: '#F3F4F6', dark: '#111827' }, 'background');
+  const activeBackground = useThemeColor({ light: '#FFFFFF', dark: '#1E2537' }, 'background');
+
+  const shouldRenderNav = Platform.OS !== 'web' && !isLargeScreen;
+
+  const { data: unreadMessagesCount = 0 } = useUnreadMessagesCount(shouldRenderNav);
+  const { data: unreadNotificationsCount = 0 } = useUnreadNotificationsCount(shouldRenderNav);
+
+  const navItems = useMemo<NavItem[]>(
+    () => [
+      { key: 'timeline', icon: 'house.fill', route: '/(tabs)' },
+      { key: 'search', icon: 'magnifyingglass', route: '/(tabs)/search' },
+      {
+        key: 'messages',
+        icon: 'message.fill',
+        route: '/(tabs)/messages',
+        badge: unreadMessagesCount,
+      },
+      {
+        key: 'notifications',
+        icon: 'bell.fill',
+        route: '/(tabs)/notifications',
+        badge: unreadNotificationsCount,
+      },
+      { key: 'profile', icon: 'person.fill', route: '/(tabs)/profile' },
+      { key: 'settings', icon: 'gearshape.fill', route: '/(tabs)/settings' },
+    ],
+    [unreadMessagesCount, unreadNotificationsCount],
+  );
+
+  const activeKey = useMemo<NavKey>(() => {
+    if (!pathname) {
+      return 'timeline';
+    }
+
+    if (pathname.startsWith('/(tabs)/search') || pathname.startsWith('/search')) {
+      return 'search';
+    }
+
+    if (pathname.startsWith('/(tabs)/messages') || pathname.startsWith('/messages')) {
+      return 'messages';
+    }
+
+    if (pathname.startsWith('/(tabs)/notifications') || pathname.startsWith('/notifications')) {
+      return 'notifications';
+    }
+
+    if (pathname.startsWith('/(tabs)/profile') || pathname.startsWith('/profile')) {
+      return 'profile';
+    }
+
+    if (pathname.startsWith('/(tabs)/settings') || pathname.startsWith('/settings')) {
+      return 'settings';
+    }
+
+    return 'timeline';
+  }, [pathname]);
+
+  const handleNavigate = useCallback(
+    (item: NavItem) => {
+      router.push(item.route as never);
+    },
+    [router],
+  );
+
+  const handleOpenAccountSwitcher = useCallback(() => {
+    setAccountSwitcherVisible(true);
+  }, []);
+
+  const handleCloseAccountSwitcher = useCallback(() => {
+    setAccountSwitcherVisible(false);
+  }, []);
+
+  if (!shouldRenderNav) {
+    return null;
+  }
+
+  return (
+    <>
+      <View
+        style={[
+          styles.container,
+          {
+            borderColor,
+            backgroundColor: tabBarSurface,
+            paddingBottom: bottom + 18,
+          },
+        ]}
+      >
+        {navItems.map((item) => {
+          const isActive = item.key === activeKey;
+          const iconColor = isActive ? accentColor : inactiveTint;
+          const showBadge = (item.badge ?? 0) > 0;
+
+          return (
+            <Pressable
+              key={item.key}
+              accessibilityRole="button"
+              accessibilityState={{ selected: isActive }}
+              style={({ pressed }) => [
+                styles.button,
+                {
+                  borderColor: isActive ? accentColor : borderColor,
+                  backgroundColor: isActive ? activeBackground : inactiveBackground,
+                },
+                pressed && styles.buttonPressed,
+              ]}
+              onPress={() => handleNavigate(item)}
+              onLongPress={item.key === 'profile' ? handleOpenAccountSwitcher : undefined}
+            >
+              <View style={[styles.indicator, { backgroundColor: isActive ? accentColor : 'transparent' }]} />
+              <View style={styles.iconContainer}>
+                <IconSymbol name={item.icon} color={iconColor} size={26} />
+                {showBadge ? <TabBadge count={item.badge ?? 0} size="small" /> : null}
+              </View>
+            </Pressable>
+          );
+        })}
+      </View>
+      <AccountSwitcherSheet visible={isAccountSwitcherVisible} onClose={handleCloseAccountSwitcher} />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    borderTopWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: 12,
+    paddingTop: 8,
+    gap: 8,
+    shadowColor: 'rgba(12, 14, 24, 0.28)',
+    shadowOffset: { width: 0, height: -8 },
+    shadowOpacity: 0.18,
+    shadowRadius: 20,
+    elevation: 10,
+  },
+  button: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 0,
+    paddingVertical: 10,
+    position: 'relative',
+    overflow: 'hidden',
+  },
+  buttonPressed: {
+    opacity: 0.85,
+  },
+  indicator: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 3,
+  },
+  iconContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    position: 'relative',
+  },
+});

--- a/apps/akari/components/ResponsiveLayout.tsx
+++ b/apps/akari/components/ResponsiveLayout.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
+import { MobileBottomNav } from '@/components/MobileBottomNav';
 import { Sidebar } from '@/components/Sidebar';
 import { ThemedView } from '@/components/ThemedView';
 import { useResponsive } from '@/hooks/useResponsive';
 
-interface ResponsiveLayoutProps {
+type ResponsiveLayoutProps = {
   children: React.ReactNode;
-}
+};
 
 export function ResponsiveLayout({ children }: ResponsiveLayoutProps) {
   const { isLargeScreen } = useResponsive();
+  const shouldShowSidebar = Platform.OS === 'web' || isLargeScreen;
 
-  if (isLargeScreen) {
+  if (shouldShowSidebar) {
     return (
       <ThemedView style={{ flex: 1 }}>
         <View
@@ -45,5 +47,10 @@ export function ResponsiveLayout({ children }: ResponsiveLayoutProps) {
     );
   }
 
-  return <>{children}</>;
+  return (
+    <View style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>{children}</View>
+      <MobileBottomNav />
+    </View>
+  );
 }


### PR DESCRIPTION
## Summary
- add a shared mobile bottom navigation component so responsive layouts retain tab access on small screens
- update the responsive layout to render the sidebar on web/large screens and mobile nav on native phones
- wrap the profile handle route in the responsive layout and refresh related tests

## Testing
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68d080b512e8832b8fee5c2c68338347