### PR TITLE
feat: add new chat panel for messages

### DIFF
--- a/apps/akari/app/(tabs)/messages/index.tsx
+++ b/apps/akari/app/(tabs)/messages/index.tsx
@@ -5,7 +5,11 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
+import { StartChatPanel } from '@/components/StartChatPanel';
 import { IconSymbol } from '@/components/ui/IconSymbol';
+import { DialogModal } from '@/components/ui/DialogModal';
+import { useDialogManager } from '@/contexts/DialogContext';
+import { NEW_CHAT_PANEL_ID } from '@/constants/dialogs';
 import { ConversationSkeleton } from '@/components/skeletons';
 import { useConversations } from '@/hooks/queries/useConversations';
 import { useBorderColor } from '@/hooks/useBorderColor';
@@ -53,6 +57,7 @@ export function MessagesListScreen({
   const borderColor = useBorderColor();
   const flatListRef = React.useRef<FlatList>(null);
   const { t } = useTranslation();
+  const dialogManager = useDialogManager();
 
   const scrollToTop = React.useCallback(() => {
     flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
@@ -76,6 +81,19 @@ export function MessagesListScreen({
 
     return flattened.filter((conversation) => conversation.status === status);
   }, [conversationsData, status]);
+
+  const handleOpenNewChat = React.useCallback(() => {
+    const closePanel = () => dialogManager.close(NEW_CHAT_PANEL_ID);
+
+    dialogManager.open({
+      id: NEW_CHAT_PANEL_ID,
+      component: (
+        <DialogModal onRequestClose={closePanel}>
+          <StartChatPanel panelId={NEW_CHAT_PANEL_ID} />
+        </DialogModal>
+      ),
+    });
+  }, [dialogManager]);
 
   const renderConversation = ({ item }: { item: Conversation }) => (
     <TouchableOpacity
@@ -157,15 +175,27 @@ export function MessagesListScreen({
           ) : null}
           <ThemedText style={styles.title}>{t(titleKey)}</ThemedText>
         </ThemedView>
-        {pendingButtonConfig ? (
+        <ThemedView style={styles.headerActions}>
           <TouchableOpacity
-            style={styles.pendingButton}
-            onPress={pendingButtonConfig.onPress}
-            activeOpacity={0.7}
+            style={styles.newChatButton}
+            onPress={handleOpenNewChat}
+            activeOpacity={0.8}
+            accessibilityRole="button"
+            accessibilityLabel={t('common.newChat')}
           >
-            <ThemedText style={styles.pendingButtonText}>{t(pendingButtonConfig.labelKey)}</ThemedText>
+            <IconSymbol name="plus" size={16} color="#ffffff" />
+            <ThemedText style={styles.newChatButtonText}>{t('common.newChat')}</ThemedText>
           </TouchableOpacity>
-        ) : null}
+          {pendingButtonConfig ? (
+            <TouchableOpacity
+              style={styles.pendingButton}
+              onPress={pendingButtonConfig.onPress}
+              activeOpacity={0.7}
+            >
+              <ThemedText style={styles.pendingButtonText}>{t(pendingButtonConfig.labelKey)}</ThemedText>
+            </TouchableOpacity>
+          ) : null}
+        </ThemedView>
       </ThemedView>
 
       <FlatList
@@ -241,11 +271,30 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: 'bold',
   },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  newChatButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#0A84FF',
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+    borderRadius: 16,
+  },
+  newChatButtonText: {
+    color: '#ffffff',
+    fontSize: 14,
+    fontWeight: '600',
+    marginLeft: 6,
+  },
   pendingButton: {
     backgroundColor: '#007AFF',
     paddingHorizontal: 12,
     paddingVertical: 6,
     borderRadius: 16,
+    marginLeft: 8,
   },
   pendingButtonText: {
     color: 'white',

--- a/apps/akari/components/StartChatPanel.tsx
+++ b/apps/akari/components/StartChatPanel.tsx
@@ -1,0 +1,392 @@
+import { useRouter } from 'expo-router';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Image } from 'expo-image';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { IconSymbol } from '@/components/ui/IconSymbol';
+import { Panel } from '@/components/ui/Panel';
+import { useDialogManager } from '@/contexts/DialogContext';
+import { NEW_CHAT_PANEL_ID } from '@/constants/dialogs';
+import { useCreateConversation } from '@/hooks/mutations/useCreateConversation';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import {
+  useProfileSearch,
+  type ProfileSearchError,
+  type ProfileSearchResult,
+} from '@/hooks/queries/useProfileSearch';
+import { useThemeColor } from '@/hooks/useThemeColor';
+import { useTranslation } from '@/hooks/useTranslation';
+import { showAlert } from '@/utils/alert';
+
+import type { CreateConversationError } from '@/hooks/mutations/useCreateConversation';
+
+type StartChatPanelProps = {
+  panelId?: string;
+};
+
+export function StartChatPanel({ panelId = NEW_CHAT_PANEL_ID }: StartChatPanelProps) {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const dialogManager = useDialogManager();
+  const { data: currentAccount } = useCurrentAccount();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedProfile, setSelectedProfile] = useState<ProfileSearchResult | null>(null);
+
+  const createConversationMutation = useCreateConversation();
+  const { data, isFetching, isError, error } = useProfileSearch(searchQuery);
+
+  const filteredProfiles = useMemo(() => {
+    const baseProfiles = data?.profiles ?? [];
+
+    if (!currentAccount?.did) {
+      return baseProfiles.slice();
+    }
+
+    return baseProfiles.filter((profile) => profile.did !== currentAccount.did);
+  }, [data?.profiles, currentAccount?.did]);
+
+  useEffect(() => {
+    if (selectedProfile && !filteredProfiles.some((profile) => profile.did === selectedProfile.did)) {
+      setSelectedProfile(null);
+    }
+  }, [filteredProfiles, selectedProfile]);
+
+  const hasMinimumQuery = searchQuery.trim().length >= 2;
+  const isSubmitting = createConversationMutation.isPending;
+
+  const borderColor = useThemeColor({ light: '#E5E7EB', dark: '#1F212D' }, 'border');
+  const inputBackground = useThemeColor({ light: '#ffffff', dark: '#111827' }, 'background');
+  const labelColor = useThemeColor({ light: '#374151', dark: '#E2E8F0' }, 'text');
+  const mutedColor = useThemeColor({ light: '#6B7280', dark: '#9CA3AF' }, 'text');
+  const textColor = useThemeColor({}, 'text');
+  const iconColor = useThemeColor({ light: '#4B5563', dark: '#9CA3AF' }, 'icon');
+  const tintColor = useThemeColor({}, 'tint');
+  const selectedBackground = useThemeColor({ light: '#EFF6FF', dark: '#1E2537' }, 'background');
+  const errorColor = '#EF4444';
+
+  const handleDismiss = () => {
+    if (isSubmitting) {
+      return;
+    }
+
+    dialogManager.close(panelId);
+  };
+
+  const handleStartChat = async () => {
+    if (!selectedProfile) {
+      return;
+    }
+
+    if (selectedProfile.did === currentAccount?.did) {
+      showAlert({
+        title: t('common.error'),
+        message: t('messages.cannotStartChatWithSelf'),
+      });
+      return;
+    }
+
+    try {
+      await createConversationMutation.mutateAsync({ did: selectedProfile.did });
+      dialogManager.close(panelId);
+      router.push(`/(tabs)/messages/${encodeURIComponent(selectedProfile.handle)}`);
+    } catch (mutationError) {
+      const createError = mutationError as CreateConversationError | Error;
+      const message = 'message' in createError ? createError.message : undefined;
+
+      showAlert({
+        title: t('common.error'),
+        message: message ?? t('messages.errorStartingChat'),
+      });
+    }
+  };
+
+  const renderResults = () => {
+    if (!hasMinimumQuery) {
+      return (
+        <ThemedText style={[styles.helperText, { color: mutedColor }]}>
+          {t('messages.searchMinimumCharacters')}
+        </ThemedText>
+      );
+    }
+
+    if (isError) {
+      const searchError = error as ProfileSearchError;
+      return (
+        <ThemedText style={[styles.helperText, { color: errorColor }]}>
+          {searchError.message}
+        </ThemedText>
+      );
+    }
+
+    if (!isFetching && filteredProfiles.length === 0) {
+      return (
+        <ThemedText style={[styles.helperText, { color: mutedColor }]}>
+          {t('search.noUsersFound')}
+        </ThemedText>
+      );
+    }
+
+    return (
+      <View>
+        {filteredProfiles.map((profile, index) => {
+          const isSelected = selectedProfile?.did === profile.did;
+
+          return (
+            <TouchableOpacity
+              key={profile.did}
+              accessibilityRole="button"
+              activeOpacity={0.8}
+              onPress={() => setSelectedProfile(profile)}
+              disabled={isSubmitting}
+              style={[
+                styles.resultItem,
+                index > 0 ? styles.resultItemSpacing : null,
+                {
+                  borderColor: isSelected ? tintColor : borderColor,
+                  backgroundColor: isSelected ? selectedBackground : inputBackground,
+                },
+              ]}
+            >
+              {profile.avatar ? (
+                <Image source={{ uri: profile.avatar }} style={styles.avatarImage} contentFit="cover" />
+              ) : (
+                <View style={[styles.avatarFallback, { backgroundColor: tintColor }]}>
+                  <ThemedText style={styles.avatarInitial}>
+                    {(profile.displayName || profile.handle).charAt(0).toUpperCase()}
+                  </ThemedText>
+                </View>
+              )}
+
+              <View style={styles.resultInfo}>
+                <ThemedText style={[styles.resultDisplayName, { color: textColor }]} numberOfLines={1}>
+                  {profile.displayName}
+                </ThemedText>
+                <ThemedText style={[styles.resultHandle, { color: mutedColor }]} numberOfLines={1}>
+                  @{profile.handle}
+                </ThemedText>
+                {profile.description ? (
+                  <ThemedText style={[styles.resultDescription, { color: mutedColor }]} numberOfLines={2}>
+                    {profile.description}
+                  </ThemedText>
+                ) : null}
+              </View>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    );
+  };
+
+  const startChatLabel = isSubmitting ? t('messages.startingChat') : t('messages.startChat');
+
+  return (
+    <Panel
+      title={t('messages.startNewChat')}
+      headerActions={
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessibilityLabel={t('common.cancel')}
+          onPress={handleDismiss}
+          disabled={isSubmitting}
+          style={[styles.iconButton, isSubmitting ? styles.disabledButton : null]}
+        >
+          <IconSymbol name="xmark" size={18} color={iconColor} />
+        </TouchableOpacity>
+      }
+      footerActions={
+        <View style={styles.footerActions}>
+          <TouchableOpacity
+            accessibilityRole="button"
+            onPress={handleDismiss}
+            disabled={isSubmitting}
+            style={[styles.secondaryButton, isSubmitting ? styles.disabledButton : null]}
+          >
+            <ThemedText style={[styles.secondaryButtonText, { color: labelColor }]}>
+              {t('common.cancel')}
+            </ThemedText>
+          </TouchableOpacity>
+          <TouchableOpacity
+            accessibilityRole="button"
+            onPress={handleStartChat}
+            disabled={!selectedProfile || isSubmitting}
+            style={[
+              styles.primaryButton,
+              (!selectedProfile || isSubmitting) && styles.disabledPrimaryButton,
+            ]}
+          >
+            <ThemedText style={styles.primaryButtonText}>{startChatLabel}</ThemedText>
+          </TouchableOpacity>
+        </View>
+      }
+    >
+      <ThemedView>
+        <ThemedText style={[styles.description, { color: mutedColor }]}>
+          {t('messages.startNewChatDescription')}
+        </ThemedText>
+
+        <View style={styles.fieldGroup}>
+          <ThemedText style={[styles.label, { color: labelColor }]}>
+            {t('messages.searchInputLabel')}
+          </ThemedText>
+          <View style={[styles.searchInputContainer, { borderColor, backgroundColor: inputBackground }]}
+          >
+            <View style={styles.searchIcon}>
+              <IconSymbol name="magnifyingglass" size={18} color={iconColor} />
+            </View>
+            <TextInput
+              style={[styles.searchInput, { color: textColor }]}
+              value={searchQuery}
+              onChangeText={setSearchQuery}
+              placeholder={t('messages.searchPlaceholder')}
+              placeholderTextColor={mutedColor}
+              autoCapitalize="none"
+              autoCorrect={false}
+              editable={!isSubmitting}
+              returnKeyType="search"
+            />
+            {isFetching ? (
+              <ActivityIndicator size="small" color={tintColor} style={styles.searchLoading} />
+            ) : null}
+          </View>
+
+          <View style={styles.resultsWrapper}>{renderResults()}</View>
+        </View>
+      </ThemedView>
+    </Panel>
+  );
+}
+
+const styles = StyleSheet.create({
+  description: {
+    fontSize: 14,
+    lineHeight: 20,
+    marginBottom: 16,
+  },
+  fieldGroup: {
+    marginTop: 8,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  searchInputContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  searchIcon: {
+    marginRight: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 16,
+    paddingVertical: 0,
+  },
+  searchLoading: {
+    marginLeft: 8,
+  },
+  resultsWrapper: {
+    minHeight: 120,
+    marginTop: 12,
+  },
+  resultItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+  },
+  resultItemSpacing: {
+    marginTop: 12,
+  },
+  avatarImage: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    marginRight: 12,
+  },
+  avatarFallback: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 12,
+  },
+  avatarInitial: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#ffffff',
+  },
+  resultInfo: {
+    flex: 1,
+  },
+  resultDisplayName: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  resultHandle: {
+    fontSize: 14,
+    marginTop: 2,
+  },
+  resultDescription: {
+    fontSize: 12,
+    marginTop: 6,
+    lineHeight: 16,
+  },
+  helperText: {
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  footerActions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  secondaryButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderRadius: 12,
+    backgroundColor: 'transparent',
+    marginRight: 12,
+  },
+  secondaryButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  primaryButton: {
+    backgroundColor: '#007AFF',
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    borderRadius: 12,
+  },
+  primaryButtonText: {
+    color: '#ffffff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  disabledButton: {
+    opacity: 0.6,
+  },
+  disabledPrimaryButton: {
+    opacity: 0.5,
+  },
+  iconButton: {
+    padding: 8,
+    borderRadius: 999,
+    backgroundColor: 'transparent',
+  },
+});

--- a/apps/akari/constants/dialogs.ts
+++ b/apps/akari/constants/dialogs.ts
@@ -1,1 +1,2 @@
 export const ADD_ACCOUNT_PANEL_ID = 'add-account-panel';
+export const NEW_CHAT_PANEL_ID = 'new-chat-panel';

--- a/apps/akari/hooks/mutations/useCreateConversation.ts
+++ b/apps/akari/hooks/mutations/useCreateConversation.ts
@@ -1,0 +1,68 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { BlueskyApi, type BlueskyConvo } from '@/bluesky-api';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+
+type CreateConversationVariables = {
+  did: string;
+};
+
+export type CreateConversationError = {
+  type: 'permission' | 'network' | 'unknown';
+  message: string;
+};
+
+export function useCreateConversation() {
+  const queryClient = useQueryClient();
+  const { data: token } = useJwtToken();
+  const { data: currentAccount } = useCurrentAccount();
+
+  return useMutation({
+    mutationKey: ['createConversation'],
+    mutationFn: async ({ did }: CreateConversationVariables): Promise<BlueskyConvo> => {
+      if (!token) throw new Error('No access token');
+      if (!currentAccount?.did) throw new Error('No user DID available');
+      if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
+
+      const api = new BlueskyApi(currentAccount.pdsUrl);
+
+      try {
+        const response = await api.getConversationForMembers(token, [currentAccount.did, did]);
+        return response.convo;
+      } catch (error: unknown) {
+        let errorType: CreateConversationError['type'] = 'unknown';
+        let errorMessage = 'Failed to start chat';
+
+        const errorObj = error as { message?: string } | CreateConversationError;
+
+        if ('type' in (errorObj ?? {}) && 'message' in (errorObj ?? {})) {
+          throw errorObj as CreateConversationError;
+        }
+
+        const message = errorObj?.message ?? '';
+
+        if (message.includes('401') || message.toLowerCase().includes('unauthorized')) {
+          errorType = 'permission';
+          errorMessage = "Your app password doesn't have permission to start chats";
+        } else if (message.includes('403') || message.toLowerCase().includes('forbidden')) {
+          errorType = 'permission';
+          errorMessage = 'Access to chats is not allowed with this app password';
+        } else if (message.toLowerCase().includes('network')) {
+          errorType = 'network';
+          errorMessage = 'Network error. Please check your connection and try again';
+        }
+
+        const createError: CreateConversationError = {
+          type: errorType,
+          message: errorMessage,
+        };
+
+        throw createError;
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['conversations'] });
+    },
+  });
+}

--- a/apps/akari/hooks/queries/useProfileSearch.ts
+++ b/apps/akari/hooks/queries/useProfileSearch.ts
@@ -1,0 +1,87 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { BlueskyApi } from '@/bluesky-api';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+
+type ProfileSearchResult = {
+  did: string;
+  handle: string;
+  displayName: string;
+  avatar?: string;
+  description?: string;
+};
+
+type ProfileSearchResponse = {
+  profiles: ProfileSearchResult[];
+};
+
+type ProfileSearchError = {
+  type: 'permission' | 'network' | 'unknown';
+  message: string;
+};
+
+export function useProfileSearch(query: string, limit: number = 10) {
+  const { data: token } = useJwtToken();
+  const { data: currentAccount } = useCurrentAccount();
+  const trimmedQuery = query.trim();
+
+  return useQuery<ProfileSearchResponse, ProfileSearchError>({
+    queryKey: ['profileSearch', trimmedQuery, limit, currentAccount?.pdsUrl],
+    queryFn: async () => {
+      if (!token) throw new Error('No access token');
+      if (!trimmedQuery) return { profiles: [] };
+      if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
+
+      try {
+        const api = new BlueskyApi(currentAccount.pdsUrl);
+        const response = await api.searchProfiles(token, trimmedQuery, limit);
+
+        const profiles = (response.actors ?? []).map((actor) => ({
+          did: actor.did,
+          handle: actor.handle,
+          displayName: actor.displayName || actor.handle,
+          avatar: actor.avatar,
+          description: actor.description,
+        }));
+
+        return { profiles };
+      } catch (error: unknown) {
+        let errorType: ProfileSearchError['type'] = 'unknown';
+        let errorMessage = 'Failed to search profiles';
+
+        const errorObj = error as { message?: string };
+        const message = errorObj?.message ?? '';
+
+        if (message.includes('401') || message.toLowerCase().includes('unauthorized')) {
+          errorType = 'permission';
+          errorMessage = "Your app password doesn't have permission to search profiles";
+        } else if (message.includes('403') || message.toLowerCase().includes('forbidden')) {
+          errorType = 'permission';
+          errorMessage = 'Access to profile search is not allowed with this app password';
+        } else if (message.toLowerCase().includes('network')) {
+          errorType = 'network';
+          errorMessage = 'Network error. Please check your connection and try again';
+        }
+
+        const searchError: ProfileSearchError = {
+          type: errorType,
+          message: errorMessage,
+        };
+
+        throw searchError;
+      }
+    },
+    enabled: trimmedQuery.length >= 2 && !!token && !!currentAccount?.pdsUrl,
+    staleTime: 60 * 1000,
+    retry: (failureCount, error) => {
+      if (error?.type === 'permission') {
+        return false;
+      }
+
+      return failureCount < 3;
+    },
+  });
+}
+
+export type { ProfileSearchError, ProfileSearchResult };

--- a/apps/akari/translations/en-US.json
+++ b/apps/akari/translations/en-US.json
@@ -58,6 +58,7 @@
       "unmute": "Unmute",
       "pendingChats": "Pending chats",
       "viewPendingChats": "View pending chats",
+      "newChat": "New chat",
       "bookmarks": "Bookmarks"
     },
     "auth": {
@@ -234,7 +235,16 @@
     },
     "messages": {
       "typeMessage": "Type a message...",
-      "errorSendingMessage": "Failed to send message. Please try again."
+      "errorSendingMessage": "Failed to send message. Please try again.",
+      "startNewChat": "Start a new chat",
+      "startNewChatDescription": "Search for someone on Bluesky to begin a conversation.",
+      "searchInputLabel": "Find someone",
+      "searchPlaceholder": "Search by handle or display name",
+      "searchMinimumCharacters": "Enter at least 2 characters to search.",
+      "startChat": "Start chat",
+      "startingChat": "Starting chat...",
+      "errorStartingChat": "We couldn't start this chat. Please try again.",
+      "cannotStartChatWithSelf": "You can't start a chat with yourself."
     },
     "settings": {
       "account": "Account",

--- a/apps/akari/translations/en.json
+++ b/apps/akari/translations/en.json
@@ -58,6 +58,7 @@
       "checkOutImage": "Check out this image!",
       "pendingChats": "Pending chats",
       "viewPendingChats": "View pending chats",
+      "newChat": "New chat",
       "bookmarks": "Bookmarks"
     },
     "auth": {
@@ -244,7 +245,16 @@
     },
     "messages": {
       "typeMessage": "Type a message...",
-      "errorSendingMessage": "Failed to send message. Please try again."
+      "errorSendingMessage": "Failed to send message. Please try again.",
+      "startNewChat": "Start a new chat",
+      "startNewChatDescription": "Search for someone on Bluesky to begin a conversation.",
+      "searchInputLabel": "Find someone",
+      "searchPlaceholder": "Search by handle or display name",
+      "searchMinimumCharacters": "Enter at least 2 characters to search.",
+      "startChat": "Start chat",
+      "startingChat": "Starting chat...",
+      "errorStartingChat": "We couldn't start this chat. Please try again.",
+      "cannotStartChatWithSelf": "You can't start a chat with yourself."
     },
     "settings": {
       "account": "Account",

--- a/packages/bluesky-api/src/api.ts
+++ b/packages/bluesky-api/src/api.ts
@@ -8,6 +8,7 @@ import { BlueskyNotifications } from './notifications';
 import { BlueskySearch } from './search';
 import type {
   BlueskyBookmarksResponse,
+  BlueskyConvoResponse,
   BlueskyConvosResponse,
   BlueskyFeed,
   BlueskyFeedResponse,
@@ -193,6 +194,10 @@ export class BlueskyApi extends BlueskyApiClient {
     status?: 'request' | 'accepted',
   ): Promise<BlueskyConvosResponse> {
     return this.conversations.listConversations(accessJwt, limit, cursor, readState, status);
+  }
+
+  async getConversationForMembers(accessJwt: string, members: string[]): Promise<BlueskyConvoResponse> {
+    return this.conversations.getConversationForMembers(accessJwt, members);
   }
 
   async getMessages(

--- a/packages/bluesky-api/src/client.ts
+++ b/packages/bluesky-api/src/client.ts
@@ -26,7 +26,7 @@ export class BlueskyApiClient {
       method?: 'GET' | 'POST';
       headers?: Record<string, string>;
       body?: Record<string, unknown> | FormData | Blob;
-      params?: Record<string, string>;
+      params?: Record<string, string | string[]>;
     } = {},
   ): Promise<T> {
     const { method = 'GET', headers = {}, body, params } = options;
@@ -36,9 +36,20 @@ export class BlueskyApiClient {
     if (params && Object.keys(params).length > 0) {
       const searchParams = new URLSearchParams();
       Object.entries(params).forEach(([key, value]) => {
-        if (value !== undefined && value !== null) {
-          searchParams.append(key, value);
+        if (value === undefined || value === null) {
+          return;
         }
+
+        if (Array.isArray(value)) {
+          for (const item of value) {
+            if (item !== undefined && item !== null) {
+              searchParams.append(key, item);
+            }
+          }
+          return;
+        }
+
+        searchParams.append(key, value);
       });
       url += `?${searchParams.toString()}`;
     }
@@ -79,7 +90,7 @@ export class BlueskyApiClient {
     options: {
       method?: 'GET' | 'POST';
       body?: Record<string, unknown> | FormData | Blob;
-      params?: Record<string, string>;
+      params?: Record<string, string | string[]>;
       headers?: Record<string, string>;
     } = {},
   ): Promise<T> {

--- a/packages/bluesky-api/src/conversations.ts
+++ b/packages/bluesky-api/src/conversations.ts
@@ -1,5 +1,10 @@
 import { BlueskyApiClient } from './client';
-import type { BlueskyConvosResponse, BlueskyMessagesResponse, BlueskySendMessageResponse } from './types';
+import type {
+  BlueskyConvoResponse,
+  BlueskyConvosResponse,
+  BlueskyMessagesResponse,
+  BlueskySendMessageResponse,
+} from './types';
 
 /**
  * Bluesky API conversation methods
@@ -33,6 +38,25 @@ export class BlueskyConversations extends BlueskyApiClient {
         'atproto-proxy': 'did:web:api.bsky.chat#bsky_chat',
       },
     });
+  }
+
+  /**
+   * Gets (or creates) a conversation for the specified members
+   * @param accessJwt - Valid access JWT token
+   * @param members - Array of member DIDs (including the current user)
+   * @returns Promise resolving to the conversation data
+   */
+  async getConversationForMembers(accessJwt: string, members: string[]): Promise<BlueskyConvoResponse> {
+    return this.makeAuthenticatedRequest<BlueskyConvoResponse>(
+      '/chat.bsky.convo.getConvoForMembers',
+      accessJwt,
+      {
+        params: { members },
+        headers: {
+          'atproto-proxy': 'did:web:api.bsky.chat#bsky_chat',
+        },
+      },
+    );
   }
 
   /**

--- a/packages/bluesky-api/src/types.ts
+++ b/packages/bluesky-api/src/types.ts
@@ -418,6 +418,13 @@ export type BlueskyConvosResponse = {
 };
 
 /**
+ * Bluesky single conversation response
+ */
+export type BlueskyConvoResponse = {
+  convo: BlueskyConvo;
+};
+
+/**
  * Bluesky feed item (post with context)
  */
 export type BlueskyFeedItem = {
@@ -868,10 +875,10 @@ export type BlueskyAppStatePref = {
   /** Type identifier */
   $type: 'app.bsky.actor.defs#bskyAppStatePref';
   /** NUX completion status */
-  nuxs?: Array<{
+  nuxs?: {
     id: string;
     completed: boolean;
-  }>;
+  }[];
 };
 
 /**


### PR DESCRIPTION
## Summary
- add a New Chat control to the messages list header that opens a dialog
- implement a StartChatPanel with profile search and conversation creation logic
- extend the API client, hooks, and translations to support starting new conversations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d081a782a4832b8858cffacdbaa336