### PR TITLE
feat: enhance search explore experience

### DIFF
--- a/apps/akari/__tests__/app/tabs/search.test.tsx
+++ b/apps/akari/__tests__/app/tabs/search.test.tsx
@@ -4,9 +4,14 @@ import { FlatList, Keyboard, Text, TouchableOpacity, View } from 'react-native';
 
 import SearchScreen from '@/app/(tabs)/search';
 import { useLocalSearchParams } from 'expo-router';
+import { useSetSelectedFeed } from '@/hooks/mutations/useSetSelectedFeed';
+import { useFeedGenerators } from '@/hooks/queries/useFeedGenerators';
+import { usePreferences } from '@/hooks/queries/usePreferences';
 import { useSearch } from '@/hooks/queries/useSearch';
+import { useTrendingTopics } from '@/hooks/queries/useTrendingTopics';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useResponsive } from '@/hooks/useResponsive';
 
 jest.mock('expo-image', () => {
   const { Image } = require('react-native');
@@ -68,23 +73,46 @@ jest.mock('@/components/skeletons', () => {
   return { SearchResultSkeleton: () => <Text>Skeleton</Text> };
 });
 
+jest.mock('@/hooks/mutations/useSetSelectedFeed');
+jest.mock('@/hooks/queries/useFeedGenerators');
+jest.mock('@/hooks/queries/usePreferences');
 jest.mock('@/hooks/queries/useSearch');
+jest.mock('@/hooks/queries/useTrendingTopics');
 jest.mock('@/hooks/useThemeColor');
 jest.mock('@/hooks/useTranslation');
+jest.mock('@/hooks/useResponsive');
 jest.mock('@/utils/tabScrollRegistry', () => ({
   tabScrollRegistry: { register: jest.fn() },
 }));
 
 const mockUseLocalSearchParams = useLocalSearchParams as unknown as jest.Mock;
+const mockUsePreferences = usePreferences as jest.Mock;
+const mockUseTrendingTopics = useTrendingTopics as jest.Mock;
+const mockUseFeedGenerators = useFeedGenerators as jest.Mock;
 const mockUseSearch = useSearch as jest.Mock;
+const mockUseSetSelectedFeed = useSetSelectedFeed as jest.Mock;
 const mockUseThemeColor = useThemeColor as jest.Mock;
 const mockUseTranslation = useTranslation as jest.Mock;
+const mockUseResponsive = useResponsive as jest.Mock;
 
 describe('SearchScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseThemeColor.mockImplementation((c: any) => (typeof c === 'string' ? c : c.light ?? '#000'));
     mockUseTranslation.mockReturnValue({ t: (k: string) => k });
+    mockUseResponsive.mockReturnValue({ isLargeScreen: false });
+    mockUsePreferences.mockReturnValue({
+      data: { preferences: [] },
+      isLoading: false,
+      error: null,
+    });
+    mockUseTrendingTopics.mockReturnValue({
+      data: { topics: [], suggested: [] },
+      isLoading: false,
+      error: null,
+    });
+    mockUseFeedGenerators.mockReturnValue({ data: { feeds: [] }, isLoading: false });
+    mockUseSetSelectedFeed.mockReturnValue({ mutate: jest.fn() });
   });
 
   it('trims query and triggers search', async () => {

--- a/apps/akari/hooks/queries/useTrendingTopics.ts
+++ b/apps/akari/hooks/queries/useTrendingTopics.ts
@@ -1,0 +1,17 @@
+import { BlueskyApi } from '@/bluesky-api';
+import { useQuery } from '@tanstack/react-query';
+
+/**
+ * Query hook for fetching trending topics surfaced by Bluesky
+ * @param limit - Number of topics to fetch (default: 10)
+ */
+export function useTrendingTopics(limit: number = 10) {
+  return useQuery({
+    queryKey: ['trendingTopics', limit],
+    queryFn: async () => {
+      const api = new BlueskyApi('https://public.api.bsky.app');
+      return await api.getTrendingTopics(limit);
+    },
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}

--- a/apps/akari/translations/ar.json
+++ b/apps/akari/translations/ar.json
@@ -110,7 +110,17 @@
       "all": "الكل",
       "users": "المستخدمون",
       "posts": "المنشورات",
-      "loadingMoreResults": "تحميل المزيد من النتائج..."
+      "loadingMoreResults": "تحميل المزيد من النتائج...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "أعجب بمنشورك",

--- a/apps/akari/translations/cy.json
+++ b/apps/akari/translations/cy.json
@@ -110,7 +110,17 @@
       "all": "Pob un",
       "users": "Defnyddwyr",
       "posts": "Swyddi",
-      "loadingMoreResults": "Wrthi'n llwytho mwy o ganlyniadau..."
+      "loadingMoreResults": "Wrthi'n llwytho mwy o ganlyniadau...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "hoffodd eich swydd",

--- a/apps/akari/translations/de.json
+++ b/apps/akari/translations/de.json
@@ -110,7 +110,17 @@
       "all": "Alle",
       "users": "Benutzer",
       "posts": "Beiträge",
-      "loadingMoreResults": "Lade weitere Ergebnisse..."
+      "loadingMoreResults": "Lade weitere Ergebnisse...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "gefällt dein Beitrag",

--- a/apps/akari/translations/en-US.json
+++ b/apps/akari/translations/en-US.json
@@ -110,7 +110,17 @@
       "all": "All",
       "users": "Users",
       "posts": "Posts",
-      "loadingMoreResults": "Loading more results..."
+      "loadingMoreResults": "Loading more results...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "liked your post",

--- a/apps/akari/translations/en.json
+++ b/apps/akari/translations/en.json
@@ -110,7 +110,17 @@
       "all": "All",
       "users": "Users",
       "posts": "Posts",
-      "loadingMoreResults": "Loading more results..."
+      "loadingMoreResults": "Loading more results...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "liked your post",

--- a/apps/akari/translations/es.json
+++ b/apps/akari/translations/es.json
@@ -110,7 +110,17 @@
       "all": "Todo",
       "users": "Usuarios",
       "posts": "Publicaciones",
-      "loadingMoreResults": "Cargando más resultados..."
+      "loadingMoreResults": "Cargando más resultados...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "le gustó tu publicación",

--- a/apps/akari/translations/fr.json
+++ b/apps/akari/translations/fr.json
@@ -110,7 +110,17 @@
       "all": "Tout",
       "users": "Utilisateurs",
       "posts": "Publications",
-      "loadingMoreResults": "Chargement de plus de résultats..."
+      "loadingMoreResults": "Chargement de plus de résultats...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "a aimé votre publication",

--- a/apps/akari/translations/hi.json
+++ b/apps/akari/translations/hi.json
@@ -110,7 +110,17 @@
       "all": "सभी",
       "users": "उपयोगकर्ता",
       "posts": "पोस्ट",
-      "loadingMoreResults": "अधिक परिणाम लोड हो रहे हैं..."
+      "loadingMoreResults": "अधिक परिणाम लोड हो रहे हैं...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "आपकी पोस्ट को लाइक किया",

--- a/apps/akari/translations/id.json
+++ b/apps/akari/translations/id.json
@@ -110,7 +110,17 @@
       "all": "Semua",
       "users": "Pengguna",
       "posts": "Post",
-      "loadingMoreResults": "Memuat lebih banyak hasil..."
+      "loadingMoreResults": "Memuat lebih banyak hasil...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "menyukai post Anda",

--- a/apps/akari/translations/it.json
+++ b/apps/akari/translations/it.json
@@ -110,7 +110,17 @@
       "all": "Tutti",
       "users": "Utenti",
       "posts": "Post",
-      "loadingMoreResults": "Caricamento di altri risultati..."
+      "loadingMoreResults": "Caricamento di altri risultati...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "è piaciuto il tuo post",

--- a/apps/akari/translations/ja.json
+++ b/apps/akari/translations/ja.json
@@ -110,7 +110,17 @@
       "all": "すべて",
       "users": "ユーザー",
       "posts": "投稿",
-      "loadingMoreResults": "さらに結果を読み込み中..."
+      "loadingMoreResults": "さらに結果を読み込み中...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "があなたの投稿にいいねしました",

--- a/apps/akari/translations/ko.json
+++ b/apps/akari/translations/ko.json
@@ -110,7 +110,17 @@
       "all": "전체",
       "users": "사용자",
       "posts": "게시물",
-      "loadingMoreResults": "더 많은 결과 로딩 중..."
+      "loadingMoreResults": "더 많은 결과 로딩 중...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "게시물에 좋아요를 눌렀습니다",

--- a/apps/akari/translations/nl.json
+++ b/apps/akari/translations/nl.json
@@ -110,7 +110,17 @@
       "all": "Alles",
       "users": "Gebruikers",
       "posts": "Berichten",
-      "loadingMoreResults": "Meer resultaten laden..."
+      "loadingMoreResults": "Meer resultaten laden...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "vond je bericht leuk",

--- a/apps/akari/translations/pl.json
+++ b/apps/akari/translations/pl.json
@@ -110,7 +110,17 @@
       "all": "Wszystko",
       "users": "Użytkownicy",
       "posts": "Posty",
-      "loadingMoreResults": "Ładowanie większej liczby wyników..."
+      "loadingMoreResults": "Ładowanie większej liczby wyników...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "polubił Twój post",

--- a/apps/akari/translations/pt.json
+++ b/apps/akari/translations/pt.json
@@ -110,7 +110,17 @@
       "all": "Todos",
       "users": "Usuários",
       "posts": "Publicações",
-      "loadingMoreResults": "Carregando mais resultados..."
+      "loadingMoreResults": "Carregando mais resultados...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "curtiu sua publicação",

--- a/apps/akari/translations/ru.json
+++ b/apps/akari/translations/ru.json
@@ -110,7 +110,17 @@
       "all": "Все",
       "users": "Пользователи",
       "posts": "Посты",
-      "loadingMoreResults": "Загрузка дополнительных результатов..."
+      "loadingMoreResults": "Загрузка дополнительных результатов...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "понравился ваш пост",

--- a/apps/akari/translations/th.json
+++ b/apps/akari/translations/th.json
@@ -110,7 +110,17 @@
       "all": "ทั้งหมด",
       "users": "ผู้ใช้",
       "posts": "โพสต์",
-      "loadingMoreResults": "กำลังโหลดผลลัพธ์เพิ่มเติม..."
+      "loadingMoreResults": "กำลังโหลดผลลัพธ์เพิ่มเติม...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "ถูกใจโพสต์ของคุณ",

--- a/apps/akari/translations/tr.json
+++ b/apps/akari/translations/tr.json
@@ -110,7 +110,17 @@
       "all": "Tümü",
       "users": "Kullanıcılar",
       "posts": "Gönderiler",
-      "loadingMoreResults": "Daha fazla sonuç yükleniyor..."
+      "loadingMoreResults": "Daha fazla sonuç yükleniyor...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "gönderinizi beğendi",

--- a/apps/akari/translations/vi.json
+++ b/apps/akari/translations/vi.json
@@ -110,7 +110,17 @@
       "all": "Tất cả",
       "users": "Người dùng",
       "posts": "Bài đăng",
-      "loadingMoreResults": "Đang tải thêm kết quả..."
+      "loadingMoreResults": "Đang tải thêm kết quả...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "đã thích bài đăng của bạn",

--- a/apps/akari/translations/zh-CN.json
+++ b/apps/akari/translations/zh-CN.json
@@ -110,7 +110,17 @@
       "all": "全部",
       "users": "用户",
       "posts": "帖子",
-      "loadingMoreResults": "加载更多结果..."
+      "loadingMoreResults": "加载更多结果...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "点赞了您的帖子",

--- a/apps/akari/translations/zh-TW.json
+++ b/apps/akari/translations/zh-TW.json
@@ -110,7 +110,17 @@
       "all": "全部",
       "users": "使用者",
       "posts": "貼文",
-      "loadingMoreResults": "載入更多結果..."
+      "loadingMoreResults": "載入更多結果...",
+      "yourInterests": "Your interests",
+      "editInterests": "Edit interests",
+      "noInterests": "Add interests to personalize your Discover experience.",
+      "searchTopic": "Search posts",
+      "trendingTopics": "Trending topics",
+      "loadingTrendingTopics": "Loading trending topics...",
+      "noTrendingTopics": "No trending topics right now.",
+      "discoverFeeds": "Discover new feeds",
+      "openFeed": "Open feed",
+      "feedByCreator": "By {{author}}"
     },
     "notifications": {
       "likedYourPost": "對您的貼文按讚",

--- a/apps/akari/utils/feedLinks.ts
+++ b/apps/akari/utils/feedLinks.ts
@@ -1,0 +1,60 @@
+const BSKY_WEB_BASE_URL = 'https://bsky.app';
+
+/**
+ * Normalizes a Bluesky app link so it can be opened externally
+ */
+export function resolveBskyLink(link: string): string {
+  if (!link) {
+    return BSKY_WEB_BASE_URL;
+  }
+
+  if (link.startsWith('http://') || link.startsWith('https://')) {
+    return link;
+  }
+
+  if (link.startsWith('/')) {
+    return `${BSKY_WEB_BASE_URL}${link}`;
+  }
+
+  return `${BSKY_WEB_BASE_URL}/${link}`;
+}
+
+/**
+ * Attempts to extract an at:// feed URI from a Bluesky link
+ */
+export function extractFeedUriFromLink(link: string): string | null {
+  if (!link) {
+    return null;
+  }
+
+  try {
+    const url = link.startsWith('http://') || link.startsWith('https://')
+      ? new URL(link)
+      : new URL(link, BSKY_WEB_BASE_URL);
+
+    const feedParam = url.searchParams.get('feed');
+    if (feedParam) {
+      return decodeURIComponent(feedParam);
+    }
+
+    const segments = url.pathname.split('/').filter(Boolean);
+    const atUriSegment = segments.find((segment) => segment.startsWith('at://'));
+    if (atUriSegment) {
+      return decodeURIComponent(atUriSegment);
+    }
+
+    const feedIndex = segments.indexOf('feed');
+    if (feedIndex > 0 && feedIndex + 1 < segments.length) {
+      const actorSegment = decodeURIComponent(segments[feedIndex - 1] ?? '');
+      const rkeySegment = decodeURIComponent(segments[feedIndex + 1]);
+
+      if (actorSegment) {
+        return `at://${actorSegment}/app.bsky.feed.generator/${rkeySegment}`;
+      }
+    }
+  } catch (error) {
+    // Ignore malformed URLs
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- expand the Search screen with interest, trending topic, and discoverable feed panels driven by preferences and trending data
- add helpers for parsing Bluesky feed links and a dedicated trending topics query hook
- update translations and Search screen tests to cover the new explore surface

## Testing
- npm run test:coverage *(fails: existing Jest config cannot parse ESM dependencies in packages/tenor-api and packages/clearsky-api)*
- npm run test -- --runTestsByPath __tests__/app/tabs/search.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d081fb54bc832b93a7e1f10c891146