### PR TITLE
fix: embed profile dropdown inside header

### DIFF
--- a/apps/akari/app/(tabs)/profile.tsx
+++ b/apps/akari/app/(tabs)/profile.tsx
@@ -1,8 +1,5 @@
 import React, { useRef, useState } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
-import * as Clipboard from 'expo-clipboard';
-
-import { ProfileDropdown } from '@/components/ProfileDropdown';
+import { ScrollView, StyleSheet } from 'react-native';
 import { ProfileHeader } from '@/components/ProfileHeader';
 import { ProfileTabs } from '@/components/ProfileTabs';
 import { ThemedText } from '@/components/ThemedText';
@@ -14,12 +11,10 @@ import { PostsTab } from '@/components/profile/PostsTab';
 import { RepliesTab } from '@/components/profile/RepliesTab';
 import { StarterpacksTab } from '@/components/profile/StarterpacksTab';
 import { VideosTab } from '@/components/profile/VideosTab';
-import { useToast } from '@/contexts/ToastContext';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useProfile } from '@/hooks/queries/useProfile';
 import { useTranslation } from '@/hooks/useTranslation';
 import { tabScrollRegistry } from '@/utils/tabScrollRegistry';
-import { showAlert } from '@/utils/alert';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import type { ProfileTabType } from '@/types/profile';
@@ -28,11 +23,8 @@ export default function ProfileScreen() {
   const { data: currentAccount } = useCurrentAccount();
   const insets = useSafeAreaInsets();
   const [activeTab, setActiveTab] = useState<ProfileTabType>('posts');
-  const [showDropdown, setShowDropdown] = useState(false);
-  const dropdownRef = useRef<View | null>(null);
   const scrollViewRef = useRef<ScrollView>(null);
   const { t } = useTranslation();
-  const { showToast } = useToast();
 
   // Create scroll to top function
   const scrollToTop = () => {
@@ -45,57 +37,6 @@ export default function ProfileScreen() {
   }, []);
 
   const { data: profile } = useProfile(currentAccount?.handle);
-
-  const [dropdownPosition, setDropdownPosition] = useState({ top: 0, right: 0 });
-
-  const handleDropdownToggle = (isOpen: boolean) => {
-    if (isOpen && dropdownRef.current) {
-      // Measure the position of the more button
-      dropdownRef.current.measure((x, y, width, height, pageX, pageY) => {
-        setDropdownPosition({
-          top: pageY + height + 4, // Position below the button with 4px gap
-          right: 20, // 20px from right edge
-        });
-      });
-    }
-    setShowDropdown(isOpen);
-  };
-
-  const handleCopyLink = async () => {
-    const profileHandle = currentAccount?.handle || profile?.handle;
-
-    if (!profileHandle) {
-      showAlert({
-        title: t('common.error'),
-        message: t('profile.linkCopyError'),
-        buttons: [{ text: t('common.ok') }],
-      });
-      setShowDropdown(false);
-      return;
-    }
-
-    try {
-      const profileUrl = `https://bsky.app/profile/${profileHandle}`;
-      await Clipboard.setStringAsync(profileUrl);
-      showToast({
-        message: t('profile.linkCopied'),
-        type: 'success',
-      });
-    } catch (error) {
-      showAlert({
-        title: t('common.error'),
-        message: t('profile.linkCopyError'),
-        buttons: [{ text: t('common.ok') }],
-      });
-    } finally {
-      setShowDropdown(false);
-    }
-  };
-
-  const handleSearchPosts = () => {
-    // TODO: Implement search posts functionality
-    setShowDropdown(false);
-  };
 
   const handleTabChange = (tab: ProfileTabType) => {
     setActiveTab(tab);
@@ -159,44 +100,12 @@ export default function ProfileScreen() {
             labels: profile?.labels,
           }}
           isOwnProfile={true}
-          onDropdownToggle={handleDropdownToggle}
-          dropdownRef={dropdownRef}
         />
         <ProfileTabs activeTab={activeTab} onTabChange={handleTabChange} profileHandle={currentAccount?.handle || ''} />
 
         {renderTabContent()}
       </ScrollView>
 
-      {/* Dropdown rendered at root level */}
-      <ProfileDropdown
-        isVisible={showDropdown}
-        onCopyLink={handleCopyLink}
-        onSearchPosts={handleSearchPosts}
-        onAddToLists={() => {
-          // TODO: Implement add to lists functionality
-          setShowDropdown(false);
-        }}
-        onMuteAccount={() => {
-          // TODO: Implement mute account functionality
-          setShowDropdown(false);
-        }}
-        onBlockPress={() => {
-          // TODO: Implement block account functionality
-          setShowDropdown(false);
-        }}
-        onReportAccount={() => {
-          // TODO: Implement report account functionality
-          setShowDropdown(false);
-        }}
-        isFollowing={false}
-        isBlocking={false}
-        isMuted={false}
-        isOwnProfile={true}
-        style={{
-          top: dropdownPosition.top,
-          right: dropdownPosition.right,
-        }}
-      />
     </ThemedView>
   );
 }

--- a/apps/akari/app/profile/[handle].tsx
+++ b/apps/akari/app/profile/[handle].tsx
@@ -1,9 +1,7 @@
 import { useLocalSearchParams } from 'expo-router';
-import { useRef, useState } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
-import * as Clipboard from 'expo-clipboard';
+import { useState } from 'react';
+import { ScrollView, StyleSheet } from 'react-native';
 
-import { ProfileDropdown } from '@/components/ProfileDropdown';
 import { ProfileHeader } from '@/components/ProfileHeader';
 import { ProfileTabs } from '@/components/ProfileTabs';
 import { ThemedText } from '@/components/ThemedText';
@@ -16,22 +14,16 @@ import { RepliesTab } from '@/components/profile/RepliesTab';
 import { StarterpacksTab } from '@/components/profile/StarterpacksTab';
 import { VideosTab } from '@/components/profile/VideosTab';
 import { ProfileHeaderSkeleton } from '@/components/skeletons';
-import { useToast } from '@/contexts/ToastContext';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useProfile } from '@/hooks/queries/useProfile';
 import { useTranslation } from '@/hooks/useTranslation';
 import type { ProfileTabType } from '@/types/profile';
-import { showAlert } from '@/utils/alert';
 
 export default function ProfileScreen() {
   const { handle } = useLocalSearchParams<{ handle: string }>();
   const [activeTab, setActiveTab] = useState<ProfileTabType>('posts');
-  const [showDropdown, setShowDropdown] = useState(false);
-  const [dropdownPosition, setDropdownPosition] = useState({ top: 0, right: 0 });
-  const dropdownRef = useRef<View | null>(null);
   const { t } = useTranslation();
   const { data: currentUser } = useCurrentAccount();
-  const { showToast } = useToast();
 
   const { data: profile, isLoading, error } = useProfile(handle);
 
@@ -48,80 +40,6 @@ export default function ProfileScreen() {
   }
 
   const isOwnProfile = currentUser?.handle === profile?.handle;
-
-  const handleDropdownToggle = (isOpen: boolean) => {
-    if (isOpen && dropdownRef.current) {
-      // Measure the position of the more button
-      dropdownRef.current.measure((x, y, width, height, pageX, pageY) => {
-        setDropdownPosition({
-          top: pageY + height - 62, // Position with final fine-tuned adjustment
-          right: 20, // 20px from right edge
-        });
-      });
-    }
-    setShowDropdown(isOpen);
-  };
-
-  const handleCopyLink = async () => {
-    const profileHandle = profile?.handle;
-
-    if (!profileHandle) {
-      showAlert({
-        title: t('common.error'),
-        message: t('profile.linkCopyError'),
-        buttons: [{ text: t('common.ok') }],
-      });
-      setShowDropdown(false);
-      return;
-    }
-
-    try {
-      const profileUrl = `https://bsky.app/profile/${profileHandle}`;
-      await Clipboard.setStringAsync(profileUrl);
-      showToast({
-        message: t('profile.linkCopied'),
-        type: 'success',
-      });
-    } catch (error) {
-      showAlert({
-        title: t('common.error'),
-        message: t('profile.linkCopyError'),
-        buttons: [{ text: t('common.ok') }],
-      });
-    } finally {
-      setShowDropdown(false);
-    }
-  };
-
-  const handleSearchPosts = () => {
-    // TODO: Implement search posts functionality
-    console.log('Search posts');
-    setShowDropdown(false);
-  };
-
-  const handleAddToLists = () => {
-    // TODO: Implement add to lists functionality
-    console.log('Add to lists');
-    setShowDropdown(false);
-  };
-
-  const handleMuteAccount = () => {
-    // TODO: Implement mute functionality
-    console.log('Mute account');
-    setShowDropdown(false);
-  };
-
-  const handleBlockPress = () => {
-    // TODO: Implement block functionality
-    console.log('Block account');
-    setShowDropdown(false);
-  };
-
-  const handleReportAccount = () => {
-    // TODO: Implement report functionality
-    console.log('Report account');
-    setShowDropdown(false);
-  };
 
   const renderTabContent = () => {
     if (!handle) return null;
@@ -168,8 +86,6 @@ export default function ProfileScreen() {
             labels: profile?.labels,
           }}
           isOwnProfile={isOwnProfile}
-          onDropdownToggle={handleDropdownToggle}
-          dropdownRef={dropdownRef}
         />
 
         {/* Tabs */}
@@ -179,24 +95,6 @@ export default function ProfileScreen() {
         {renderTabContent()}
       </ScrollView>
 
-      {/* Dropdown rendered at root level */}
-      <ProfileDropdown
-        isVisible={showDropdown}
-        onCopyLink={handleCopyLink}
-        onSearchPosts={handleSearchPosts}
-        onAddToLists={handleAddToLists}
-        onMuteAccount={handleMuteAccount}
-        onBlockPress={handleBlockPress}
-        onReportAccount={handleReportAccount}
-        isFollowing={!!profile?.viewer?.following}
-        isBlocking={!!profile?.viewer?.blocking}
-        isMuted={!!profile?.viewer?.muted}
-        isOwnProfile={isOwnProfile}
-        style={{
-          top: dropdownPosition.top,
-          right: dropdownPosition.right,
-        }}
-      />
     </ThemedView>
   );
 }

--- a/apps/akari/components/ProfileDropdown.tsx
+++ b/apps/akari/components/ProfileDropdown.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
 
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
@@ -19,7 +20,7 @@ type ProfileDropdownProps = {
   isBlocking: boolean;
   isMuted: boolean;
   isOwnProfile: boolean;
-  style?: any;
+  style?: StyleProp<ViewStyle>;
 };
 
 export function ProfileDropdown({
@@ -50,7 +51,14 @@ export function ProfileDropdown({
   if (!isVisible) return null;
 
   return (
-    <ThemedView style={[styles.dropdown, { backgroundColor: dropdownBackgroundColor, borderColor: borderColor }, style]}>
+    <ThemedView
+      testID="profile-dropdown"
+      style={[
+        styles.dropdown,
+        { backgroundColor: dropdownBackgroundColor, borderColor: borderColor },
+        style,
+      ]}
+    >
       {isOwnProfile ? (
         <>
           <TouchableOpacity style={styles.dropdownItem} onPress={onSearchPosts}>
@@ -93,7 +101,6 @@ export function ProfileDropdown({
 
 const styles = StyleSheet.create({
   dropdown: {
-    position: 'absolute',
     borderRadius: 8,
     borderWidth: 1,
     shadowColor: '#000',
@@ -106,6 +113,10 @@ const styles = StyleSheet.create({
     elevation: 5,
     minWidth: 140,
     zIndex: 9999999,
+    position: 'absolute',
+    top: '100%',
+    right: 0,
+    marginTop: 8,
   },
   dropdownItem: {
     paddingHorizontal: 12,


### PR DESCRIPTION
## Summary
- move dropdown rendering into ProfileHeader so the menu positions itself relative to the action button
- handle copy-link toast and other dropdown actions inside the header and remove dropdown plumbing from profile screens
- update profile-related tests to exercise the integrated dropdown behaviour

## Testing
- npm run lint
- npm run test:coverage *(fails: clearsky-api and tenor-api still cannot transform the ESM-only until-async dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d08a5e0560832ba74df252f6c21125