### PR TITLE
feat: add Axiom crash reporter package

### DIFF
--- a/apps/akari/__tests__/app/root-layout.test.tsx
+++ b/apps/akari/__tests__/app/root-layout.test.tsx
@@ -6,6 +6,10 @@ import { useFonts } from 'expo-font';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { Platform } from 'react-native';
 
+jest.mock('@/utils/crashReporter', () => ({
+  initializeCrashReporter: jest.fn(),
+}));
+
 jest.mock('@react-navigation/native', () => {
   const React = require('react');
   const actual = jest.requireActual('@react-navigation/native');

--- a/apps/akari/__tests__/utils/crashReporter.test.ts
+++ b/apps/akari/__tests__/utils/crashReporter.test.ts
@@ -1,0 +1,161 @@
+import type { AxiomCrashReporter } from 'axiom-crash-reporter';
+import { Platform } from 'react-native';
+
+type UnknownRecord = Record<string, unknown>;
+
+type CrashReporterModule = typeof import('@/utils/crashReporter');
+
+const mockInitializeAxiomCrashReporter = jest.fn();
+
+jest.mock('axiom-crash-reporter', () => ({
+  initializeAxiomCrashReporter: mockInitializeAxiomCrashReporter,
+}));
+
+const createConstantsMock = (extraOverrides?: UnknownRecord) => {
+  const extra: UnknownRecord = { variant: 'production', ...(extraOverrides ?? {}) };
+
+  return {
+    __esModule: true,
+    default: {
+      appOwnership: 'standalone',
+      debugMode: false,
+      deviceName: 'Test Device',
+      deviceYearClass: 2023,
+      executionEnvironment: 'standalone',
+      expoRuntimeVersion: '1.0.0',
+      expoVersion: '53.0.0',
+      sessionId: 'session-id',
+      statusBarHeight: 20,
+      systemVersion: 17,
+      expoConfig: {
+        version: '1.2.3',
+        ios: { bundleIdentifier: 'com.example.app' },
+        android: { package: 'com.example.app' },
+        extra,
+      },
+    },
+  };
+};
+
+const originalPlatform = Platform.OS;
+const originalDevFlag = (globalThis as { __DEV__?: boolean }).__DEV__;
+
+beforeEach(() => {
+  jest.resetModules();
+  mockInitializeAxiomCrashReporter.mockReset();
+  (globalThis as { __DEV__?: boolean }).__DEV__ = false;
+  jest.spyOn(console, 'info').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  Object.defineProperty(Platform, 'OS', { configurable: true, value: originalPlatform });
+  if (originalDevFlag === undefined) {
+    delete (globalThis as { __DEV__?: boolean }).__DEV__;
+  } else {
+    (globalThis as { __DEV__?: boolean }).__DEV__ = originalDevFlag;
+  }
+});
+
+const loadCrashReporterModule = (): CrashReporterModule => {
+  return require('@/utils/crashReporter') as CrashReporterModule;
+};
+
+describe('crashReporter utilities', () => {
+  it('returns null when configuration is missing', async () => {
+    jest.doMock('expo-constants', () => createConstantsMock({ variant: 'development' }));
+    const { initializeCrashReporter } = loadCrashReporterModule();
+    const reporter = initializeCrashReporter();
+    expect(reporter).toBeNull();
+    expect(mockInitializeAxiomCrashReporter).not.toHaveBeenCalled();
+  });
+
+  it('initializes the crash reporter with Expo metadata', async () => {
+    const fakeReporter = {
+      reportError: jest.fn(),
+      reportFatalError: jest.fn(),
+    } as unknown as AxiomCrashReporter;
+
+    jest.doMock('expo-constants', () =>
+      createConstantsMock({
+        variant: 'production',
+        axiom: {
+          dataset: 'app-crashes',
+          token: 'token-123',
+          releaseChannel: 'beta',
+          flushOnCapture: false,
+        },
+      }),
+    );
+
+    Object.defineProperty(Platform, 'OS', { configurable: true, value: 'ios' });
+
+    mockInitializeAxiomCrashReporter.mockReturnValue(fakeReporter);
+
+    const { initializeCrashReporter, getCrashReporter } = loadCrashReporterModule();
+    const reporter = initializeCrashReporter();
+
+    expect(mockInitializeAxiomCrashReporter).toHaveBeenCalledTimes(1);
+    expect(mockInitializeAxiomCrashReporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dataset: 'app-crashes',
+        token: 'token-123',
+        environment: 'production',
+        releaseChannel: 'beta',
+        appVersion: '1.2.3',
+        applicationId: 'com.example.app',
+        metadata: expect.objectContaining({
+          platform: 'ios',
+          appVariant: 'production',
+          executionEnvironment: 'standalone',
+          appOwnership: 'standalone',
+        }),
+        flushOnCapture: false,
+      }),
+    );
+
+    expect(reporter).toBe(fakeReporter);
+    expect(getCrashReporter()).toBe(fakeReporter);
+  });
+
+  it('captures handled and fatal crashes with the shared reporter instance', async () => {
+    const fakeReporter = {
+      reportError: jest.fn().mockResolvedValue(undefined),
+      reportFatalError: jest.fn().mockResolvedValue(undefined),
+    } as unknown as AxiomCrashReporter;
+
+    jest.doMock('expo-constants', () =>
+      createConstantsMock({
+        variant: 'production',
+        axiom: {
+          dataset: 'app-crashes',
+          token: 'token-123',
+        },
+      }),
+    );
+
+    Object.defineProperty(Platform, 'OS', { configurable: true, value: 'android' });
+
+    mockInitializeAxiomCrashReporter.mockReturnValue(fakeReporter);
+
+    const { initializeCrashReporter, captureCrash, captureFatalCrash } = loadCrashReporterModule();
+
+    initializeCrashReporter();
+
+    await captureCrash(new Error('boom'), { metadata: { feature: 'feed' } });
+    await captureFatalCrash('fatal-error', { metadata: { feature: 'fatal' } });
+
+    expect(fakeReporter.reportError).toHaveBeenCalledTimes(1);
+    expect(fakeReporter.reportError).toHaveBeenCalledWith(expect.any(Error), {
+      metadata: { feature: 'feed' },
+    });
+
+    expect(fakeReporter.reportFatalError).toHaveBeenCalledTimes(1);
+    expect(fakeReporter.reportFatalError).toHaveBeenCalledWith('fatal-error', {
+      metadata: { feature: 'fatal' },
+    });
+
+    expect(mockInitializeAxiomCrashReporter).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/akari/app/_layout.tsx
+++ b/apps/akari/app/_layout.tsx
@@ -13,10 +13,13 @@ import { ToastProvider } from '@/contexts/ToastContext';
 import { LanguageProvider } from '@/contexts/LanguageContext';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import '@/utils/i18n';
+import { initializeCrashReporter } from '@/utils/crashReporter';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Platform } from 'react-native';
 
 const queryClient = new QueryClient();
+
+initializeCrashReporter();
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();

--- a/apps/akari/package.json
+++ b/apps/akari/package.json
@@ -50,6 +50,7 @@
     "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-query-devtools": "^5.83.0",
     "@tanstack/react-query-persist-client": "^5.83.0",
+    "axiom-crash-reporter": "*",
     "bluesky-api": "*",
     "clearsky-api": "*",
     "tenor-api": "*",

--- a/apps/akari/utils/crashReporter.ts
+++ b/apps/akari/utils/crashReporter.ts
@@ -1,0 +1,263 @@
+import {
+  initializeAxiomCrashReporter,
+  type AxiomCrashReporter,
+  type CrashReportContext,
+  type CrashReporterOptions,
+} from 'axiom-crash-reporter';
+import Constants from 'expo-constants';
+import { Platform } from 'react-native';
+
+type UnknownRecord = Record<string, unknown>;
+
+type ExpoConfigShape = {
+  android?: { package?: string };
+  ios?: { bundleIdentifier?: string };
+  version?: string;
+  extra?: UnknownRecord;
+};
+
+let reporter: AxiomCrashReporter | null = null;
+let configurationWarningLogged = false;
+let initializationFailureLogged = false;
+
+const isDevelopmentMode = (): boolean => {
+  const devFlag = (globalThis as { __DEV__?: boolean }).__DEV__;
+  return devFlag === true;
+};
+
+const isRecord = (value: unknown): value is UnknownRecord => typeof value === 'object' && value !== null;
+
+const resolveString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+const resolveBoolean = (value: unknown): boolean | undefined => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  return undefined;
+};
+
+const getExpoConfig = (): ExpoConfigShape | undefined => {
+  const expoConfig = Constants.expoConfig;
+  if (expoConfig && typeof expoConfig === 'object') {
+    return expoConfig as ExpoConfigShape;
+  }
+
+  return undefined;
+};
+
+const getExtra = (): UnknownRecord | undefined => {
+  const expoConfig = getExpoConfig();
+  if (expoConfig && isRecord(expoConfig.extra)) {
+    return expoConfig.extra as UnknownRecord;
+  }
+
+  return undefined;
+};
+
+const getAxiomExtra = (): UnknownRecord | undefined => {
+  const extra = getExtra();
+  if (extra && isRecord(extra.axiom)) {
+    return extra.axiom as UnknownRecord;
+  }
+
+  return undefined;
+};
+
+const resolveVariant = (): string | undefined => resolveString(getExtra()?.variant);
+
+const resolveAppVersion = (): string | undefined => resolveString(getExpoConfig()?.version);
+
+const resolveApplicationId = (): string | undefined => {
+  const expoConfig = getExpoConfig();
+  if (!expoConfig) {
+    return undefined;
+  }
+
+  if (Platform.OS === 'android') {
+    return resolveString(expoConfig.android?.package);
+  }
+
+  if (Platform.OS === 'ios') {
+    return resolveString(expoConfig.ios?.bundleIdentifier);
+  }
+
+  return undefined;
+};
+
+const buildMetadata = (variant?: string): UnknownRecord => {
+  const metadata: UnknownRecord = { platform: Platform.OS };
+
+  if (variant) {
+    metadata.appVariant = variant;
+  }
+
+  if (typeof Constants.executionEnvironment === 'string') {
+    metadata.executionEnvironment = Constants.executionEnvironment;
+  }
+
+  if (typeof Constants.appOwnership === 'string') {
+    metadata.appOwnership = Constants.appOwnership;
+  }
+
+  if (typeof Constants.debugMode === 'boolean') {
+    metadata.debugMode = Constants.debugMode;
+  }
+
+  if (typeof Constants.deviceName === 'string' && Constants.deviceName) {
+    metadata.deviceName = Constants.deviceName;
+  }
+
+  if (typeof Constants.deviceYearClass === 'number' && Number.isFinite(Constants.deviceYearClass)) {
+    metadata.deviceYearClass = Constants.deviceYearClass;
+  }
+
+  if (typeof Constants.expoRuntimeVersion === 'string') {
+    metadata.expoRuntimeVersion = Constants.expoRuntimeVersion;
+  }
+
+  if (typeof Constants.expoVersion === 'string') {
+    metadata.expoVersion = Constants.expoVersion;
+  }
+
+  if (typeof Constants.sessionId === 'string' && Constants.sessionId) {
+    metadata.sessionId = Constants.sessionId;
+  }
+
+  if (typeof Constants.statusBarHeight === 'number' && Number.isFinite(Constants.statusBarHeight)) {
+    metadata.statusBarHeight = Constants.statusBarHeight;
+  }
+
+  if (typeof Constants.systemVersion === 'number' || typeof Constants.systemVersion === 'string') {
+    metadata.systemVersion = Constants.systemVersion;
+  }
+
+  return metadata;
+};
+
+const warnMissingConfiguration = () => {
+  if (!configurationWarningLogged && isDevelopmentMode()) {
+    configurationWarningLogged = true;
+    console.info('Axiom crash reporter is disabled because dataset or token values are missing.');
+  }
+};
+
+const logInitializationFailure = (error: unknown) => {
+  if (!initializationFailureLogged && isDevelopmentMode()) {
+    initializationFailureLogged = true;
+    console.error('Failed to initialize the Axiom crash reporter', error);
+  }
+};
+
+const buildCrashReporterOptions = (): CrashReporterOptions | null => {
+  const axiomExtra = getAxiomExtra();
+  const dataset = resolveString(axiomExtra?.dataset);
+  const token = resolveString(axiomExtra?.token);
+
+  if (!dataset || !token) {
+    warnMissingConfiguration();
+    return null;
+  }
+
+  const variant = resolveVariant();
+  const environment = resolveString(axiomExtra?.environment) ?? variant;
+  const releaseChannel = resolveString(axiomExtra?.releaseChannel) ?? variant;
+  const flushOnCapture = resolveBoolean(axiomExtra?.flushOnCapture);
+
+  const options: CrashReporterOptions = {
+    dataset,
+    token,
+  };
+
+  if (environment) {
+    options.environment = environment;
+  }
+
+  const appVersion = resolveAppVersion();
+  if (appVersion) {
+    options.appVersion = appVersion;
+  }
+
+  if (releaseChannel) {
+    options.releaseChannel = releaseChannel;
+  }
+
+  const applicationId = resolveApplicationId();
+  if (applicationId) {
+    options.applicationId = applicationId;
+  }
+
+  const metadata = buildMetadata(variant);
+  if (Object.keys(metadata).length > 0) {
+    options.metadata = metadata;
+  }
+
+  if (flushOnCapture !== undefined) {
+    options.flushOnCapture = flushOnCapture;
+  }
+
+  return options;
+};
+
+export const initializeCrashReporter = (): AxiomCrashReporter | null => {
+  if (reporter) {
+    return reporter;
+  }
+
+  const options = buildCrashReporterOptions();
+  if (!options) {
+    return null;
+  }
+
+  try {
+    reporter = initializeAxiomCrashReporter(options);
+    initializationFailureLogged = false;
+  } catch (error) {
+    reporter = null;
+    logInitializationFailure(error);
+    return null;
+  }
+
+  return reporter;
+};
+
+export const getCrashReporter = (): AxiomCrashReporter | null => reporter;
+
+const withReporter = async (
+  action: (instance: AxiomCrashReporter) => Promise<void>,
+  failureMessage: string,
+): Promise<void> => {
+  const instance = initializeCrashReporter();
+  if (!instance) {
+    return;
+  }
+
+  try {
+    await action(instance);
+  } catch (error) {
+    if (isDevelopmentMode()) {
+      console.error(failureMessage, error);
+    }
+  }
+};
+
+export const captureCrash = async (error: unknown, context: CrashReportContext = {}): Promise<void> => {
+  await withReporter(
+    (instance) => instance.reportError(error, context),
+    'Failed to forward crash report to Axiom',
+  );
+};
+
+export const captureFatalCrash = async (error: unknown, context: CrashReportContext = {}): Promise<void> => {
+  await withReporter(
+    (instance) => instance.reportFatalError(error, context),
+    'Failed to forward fatal crash report to Axiom',
+  );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
         "@tanstack/react-query": "^5.83.0",
         "@tanstack/react-query-devtools": "^5.83.0",
         "@tanstack/react-query-persist-client": "^5.83.0",
+        "axiom-crash-reporter": "*",
         "bluesky-api": "*",
         "clearsky-api": "*",
         "expo": "~53.0.22",

--- a/package-lock.json
+++ b/package-lock.json
@@ -252,6 +252,32 @@
       "integrity": "sha512-nOvU699OXiGMbyswao7JJnY0C9WkwE7PVC/m5WWt0UN9fsXSOor9IZWw+v9SATp+94BTJoG38XyUomUaJnoQRA==",
       "license": "MIT"
     },
+    "node_modules/@axiomhq/js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@axiomhq/js/-/js-1.3.1.tgz",
+      "integrity": "sha512-Ytf5V3wKz8FKNiqJxnqZmUhjgJ7TItKUoyHVNE/H2V9dN1ozD6NNnsueenOjKdA48cm2sGRyP432nworst18aA==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-retry": "^6.0.0",
+        "uuid": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@axiomhq/js/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
@@ -7018,6 +7044,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axiom-crash-reporter": {
+      "resolved": "packages/axiom-crash-reporter",
+      "link": true
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -10364,6 +10394,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fetch-retry": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
+      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
+      "license": "MIT"
     },
     "node_modules/fflate": {
       "version": "0.8.2",
@@ -20158,6 +20194,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/axiom-crash-reporter": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@axiomhq/js": "^1.3.1"
+      },
+      "devDependencies": {
+        "@eslint/eslintrc": "^3.0.0",
+        "@eslint/js": "^9.25.0",
+        "@types/jest": "^30.0.0",
+        "eslint": "^9.25.0",
+        "eslint-config-expo": "~9.2.0",
+        "jest": "~29.7.0",
+        "ts-jest": "^29.4.1",
+        "typescript": "~5.8.3"
       }
     },
     "packages/bluesky-api": {

--- a/packages/axiom-crash-reporter/README.md
+++ b/packages/axiom-crash-reporter/README.md
@@ -1,0 +1,76 @@
+# Axiom Crash Reporter
+
+`axiom-crash-reporter` provides a lightweight crash reporting helper that forwards runtime errors from JavaScript and React Native apps to [Axiom](https://axiom.co).
+
+## Installation
+
+```bash
+npm install axiom-crash-reporter
+```
+
+The package depends on the official [`@axiomhq/js`](https://www.npmjs.com/package/@axiomhq/js) SDK which is installed automatically.
+
+## Quick start
+
+```ts
+import { initializeAxiomCrashReporter } from 'axiom-crash-reporter';
+
+const reporter = initializeAxiomCrashReporter({
+  token: process.env.AXIOM_TOKEN!,
+  dataset: 'app-crashes',
+  environment: 'production',
+  appVersion: '1.0.0',
+});
+
+// Manually capture handled errors
+try {
+  doSomething();
+} catch (error) {
+  await reporter.reportError(error, { metadata: { action: 'doSomething' } });
+}
+```
+
+`initializeAxiomCrashReporter` installs global handlers that capture uncaught errors and promise rejections. Use the exported `AxiomCrashReporter` class for fine-grained control or to integrate with existing error handling.
+
+## API
+
+### `initializeAxiomCrashReporter(options)`
+
+Creates an `AxiomCrashReporter` instance and registers global handlers immediately. Returns the configured reporter instance.
+
+### `AxiomCrashReporter`
+
+The class exposes the following methods:
+
+- `install()` / `uninstall()` – register or remove global handlers.
+- `reportError(error, context?)` – normalize and forward an error to Axiom.
+- `reportFatalError(error, context?)` – helper that marks the payload as fatal.
+- `captureException(error, context?)` – alias for `reportError`.
+
+The `context` argument accepts optional metadata, tags, severity overrides, and fatal flags.
+
+### Options
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `dataset` | `string` | **Required.** Axiom dataset name. |
+| `token` | `string` | Ingestion token used to create an Axiom client. Provide either `token` or `client`. |
+| `client` | `Axiom` | Optional pre-configured Axiom client instance. |
+| `environment` | `string` | Environment label such as `production` or `development`. |
+| `appVersion` | `string` | Application version attached to each crash report. |
+| `releaseChannel` | `string` | Release channel or build flavor identifier. |
+| `applicationId` | `string` | Optional application identifier to aid multi-app deployments. |
+| `metadata` | `Record<string, unknown>` | Default metadata merged into every report. |
+| `flushOnCapture` | `boolean` | Flush the Axiom client after each report (default `true`). |
+| `beforeSend` | `(report) => report \| null` | Transform or drop payloads before they are ingested. |
+| `onError` | `(error) => void` | Error handler invoked when ingestion fails. |
+
+## Testing
+
+```
+npm run test --workspace axiom-crash-reporter
+```
+
+## License
+
+MIT

--- a/packages/axiom-crash-reporter/eslint.config.js
+++ b/packages/axiom-crash-reporter/eslint.config.js
@@ -1,0 +1,23 @@
+import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+export default [
+  js.configs.recommended,
+  ...compat.extends('expo'),
+  {
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+    },
+    rules: {},
+  },
+];

--- a/packages/axiom-crash-reporter/jest.config.cjs
+++ b/packages/axiom-crash-reporter/jest.config.cjs
@@ -1,0 +1,34 @@
+const baseTsconfig = require('./tsconfig.json');
+
+const jestTsconfig = {
+  ...baseTsconfig.compilerOptions,
+  types: [
+    ...new Set([
+      ...(baseTsconfig.compilerOptions?.types ?? []),
+      'jest',
+      'node',
+    ]),
+  ],
+};
+
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  extensionsToTreatAsEsm: ['.ts'],
+  coverageProvider: 'v8',
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts', '!src/**/*.d.ts'],
+  coverageReporters: ['text', 'lcov', 'html'],
+  coverageDirectory: 'coverage',
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  globals: {
+    'ts-jest': {
+      useESM: true,
+      tsconfig: jestTsconfig,
+    },
+  },
+};

--- a/packages/axiom-crash-reporter/package.json
+++ b/packages/axiom-crash-reporter/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "axiom-crash-reporter",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Crash reporting utilities for sending JavaScript errors to Axiom.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint src --ext .ts",
+    "test": "jest",
+    "test:run": "jest --coverage=false",
+    "test:coverage": "jest --coverage",
+    "clean": "rm -rf dist coverage"
+  },
+  "keywords": [
+    "axiom",
+    "crash",
+    "reporting",
+    "react-native",
+    "logging"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@axiomhq/js": "^1.3.1"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.0.0",
+    "@eslint/js": "^9.25.0",
+    "@types/jest": "^30.0.0",
+    "eslint": "^9.25.0",
+    "eslint-config-expo": "~9.2.0",
+    "jest": "~29.7.0",
+    "ts-jest": "^29.4.1",
+    "typescript": "~5.8.3"
+  }
+}

--- a/packages/axiom-crash-reporter/src/AxiomCrashReporter.test.ts
+++ b/packages/axiom-crash-reporter/src/AxiomCrashReporter.test.ts
@@ -1,0 +1,154 @@
+import { AxiomCrashReporter, initializeAxiomCrashReporter } from './AxiomCrashReporter';
+import type { CrashReport, CrashReporterClient } from './types';
+
+describe('AxiomCrashReporter', () => {
+  let ingest: jest.MockedFunction<CrashReporterClient['ingest']>;
+  let flush: jest.MockedFunction<CrashReporterClient['flush']>;
+  let client: CrashReporterClient;
+
+  beforeEach(() => {
+    ingest = jest.fn().mockResolvedValue(undefined);
+    flush = jest.fn().mockResolvedValue(undefined);
+    client = {
+      ingest,
+      flush,
+    };
+  });
+
+  it('sends normalized reports to Axiom', async () => {
+    const reporter = new AxiomCrashReporter({
+      dataset: 'crashes',
+      client,
+      environment: 'test',
+      metadata: { release: '1.0.0' },
+    });
+
+    await reporter.reportError(new Error('boom'));
+
+    expect(ingest).toHaveBeenCalledTimes(1);
+    expect(flush).toHaveBeenCalledTimes(1);
+
+    const [, events] = ingest.mock.calls[0];
+    const payload = events[0] as CrashReport;
+    expect(payload.message).toBe('boom');
+    expect(payload.environment).toBe('test');
+    expect(payload.metadata).toEqual({ release: '1.0.0' });
+    expect(payload.severity).toBe('error');
+    expect(payload.isFatal).toBe(false);
+  });
+
+  it('marks fatal errors and merges metadata overrides', async () => {
+    const reporter = new AxiomCrashReporter({
+      dataset: 'crashes',
+      client,
+      metadata: { platform: 'ios' },
+    });
+
+    await reporter.reportFatalError(new Error('fatal'), {
+      metadata: { screen: 'home' },
+      tags: { handled: 'false' },
+    });
+
+    const [, events] = ingest.mock.calls[0];
+    const payload = events[0] as CrashReport;
+    expect(payload.severity).toBe('fatal');
+    expect(payload.isFatal).toBe(true);
+    expect(payload.metadata).toEqual({ platform: 'ios', screen: 'home' });
+    expect(payload.tags).toEqual({ handled: 'false' });
+  });
+
+  it('captures error causes and aggregate members', async () => {
+    const reporter = new AxiomCrashReporter({ dataset: 'crashes', client });
+
+    const cause = new Error('network down');
+    const causedError = new Error('top-level');
+    (causedError as { cause?: unknown }).cause = cause;
+    await reporter.reportError(causedError);
+
+    const [, causeEvents] = ingest.mock.calls[0];
+    const causePayload = causeEvents[0] as CrashReport;
+    expect(causePayload.chain?.[0]?.message).toBe('network down');
+
+    ingest.mockClear();
+    const aggregate = new AggregateError([new Error('first'), 'second'], 'aggregate fail');
+    await reporter.reportError(aggregate);
+
+    const [, aggregateEvents] = ingest.mock.calls[0];
+    const aggregatePayload = aggregateEvents[0] as CrashReport;
+    expect(aggregatePayload.aggregate?.length).toBe(2);
+    expect(aggregatePayload.aggregate?.[1]?.message).toBe('second');
+  });
+
+  it('allows dropping events through beforeSend hook', async () => {
+    const reporter = new AxiomCrashReporter({
+      dataset: 'crashes',
+      client,
+      beforeSend: () => null,
+    });
+
+    await reporter.reportError(new Error('ignore'));
+    expect(ingest).not.toHaveBeenCalled();
+  });
+
+  it('invokes custom ingestion error handler', async () => {
+    const failure = new Error('network');
+    ingest.mockRejectedValueOnce(failure);
+    const onError = jest.fn();
+
+    const reporter = new AxiomCrashReporter({
+      dataset: 'crashes',
+      client,
+      onError,
+    });
+
+    await reporter.reportError(new Error('boom'));
+    expect(onError).toHaveBeenCalledWith(failure);
+  });
+
+  it('installs and restores global handlers', async () => {
+    const originalErrorUtils = (globalThis as { ErrorUtils?: unknown }).ErrorUtils;
+    const original = jest.fn();
+    const setGlobalHandler = jest.fn();
+    const getGlobalHandler = jest.fn(() => original);
+
+    (globalThis as { ErrorUtils?: unknown }).ErrorUtils = {
+      setGlobalHandler,
+      getGlobalHandler,
+    };
+
+    const reporter = new AxiomCrashReporter({ dataset: 'crashes', client });
+    reporter.install();
+
+    expect(setGlobalHandler).toHaveBeenCalledTimes(1);
+    const handler = setGlobalHandler.mock.calls[0][0];
+    const error = new Error('fatal');
+    handler(error, true);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(ingest).toHaveBeenCalledTimes(1);
+    expect(original).toHaveBeenCalledWith(error, true);
+
+    reporter.uninstall();
+    expect(setGlobalHandler).toHaveBeenCalledTimes(2);
+    expect(setGlobalHandler.mock.calls[1][0]).toBe(original);
+    (globalThis as { ErrorUtils?: unknown }).ErrorUtils = originalErrorUtils;
+  });
+
+  it('initializes and installs immediately', () => {
+    const originalErrorUtils = (globalThis as { ErrorUtils?: unknown }).ErrorUtils;
+    const setGlobalHandler = jest.fn();
+    const getGlobalHandler = jest.fn();
+
+    (globalThis as { ErrorUtils?: unknown }).ErrorUtils = {
+      setGlobalHandler,
+      getGlobalHandler,
+    };
+
+    const reporter = initializeAxiomCrashReporter({ dataset: 'crashes', client });
+    expect(setGlobalHandler).toHaveBeenCalledTimes(1);
+
+    reporter.uninstall();
+    (globalThis as { ErrorUtils?: unknown }).ErrorUtils = originalErrorUtils;
+  });
+});

--- a/packages/axiom-crash-reporter/src/AxiomCrashReporter.ts
+++ b/packages/axiom-crash-reporter/src/AxiomCrashReporter.ts
@@ -1,0 +1,364 @@
+import { Axiom } from '@axiomhq/js';
+import type {
+  CrashReport,
+  CrashReportCause,
+  CrashReporterClient,
+  CrashReporterOptions,
+  CrashReportContext,
+  CrashReportTransform,
+  CrashSeverity,
+} from './types';
+
+type GlobalErrorHandler = (error: unknown, isFatal?: boolean) => void;
+
+type ErrorUtilsShape = {
+  setGlobalHandler?: (handler: GlobalErrorHandler) => void;
+  getGlobalHandler?: () => GlobalErrorHandler;
+};
+
+type EventTargetShape = {
+  addEventListener?: (type: string, listener: (event: unknown) => void) => void;
+  removeEventListener?: (type: string, listener: (event: unknown) => void) => void;
+  onunhandledrejection?: ((event: unknown) => void) | null;
+};
+
+type NormalizedError = {
+  message: string;
+  name?: string;
+  stack?: string;
+  chain?: CrashReportCause[];
+  aggregate?: CrashReportCause[];
+};
+
+export class AxiomCrashReporter {
+  private readonly client: CrashReporterClient;
+  private readonly dataset: string;
+  private readonly environment?: string;
+  private readonly appVersion?: string;
+  private readonly releaseChannel?: string;
+  private readonly applicationId?: string;
+  private readonly baseMetadata?: Record<string, unknown>;
+  private readonly flushOnCapture: boolean;
+  private readonly beforeSend?: CrashReportTransform;
+  private readonly onClientError?: (error: unknown) => void;
+
+  private installed = false;
+  private originalErrorHandler?: GlobalErrorHandler;
+  private originalOnUnhandledRejection?: ((event: unknown) => void) | null;
+  private replacedOnUnhandledRejection = false;
+
+  private readonly unhandledRejectionHandler: (event: unknown) => void;
+  private readonly globalHandler: GlobalErrorHandler;
+
+  public constructor(options: CrashReporterOptions) {
+    if (!options.dataset) {
+      throw new Error('A dataset name is required to initialize the Axiom crash reporter.');
+    }
+
+    if (!options.client && !options.token) {
+      throw new Error('Provide either an Axiom ingestion token or a pre-configured client instance.');
+    }
+
+    this.dataset = options.dataset;
+    this.environment = options.environment;
+    this.appVersion = options.appVersion;
+    this.releaseChannel = options.releaseChannel;
+    this.applicationId = options.applicationId;
+    this.baseMetadata = options.metadata ? { ...options.metadata } : undefined;
+    this.flushOnCapture = options.flushOnCapture ?? true;
+    this.beforeSend = options.beforeSend;
+    this.onClientError = options.onError;
+
+    if (options.client) {
+      this.client = options.client;
+    } else {
+      this.client = (new Axiom({ token: options.token as string })) as unknown as CrashReporterClient;
+    }
+
+    this.unhandledRejectionHandler = (event: unknown) => {
+      const reason = this.extractRejectionReason(event);
+      void this.capture(reason, {
+        severity: 'error',
+        metadata: { crashSource: 'unhandled-rejection' },
+      });
+    };
+
+    this.globalHandler = (error: unknown, isFatal?: boolean) => {
+      void this.capture(error, {
+        severity: isFatal ? 'fatal' : 'error',
+        isFatal,
+        metadata: { crashSource: 'global-error-handler' },
+      });
+
+      if (this.originalErrorHandler) {
+        this.originalErrorHandler(error, isFatal);
+      }
+    };
+  }
+
+  public install(): void {
+    if (this.installed) {
+      return;
+    }
+
+    const errorUtils = (globalThis as unknown as { ErrorUtils?: ErrorUtilsShape }).ErrorUtils;
+    if (errorUtils?.setGlobalHandler && errorUtils?.getGlobalHandler) {
+      this.originalErrorHandler = errorUtils.getGlobalHandler();
+      errorUtils.setGlobalHandler(this.globalHandler);
+    }
+
+    const eventTarget = globalThis as unknown as EventTargetShape;
+    if (typeof eventTarget.addEventListener === 'function' && typeof eventTarget.removeEventListener === 'function') {
+      eventTarget.addEventListener('unhandledrejection', this.unhandledRejectionHandler);
+    } else if ('onunhandledrejection' in eventTarget) {
+      this.originalOnUnhandledRejection = eventTarget.onunhandledrejection ?? null;
+      this.replacedOnUnhandledRejection = true;
+      eventTarget.onunhandledrejection = (event: unknown) => {
+        if (typeof this.originalOnUnhandledRejection === 'function') {
+          this.originalOnUnhandledRejection.call(eventTarget, event);
+        }
+
+        this.unhandledRejectionHandler(event);
+      };
+    }
+
+    this.installed = true;
+  }
+
+  public uninstall(): void {
+    if (!this.installed) {
+      return;
+    }
+
+    const errorUtils = (globalThis as unknown as { ErrorUtils?: ErrorUtilsShape }).ErrorUtils;
+    if (errorUtils?.setGlobalHandler && this.originalErrorHandler) {
+      errorUtils.setGlobalHandler(this.originalErrorHandler);
+    }
+    this.originalErrorHandler = undefined;
+
+    const eventTarget = globalThis as unknown as EventTargetShape;
+    if (typeof eventTarget.removeEventListener === 'function') {
+      eventTarget.removeEventListener('unhandledrejection', this.unhandledRejectionHandler);
+    } else if (this.replacedOnUnhandledRejection && 'onunhandledrejection' in eventTarget) {
+      eventTarget.onunhandledrejection = this.originalOnUnhandledRejection ?? null;
+    }
+
+    this.originalOnUnhandledRejection = null;
+    this.replacedOnUnhandledRejection = false;
+    this.installed = false;
+  }
+
+  public async reportError(error: unknown, context: CrashReportContext = {}): Promise<void> {
+    await this.capture(error, context);
+  }
+
+  public async reportFatalError(error: unknown, context: CrashReportContext = {}): Promise<void> {
+    const nextContext: CrashReportContext = {
+      ...context,
+      severity: 'fatal',
+      isFatal: true,
+    };
+
+    await this.capture(error, nextContext);
+  }
+
+  public async captureException(error: unknown, context: CrashReportContext = {}): Promise<void> {
+    await this.reportError(error, context);
+  }
+
+  private async capture(error: unknown, context: CrashReportContext): Promise<void> {
+    const severity = this.resolveSeverity(context);
+    const isFatal = context.isFatal ?? severity === 'fatal';
+    const report = this.createReport(error, context, severity, isFatal);
+    const candidate = await this.applyBeforeSend(report);
+
+    if (!candidate) {
+      return;
+    }
+
+    try {
+      await this.client.ingest(this.dataset, [candidate]);
+      if (this.flushOnCapture) {
+        await this.client.flush();
+      }
+    } catch (ingestError) {
+      if (this.onClientError) {
+        this.onClientError(ingestError);
+      } else {
+        console.error('Failed to send crash report to Axiom', ingestError);
+      }
+    }
+  }
+
+  private resolveSeverity(context: CrashReportContext): CrashSeverity {
+    if (context.severity) {
+      return context.severity;
+    }
+
+    if (context.isFatal) {
+      return 'fatal';
+    }
+
+    return 'error';
+  }
+
+  private createReport(
+    error: unknown,
+    context: CrashReportContext,
+    severity: CrashSeverity,
+    isFatal: boolean,
+  ): CrashReport {
+    const normalized = this.normalizeError(error);
+    const metadata = this.mergeMetadata(context.metadata);
+    const tags = context.tags ? { ...context.tags } : undefined;
+
+    return {
+      id: this.generateEventId(),
+      timestamp: new Date().toISOString(),
+      message: normalized.message,
+      name: normalized.name,
+      stack: normalized.stack,
+      severity,
+      isFatal,
+      environment: this.environment,
+      appVersion: this.appVersion,
+      releaseChannel: this.releaseChannel,
+      applicationId: this.applicationId,
+      metadata,
+      tags,
+      chain: normalized.chain,
+      aggregate: normalized.aggregate,
+    };
+  }
+
+  private mergeMetadata(additional?: Record<string, unknown>): Record<string, unknown> | undefined {
+    if (!this.baseMetadata && !additional) {
+      return undefined;
+    }
+
+    return {
+      ...(this.baseMetadata ?? {}),
+      ...(additional ?? {}),
+    };
+  }
+
+  private normalizeError(error: unknown): NormalizedError {
+    if (error instanceof Error) {
+      const chain = this.extractCauseChain(error);
+      const aggregate = error instanceof AggregateError ? this.extractAggregateErrors(error.errors) : undefined;
+
+      return {
+        message: error.message,
+        name: error.name,
+        stack: error.stack,
+        chain,
+        aggregate,
+      };
+    }
+
+    if (typeof error === 'string') {
+      return { message: error };
+    }
+
+    if (typeof error === 'object' && error !== null) {
+      try {
+        return { message: JSON.stringify(error) };
+      } catch {
+        return { message: String(error) };
+      }
+    }
+
+    return { message: String(error) };
+  }
+
+  private extractCauseChain(error: Error): CrashReportCause[] | undefined {
+    const causes: CrashReportCause[] = [];
+    let current: unknown = error.cause;
+
+    while (current instanceof Error) {
+      causes.push({
+        message: current.message,
+        name: current.name,
+        stack: current.stack,
+      });
+
+      current = current.cause;
+    }
+
+    return causes.length > 0 ? causes : undefined;
+  }
+
+  private extractAggregateErrors(errors: Iterable<unknown>): CrashReportCause[] {
+    const results: CrashReportCause[] = [];
+
+    for (const entry of errors) {
+      const normalized = this.normalizeError(entry);
+      results.push({
+        message: normalized.message,
+        name: normalized.name,
+        stack: normalized.stack,
+      });
+    }
+
+    return results;
+  }
+
+  private extractRejectionReason(event: unknown): unknown {
+    if (typeof event === 'object' && event !== null && 'reason' in event) {
+      return (event as { reason?: unknown }).reason;
+    }
+
+    return event;
+  }
+
+  private async applyBeforeSend(report: CrashReport): Promise<CrashReport | null> {
+    if (!this.beforeSend) {
+      return report;
+    }
+
+    const clonedReport: CrashReport = {
+      ...report,
+      metadata: report.metadata ? { ...report.metadata } : undefined,
+      tags: report.tags ? { ...report.tags } : undefined,
+      chain: this.cloneCauses(report.chain),
+      aggregate: this.cloneCauses(report.aggregate),
+    };
+
+    const transformed = await this.beforeSend(clonedReport);
+    if (!transformed) {
+      return null;
+    }
+
+    return transformed;
+  }
+
+  private cloneCauses(causes?: CrashReportCause[]): CrashReportCause[] | undefined {
+    if (!causes) {
+      return undefined;
+    }
+
+    const result: CrashReportCause[] = [];
+    for (const cause of causes) {
+      result.push({ ...cause });
+    }
+
+    return result;
+  }
+
+  private generateEventId(): string {
+    const cryptoObject = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+    if (cryptoObject && typeof cryptoObject.randomUUID === 'function') {
+      return cryptoObject.randomUUID();
+    }
+
+    const timeComponent = Date.now().toString(36);
+    const randomComponent = Math.random().toString(36).slice(2, 10);
+    return `${timeComponent}-${randomComponent}`;
+  }
+}
+
+export function initializeAxiomCrashReporter(options: CrashReporterOptions): AxiomCrashReporter {
+  const reporter = new AxiomCrashReporter(options);
+  reporter.install();
+  return reporter;
+}

--- a/packages/axiom-crash-reporter/src/index.ts
+++ b/packages/axiom-crash-reporter/src/index.ts
@@ -1,0 +1,10 @@
+export { AxiomCrashReporter, initializeAxiomCrashReporter } from './AxiomCrashReporter';
+export type {
+  CrashReport,
+  CrashReportCause,
+  CrashReporterClient,
+  CrashReporterOptions,
+  CrashReportContext,
+  CrashReportTransform,
+  CrashSeverity,
+} from './types';

--- a/packages/axiom-crash-reporter/src/types.ts
+++ b/packages/axiom-crash-reporter/src/types.ts
@@ -1,0 +1,59 @@
+export type CrashSeverity = 'fatal' | 'error' | 'warning' | 'info';
+
+export type CrashReportCause = {
+  message: string;
+  name?: string;
+  stack?: string;
+};
+
+export type CrashReport = {
+  id: string;
+  timestamp: string;
+  message: string;
+  name?: string;
+  stack?: string;
+  severity: CrashSeverity;
+  isFatal: boolean;
+  environment?: string;
+  appVersion?: string;
+  releaseChannel?: string;
+  applicationId?: string;
+  metadata?: Record<string, unknown>;
+  tags?: Record<string, string>;
+  chain?: CrashReportCause[];
+  aggregate?: CrashReportCause[];
+};
+
+export type CrashReportContext = {
+  severity?: CrashSeverity;
+  metadata?: Record<string, unknown>;
+  tags?: Record<string, string>;
+  isFatal?: boolean;
+};
+
+export type CrashReportTransform = (
+  report: CrashReport,
+) => CrashReport | null | Promise<CrashReport | null>;
+
+export type CrashReporterClient = {
+  ingest: (
+    dataset: string,
+    events: unknown[],
+    options?: Record<string, unknown>,
+  ) => Promise<unknown>;
+  flush: () => Promise<unknown>;
+};
+
+export type CrashReporterOptions = {
+  dataset: string;
+  token?: string;
+  client?: CrashReporterClient;
+  environment?: string;
+  appVersion?: string;
+  releaseChannel?: string;
+  applicationId?: string;
+  metadata?: Record<string, unknown>;
+  flushOnCapture?: boolean;
+  beforeSend?: CrashReportTransform;
+  onError?: (error: unknown) => void;
+};

--- a/packages/axiom-crash-reporter/tsconfig.json
+++ b/packages/axiom-crash-reporter/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}


### PR DESCRIPTION
## Summary
- add a reusable `axiom-crash-reporter` workspace that wraps the official Axiom SDK
- capture global React Native errors and unhandled promise rejections with configurable metadata and hooks
- document usage and cover normalization, hooks, and installation flows with Jest tests

## Testing
- npm run lint --workspace axiom-crash-reporter
- npm run test --workspace axiom-crash-reporter
- npm run test:coverage --workspace axiom-crash-reporter

------
https://chatgpt.com/codex/tasks/task_e_68d17726bc4c832bb4eced1c24cb670a