### PR TITLE
feat: add observability library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -189,6 +189,10 @@
         }
       }
     },
+    "node_modules/@akari/observability": {
+      "resolved": "packages/observability",
+      "link": true
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
@@ -251,6 +255,32 @@
       "resolved": "https://registry.npmjs.org/@atcute/bluesky-richtext-parser/-/bluesky-richtext-parser-1.0.7.tgz",
       "integrity": "sha512-nOvU699OXiGMbyswao7JJnY0C9WkwE7PVC/m5WWt0UN9fsXSOor9IZWw+v9SATp+94BTJoG38XyUomUaJnoQRA==",
       "license": "MIT"
+    },
+    "node_modules/@axiomhq/js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@axiomhq/js/-/js-1.3.1.tgz",
+      "integrity": "sha512-Ytf5V3wKz8FKNiqJxnqZmUhjgJ7TItKUoyHVNE/H2V9dN1ozD6NNnsueenOjKdA48cm2sGRyP432nworst18aA==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-retry": "^6.0.0",
+        "uuid": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@axiomhq/js/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -4283,6 +4313,15 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -10365,6 +10404,12 @@
         }
       }
     },
+    "node_modules/fetch-retry": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
+      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
+      "license": "MIT"
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -13863,7 +13908,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.throttle": {
@@ -20269,6 +20313,270 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/observability": {
+      "name": "@akari/observability",
+      "version": "0.1.0",
+      "dependencies": {
+        "@axiomhq/js": "^1.3.1",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.41.2",
+        "@opentelemetry/resources": "^1.27.0",
+        "@opentelemetry/sdk-trace-base": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "devDependencies": {
+        "@eslint/eslintrc": "^3.0.0",
+        "@eslint/js": "^9.25.0",
+        "@types/jest": "^30.0.0",
+        "eslint": "^9.25.0",
+        "eslint-config-expo": "~9.2.0",
+        "jest": "~29.7.0",
+        "ts-jest": "^29.4.1",
+        "typescript": "~5.8.3"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-native": ">=0.70.0"
+      }
+    },
+    "packages/observability/node_modules/@opentelemetry/api-logs": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.41.2.tgz",
+      "integrity": "sha512-JEV2RAqijAFdWeT6HddYymfnkiRu2ASxoTBr4WsnGJhOjWZkEy6vp+Sx9ozr1NaIODOa2HUyckExIqQjn6qywQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/observability/node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "packages/observability/node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.41.2.tgz",
+      "integrity": "sha512-Y0fGLipjZXLMelWtlS1/MDtrPxf25oM408KukRdkN31a1MEFo4h/ZkNwS7ZfmqHGUa+4rWRt2bi6JBiqy7Ytgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/otlp-exporter-base": "0.41.2",
+        "@opentelemetry/otlp-transformer": "0.41.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/sdk-trace-base": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/observability/node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.2.tgz",
+      "integrity": "sha512-+gBv15ta96WqkHZaPpcDHiaz0utiiHZVfm2YOYSqFGrUaJpPkMoSuLBB58YFQGi6Rsb9EHos84X6X5+9JspmLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "packages/observability/node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.41.2.tgz",
+      "integrity": "sha512-jJbPwB0tNu2v+Xi0c/v/R3YBLJKLonw1p+v3RVjT2VfzeUyzSp/tBeVdY7RZtL6dzZpA9XSmp8UEfWIFQo33yA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.41.2",
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/sdk-logs": "0.41.2",
+        "@opentelemetry/sdk-metrics": "1.15.2",
+        "@opentelemetry/sdk-trace-base": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+      }
+    },
+    "packages/observability/node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.41.2.tgz",
+      "integrity": "sha512-smqKIw0tTW15waj7BAPHFomii5c3aHnSE4LQYTszGoK5P9nZs8tEAIpu15UBxi3aG31ZfsLmm4EUQkjckdlFrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.5.0",
+        "@opentelemetry/api-logs": ">=0.39.1"
+      }
+    },
+    "packages/observability/node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.15.2.tgz",
+      "integrity": "sha512-9aIlcX8GnhcsAHW/Wl8bzk4ZnWTpNlLtud+fxUfBtFATu6OZ6TrGrF4JkT9EVrnoxwtPIDtjHdEsSjOqisY/iA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+      }
+    },
+    "packages/observability/node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.2.tgz",
+      "integrity": "sha512-xmMRLenT9CXmm5HMbzpZ1hWhaUowQf8UB4jMjFlAxx1QzQcsD3KFNAVX/CAWzFPtllTyTplrA4JrQ7sCH3qmYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/semantic-conventions": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "packages/observability/node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.15.2.tgz",
+      "integrity": "sha512-BEaxGZbWtvnSPchV98qqqqa96AOcb41pjgvhfzDij10tkBhIu9m0Jd6tZ1tJB5ZHfHbTffqYVYE0AOGobec/EQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/semantic-conventions": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "packages/observability/node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.2.tgz",
+      "integrity": "sha512-CjbOKwk2s+3xPIMcd5UNYQzsf+v94RczbdNix9/kQh38WiQkM90sUOi3if8eyHFgiBjBjhwXrA7W3ydiSQP9mw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/observability/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.41.2.tgz",
+      "integrity": "sha512-pfwa6d+Dax3itZcGWiA0AoXeVaCuZbbqUTsCtOysd2re8C2PWXNxDONUfBWsn+KgxAdi+ljwTjJGiaVLDaIEvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/observability/node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.2.tgz",
+      "integrity": "sha512-+gBv15ta96WqkHZaPpcDHiaz0utiiHZVfm2YOYSqFGrUaJpPkMoSuLBB58YFQGi6Rsb9EHos84X6X5+9JspmLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "packages/observability/node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.2.tgz",
+      "integrity": "sha512-CjbOKwk2s+3xPIMcd5UNYQzsf+v94RczbdNix9/kQh38WiQkM90sUOi3if8eyHFgiBjBjhwXrA7W3ydiSQP9mw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/observability/node_modules/@opentelemetry/resources": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "packages/observability/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "packages/observability/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "packages/tenor-api": {

--- a/packages/observability/eslint.config.js
+++ b/packages/observability/eslint.config.js
@@ -1,0 +1,23 @@
+import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+export default [
+  js.configs.recommended,
+  ...compat.extends('expo'),
+  {
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+    },
+    rules: {},
+  },
+];

--- a/packages/observability/jest.config.cjs
+++ b/packages/observability/jest.config.cjs
@@ -1,0 +1,34 @@
+const baseTsconfig = require('./tsconfig.json');
+
+const jestTsconfig = {
+  ...baseTsconfig.compilerOptions,
+  types: [
+    ...new Set([
+      ...(baseTsconfig.compilerOptions?.types ?? []),
+      'jest',
+      'node',
+    ]),
+  ],
+};
+
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  extensionsToTreatAsEsm: ['.ts'],
+  coverageProvider: 'v8',
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts', '!src/**/*.d.ts'],
+  coverageReporters: ['text', 'lcov', 'html'],
+  coverageDirectory: 'coverage',
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  globals: {
+    'ts-jest': {
+      useESM: true,
+      tsconfig: jestTsconfig,
+    },
+  },
+};

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@akari/observability",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Axiom-powered logging, crash reporting, and OpenTelemetry tracing helpers for React Native apps",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "lint": "eslint src --ext .ts",
+    "test": "jest",
+    "test:run": "jest --coverage=false",
+    "test:coverage": "jest --coverage"
+  },
+  "dependencies": {
+    "@axiomhq/js": "^1.3.1",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.41.2",
+    "@opentelemetry/resources": "^1.27.0",
+    "@opentelemetry/sdk-trace-base": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.27.0"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.0.0",
+    "@eslint/js": "^9.25.0",
+    "@types/jest": "^30.0.0",
+    "eslint": "^9.25.0",
+    "eslint-config-expo": "~9.2.0",
+    "jest": "~29.7.0",
+    "ts-jest": "^29.4.1",
+    "typescript": "~5.8.3"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-native": ">=0.70.0"
+  }
+}

--- a/packages/observability/src/crash-reporter.test.ts
+++ b/packages/observability/src/crash-reporter.test.ts
@@ -1,0 +1,148 @@
+import type { AxiomLogger } from './logger';
+import { CrashReporter } from './crash-reporter';
+
+type TestGlobal = typeof globalThis & {
+  ErrorUtils?: {
+    getGlobalHandler?: () => ((error: unknown, isFatal?: boolean) => void) | undefined;
+    setGlobalHandler?: (handler: (error: unknown, isFatal?: boolean) => void) => void;
+  };
+  addEventListener?: jest.Mock;
+  removeEventListener?: jest.Mock;
+  onunhandledrejection?: ((payload: unknown) => void) | null;
+};
+
+describe('CrashReporter', () => {
+  let globalScope: TestGlobal;
+  let captureException: jest.Mock;
+  let reporter: CrashReporter;
+  let originalErrorUtils: TestGlobal['ErrorUtils'];
+  let originalAddEventListener: TestGlobal['addEventListener'];
+  let originalRemoveEventListener: TestGlobal['removeEventListener'];
+  let originalOnUnhandledRejection: TestGlobal['onunhandledrejection'];
+
+  beforeEach(() => {
+    globalScope = globalThis as TestGlobal;
+    originalErrorUtils = globalScope.ErrorUtils;
+    originalAddEventListener = globalScope.addEventListener;
+    originalRemoveEventListener = globalScope.removeEventListener;
+    originalOnUnhandledRejection = globalScope.onunhandledrejection;
+
+    const setGlobalHandler = jest.fn();
+    const getGlobalHandler = jest.fn(() => jest.fn());
+
+    globalScope.ErrorUtils = {
+      setGlobalHandler,
+      getGlobalHandler,
+    };
+
+    globalScope.addEventListener = jest.fn();
+    globalScope.removeEventListener = jest.fn();
+    globalScope.onunhandledrejection = null;
+
+    captureException = jest.fn().mockResolvedValue(undefined);
+    reporter = new CrashReporter({ captureException } as unknown as AxiomLogger, {
+      dataset: 'crashes',
+      additionalAttributes: () => ({ appVersion: '1.0.0' }),
+    });
+  });
+
+  afterEach(() => {
+    reporter.uninstall();
+    captureException.mockClear();
+    if (globalScope.ErrorUtils?.setGlobalHandler) {
+      (globalScope.ErrorUtils.setGlobalHandler as jest.Mock).mockReset();
+    }
+    if (globalScope.ErrorUtils?.getGlobalHandler) {
+      (globalScope.ErrorUtils.getGlobalHandler as jest.Mock).mockReset();
+    }
+
+    if (globalScope.addEventListener) {
+      globalScope.addEventListener.mockReset();
+    }
+    if (globalScope.removeEventListener) {
+      globalScope.removeEventListener.mockReset();
+    }
+
+    if (originalErrorUtils === undefined) {
+      Reflect.deleteProperty(globalScope, 'ErrorUtils');
+    } else {
+      globalScope.ErrorUtils = originalErrorUtils;
+    }
+
+    if (originalAddEventListener === undefined) {
+      Reflect.deleteProperty(globalScope, 'addEventListener');
+    } else {
+      globalScope.addEventListener = originalAddEventListener;
+    }
+
+    if (originalRemoveEventListener === undefined) {
+      Reflect.deleteProperty(globalScope, 'removeEventListener');
+    } else {
+      globalScope.removeEventListener = originalRemoveEventListener;
+    }
+
+    if (originalOnUnhandledRejection === undefined) {
+      Reflect.deleteProperty(globalScope, 'onunhandledrejection');
+    } else {
+      globalScope.onunhandledrejection = originalOnUnhandledRejection;
+    }
+  });
+
+  it('captures errors from the React Native global handler', async () => {
+    reporter.install();
+
+    const handler = (globalScope.ErrorUtils?.setGlobalHandler as jest.Mock).mock.calls[0][0];
+    handler(new Error('App crashed'), true);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        appVersion: '1.0.0',
+        isFatal: true,
+        source: 'react-native',
+      }),
+      expect.objectContaining({ dataset: 'crashes' }),
+    );
+  });
+
+  it('captures unhandled promise rejections when available', async () => {
+    reporter.install();
+
+    const rejectionHandler = (globalScope.addEventListener as jest.Mock).mock.calls[0][1];
+    const preventDefault = jest.fn();
+    const reason = new Error('Rejected promise');
+    rejectionHandler({ reason, preventDefault });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(captureException).toHaveBeenCalledWith(
+      reason,
+      expect.objectContaining({ source: 'unhandled-rejection', isFatal: false }),
+      expect.objectContaining({ dataset: 'crashes' }),
+    );
+
+    reporter.uninstall();
+    expect(globalScope.removeEventListener).toHaveBeenCalledWith('unhandledrejection', rejectionHandler);
+  });
+
+  it('respects passthrough configuration', async () => {
+    const originalHandler = jest.fn();
+    (globalScope.ErrorUtils?.getGlobalHandler as jest.Mock).mockReturnValue(originalHandler);
+
+    reporter = new CrashReporter({ captureException } as unknown as AxiomLogger, {
+      dataset: 'crashes',
+      passthrough: false,
+    });
+
+    reporter.install();
+    const handler = (globalScope.ErrorUtils?.setGlobalHandler as jest.Mock).mock.calls[0][0];
+    handler(new Error('App crashed'), true);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(originalHandler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/observability/src/crash-reporter.ts
+++ b/packages/observability/src/crash-reporter.ts
@@ -1,0 +1,133 @@
+import type { AxiomLogger } from './logger';
+import type { CrashReportingConfig, LogAttributes } from './types';
+
+type ErrorHandler = (error: unknown, isFatal?: boolean) => void;
+
+type ReactNativeErrorUtils = {
+  getGlobalHandler?: () => ErrorHandler | undefined;
+  setGlobalHandler?: (handler: ErrorHandler) => void;
+};
+
+type GlobalEventTarget = typeof globalThis & {
+  ErrorUtils?: ReactNativeErrorUtils;
+  addEventListener?: (event: string, handler: (payload: unknown) => void) => void;
+  removeEventListener?: (event: string, handler: (payload: unknown) => void) => void;
+  onunhandledrejection?: ((payload: unknown) => void) | null;
+};
+
+type PromiseRejectionPayload = {
+  promise?: Promise<unknown>;
+  reason?: unknown;
+  preventDefault?: () => void;
+};
+
+const getErrorUtils = (): ReactNativeErrorUtils | undefined => {
+  const globalScope = globalThis as GlobalEventTarget;
+  return globalScope.ErrorUtils;
+};
+
+const resolveAdditionalAttributes = async (
+  resolver?: CrashReportingConfig['additionalAttributes'],
+): Promise<LogAttributes> => {
+  if (!resolver) {
+    return {};
+  }
+
+  try {
+    const result = await resolver();
+    return result ?? {};
+  } catch (error) {
+    console.warn('[observability] Failed to resolve crash reporter attributes', error);
+    return {};
+  }
+};
+
+export class CrashReporter {
+  private readonly logger: AxiomLogger;
+  private readonly config: CrashReportingConfig;
+  private originalHandler?: ErrorHandler;
+  private rejectionHandler?: (payload: unknown) => void;
+  private previousUnhandledRejection?: ((payload: unknown) => void) | null;
+
+  constructor(logger: AxiomLogger, config: CrashReportingConfig = {}) {
+    this.logger = logger;
+    this.config = config;
+  }
+
+  install() {
+    if (this.config.enableGlobalHandler !== false) {
+      const errorUtils = getErrorUtils();
+      if (errorUtils?.setGlobalHandler) {
+        this.originalHandler = errorUtils.getGlobalHandler?.();
+        const handler: ErrorHandler = (error, isFatal) => {
+          void this.handleError(error, isFatal, 'react-native');
+          if (this.config.passthrough !== false) {
+            this.originalHandler?.(error, isFatal);
+          }
+        };
+        errorUtils.setGlobalHandler(handler);
+      }
+    }
+
+    if (this.config.captureUnhandledRejections !== false) {
+      const globalScope = globalThis as GlobalEventTarget;
+      this.rejectionHandler = (payload: unknown) => {
+        const event = payload as PromiseRejectionPayload;
+        if (typeof event?.preventDefault === 'function') {
+          event.preventDefault();
+        }
+        const reason = event?.reason ?? payload;
+        void this.handleError(reason, false, 'unhandled-rejection');
+        if (this.config.passthrough !== false && this.previousUnhandledRejection) {
+          this.previousUnhandledRejection(event);
+        }
+      };
+
+      if (typeof globalScope.addEventListener === 'function' && typeof globalScope.removeEventListener === 'function') {
+        globalScope.addEventListener('unhandledrejection', this.rejectionHandler);
+      } else if ('onunhandledrejection' in globalScope) {
+        this.previousUnhandledRejection = globalScope.onunhandledrejection ?? null;
+        globalScope.onunhandledrejection = this.rejectionHandler;
+      }
+    }
+  }
+
+  uninstall() {
+    const errorUtils = getErrorUtils();
+    if (this.originalHandler && errorUtils?.setGlobalHandler) {
+      errorUtils.setGlobalHandler(this.originalHandler);
+    }
+    this.originalHandler = undefined;
+
+    if (this.rejectionHandler) {
+      const globalScope = globalThis as GlobalEventTarget;
+      if (typeof globalScope.removeEventListener === 'function') {
+        globalScope.removeEventListener('unhandledrejection', this.rejectionHandler);
+      }
+      if ('onunhandledrejection' in globalScope) {
+        globalScope.onunhandledrejection = this.previousUnhandledRejection ?? null;
+      }
+    }
+
+    this.rejectionHandler = undefined;
+    this.previousUnhandledRejection = null;
+  }
+
+  private async handleError(error: unknown, isFatal: boolean | undefined, source: string) {
+    const additional = await resolveAdditionalAttributes(this.config.additionalAttributes);
+
+    const attributes: LogAttributes = {
+      ...additional,
+      isFatal: Boolean(isFatal),
+      source,
+    };
+
+    try {
+      await this.logger.captureException(error, attributes, {
+        dataset: this.config.dataset,
+      });
+    } catch (loggingError) {
+      console.warn('[observability] Failed to capture crash', loggingError);
+    }
+  }
+}

--- a/packages/observability/src/index.test.ts
+++ b/packages/observability/src/index.test.ts
@@ -1,0 +1,161 @@
+import { diag, DiagLogLevel } from '@opentelemetry/api';
+
+import { initializeObservability } from './index';
+
+const ingestMock = jest.fn();
+const flushMock = jest.fn();
+
+jest.mock('@axiomhq/js', () => ({
+  Axiom: jest.fn().mockImplementation(() => ({
+    ingest: ingestMock,
+    flush: flushMock,
+  })),
+}));
+
+const exporterShutdownMock = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('@opentelemetry/exporter-trace-otlp-http', () => ({
+  OTLPTraceExporter: jest.fn().mockImplementation(() => ({
+    export: jest.fn((_, callback) => {
+      if (typeof callback === 'function') {
+        callback({ code: 0 });
+      }
+    }),
+    shutdown: exporterShutdownMock,
+  })),
+}));
+
+type TestGlobal = typeof globalThis & {
+  ErrorUtils?: {
+    getGlobalHandler?: () => ((error: unknown, isFatal?: boolean) => void) | undefined;
+    setGlobalHandler?: (handler: (error: unknown, isFatal?: boolean) => void) => void;
+  };
+  addEventListener?: jest.Mock;
+  removeEventListener?: jest.Mock;
+};
+
+describe('initializeObservability', () => {
+  let globalScope: TestGlobal;
+  let originalErrorUtils: TestGlobal['ErrorUtils'];
+  let originalAddEventListener: TestGlobal['addEventListener'];
+  let originalRemoveEventListener: TestGlobal['removeEventListener'];
+
+  beforeEach(() => {
+    ingestMock.mockClear();
+    flushMock.mockClear();
+    exporterShutdownMock.mockClear();
+    globalScope = globalThis as TestGlobal;
+    originalErrorUtils = globalScope.ErrorUtils;
+    originalAddEventListener = globalScope.addEventListener;
+    originalRemoveEventListener = globalScope.removeEventListener;
+
+    const setGlobalHandler = jest.fn();
+    const getGlobalHandler = jest.fn().mockReturnValue(jest.fn());
+
+    globalScope.ErrorUtils = {
+      setGlobalHandler,
+      getGlobalHandler,
+    };
+    globalScope.addEventListener = jest.fn();
+    globalScope.removeEventListener = jest.fn();
+    diag.setLogger(
+      { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), verbose: jest.fn() },
+      DiagLogLevel.NONE,
+    );
+  });
+
+  afterEach(async () => {
+    if (originalErrorUtils === undefined) {
+      Reflect.deleteProperty(globalScope, 'ErrorUtils');
+    } else {
+      globalScope.ErrorUtils = originalErrorUtils;
+    }
+
+    if (originalAddEventListener === undefined) {
+      Reflect.deleteProperty(globalScope, 'addEventListener');
+    } else {
+      globalScope.addEventListener = originalAddEventListener;
+    }
+
+    if (originalRemoveEventListener === undefined) {
+      Reflect.deleteProperty(globalScope, 'removeEventListener');
+    } else {
+      globalScope.removeEventListener = originalRemoveEventListener;
+    }
+  });
+
+  type TestConfig = Parameters<typeof initializeObservability>[0];
+
+  const createConfig = (): TestConfig => ({
+    axiomToken: 'token',
+    defaultDataset: 'app-logs',
+    globalAttributes: { release: '1.0.0' },
+    tracing: {
+      serviceName: 'akari-app',
+      otlpEndpoint: 'https://otel.example/v1/traces',
+      environment: 'test',
+    },
+    crashReporting: {
+      dataset: 'crashes',
+    },
+  });
+
+  it('initializes logging, tracing, and crash reporting', async () => {
+    const config = createConfig();
+    const client = initializeObservability(config);
+
+    expect(globalScope.ErrorUtils?.setGlobalHandler).toHaveBeenCalled();
+
+    await client.logInfo('App started', { screen: 'Home' });
+    expect(ingestMock).toHaveBeenCalledWith(
+      'app-logs',
+      expect.arrayContaining([
+        expect.objectContaining({
+          level: 'info',
+          message: 'App started',
+          screen: 'Home',
+          release: '1.0.0',
+          environment: 'test',
+          serviceName: 'akari-app',
+        }),
+      ]),
+    );
+
+    ingestMock.mockClear();
+    await client.captureException(new Error('Boom'));
+    expect(ingestMock).toHaveBeenCalledWith(
+      'crashes',
+      expect.arrayContaining([expect.objectContaining({ errorMessage: 'Boom' })]),
+    );
+
+    ingestMock.mockClear();
+    await client.withSpan('load-feed', async (span) => {
+      expect(span.spanContext().traceId).toHaveLength(32);
+      await client.logDebug('inside span');
+    });
+    expect(ingestMock).toHaveBeenCalled();
+
+    await client.flush();
+    expect(flushMock).toHaveBeenCalled();
+
+    await client.shutdown();
+    expect(exporterShutdownMock).toHaveBeenCalled();
+  });
+
+  it('falls back to noop tracing when disabled', async () => {
+    const config: TestConfig = {
+      axiomToken: 'token',
+      defaultDataset: 'logs',
+    };
+
+    const client = initializeObservability(config);
+    const tracer = client.getTracer();
+
+    await client.withSpan('noop-span', async () => {
+      await client.logInfo('without tracing');
+    });
+
+    expect(tracer).toBeDefined();
+    expect(ingestMock).toHaveBeenCalled();
+  });
+});

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -1,0 +1,194 @@
+import { SpanStatusCode, trace } from '@opentelemetry/api';
+import type { Span, SpanOptions, Tracer } from '@opentelemetry/api';
+
+import { AxiomLogger, normalizeError } from './logger';
+import { CrashReporter } from './crash-reporter';
+import { toSpanAttributes, TracingManager } from './tracing';
+import type {
+  LogAttributes,
+  LogLevel,
+  LogOptions,
+  ObservabilityClient,
+  ObservabilityConfig,
+  ObservabilitySpanOptions,
+} from './types';
+
+export * from './types';
+
+class Observability implements ObservabilityClient {
+  private readonly logger: AxiomLogger;
+  private readonly tracing?: TracingManager;
+  private readonly crashReporter?: CrashReporter;
+  private readonly crashDataset?: string;
+  private readonly instrumentationScope?: {
+    name?: string;
+    version?: string;
+  };
+
+  constructor(private readonly config: ObservabilityConfig) {
+    const derivedGlobalAttributes: LogAttributes = {
+      ...(config.globalAttributes ?? {}),
+    };
+
+    if (config.tracing?.environment && derivedGlobalAttributes.environment === undefined) {
+      derivedGlobalAttributes.environment = config.tracing.environment;
+    }
+
+    if (config.tracing?.serviceName && derivedGlobalAttributes.serviceName === undefined) {
+      derivedGlobalAttributes.serviceName = config.tracing.serviceName;
+    }
+
+    this.logger = new AxiomLogger({
+      token: config.axiomToken,
+      dataset: config.defaultDataset,
+      baseUrl: config.axiomUrl,
+      orgId: config.orgId,
+      globalAttributes: derivedGlobalAttributes,
+      flushOnError: config.flushOnError,
+    });
+
+    if (config.tracing) {
+      this.tracing = new TracingManager(config.tracing);
+      this.tracing.initialize();
+      this.instrumentationScope = config.tracing.instrumentationScope;
+    }
+
+    if (config.crashReporting) {
+      this.crashDataset = config.crashReporting.dataset;
+      this.crashReporter = new CrashReporter(this.logger, config.crashReporting);
+      this.crashReporter.install();
+    }
+  }
+
+  async log(level: LogLevel, message: string, attributes: LogAttributes = {}, options: LogOptions = {}) {
+    await this.logger.log(level, message, attributes, options);
+  }
+
+  async logDebug(message: string, attributes: LogAttributes = {}, options: LogOptions = {}) {
+    await this.log('debug', message, attributes, options);
+  }
+
+  async logInfo(message: string, attributes: LogAttributes = {}, options: LogOptions = {}) {
+    await this.log('info', message, attributes, options);
+  }
+
+  async logWarn(message: string, attributes: LogAttributes = {}, options: LogOptions = {}) {
+    await this.log('warn', message, attributes, options);
+  }
+
+  async logError(message: string, attributes: LogAttributes = {}, options: LogOptions = {}) {
+    const dataset = options.dataset ?? this.crashDataset;
+    await this.log('error', message, attributes, {
+      ...options,
+      dataset,
+      flush: options.flush ?? this.config.flushOnError,
+    });
+  }
+
+  async captureException(error: unknown, attributes: LogAttributes = {}, options: LogOptions = {}) {
+    const dataset = options.dataset ?? this.crashDataset;
+    await this.logger.captureException(error, attributes, {
+      ...options,
+      dataset,
+    });
+  }
+
+  async withSpan<T>(name: string, handler: (span: Span) => Promise<T> | T, options: ObservabilitySpanOptions = {}) {
+    if (this.tracing) {
+      return this.tracing.withSpan(name, handler, options);
+    }
+
+    const tracer = this.getTracer();
+    const { attributes, status, ...spanOptions } = options;
+    const span = tracer.startSpan(name, spanOptions as SpanOptions);
+    if (attributes) {
+      span.setAttributes(toSpanAttributes(attributes));
+    }
+    if (status) {
+      span.setStatus(status);
+    }
+
+    try {
+      const result = handler(span);
+      if (result instanceof Promise) {
+        return await result
+          .then((value) => {
+            span.end();
+            return value;
+          })
+          .catch((error) => {
+            const normalized = normalizeError(error);
+            span.recordException({
+              name: normalized.name,
+              message: normalized.message,
+              stack: normalized.stack,
+            });
+            span.setStatus({
+              code: SpanStatusCode.ERROR,
+              message: normalized.message,
+            });
+            span.end();
+            throw error;
+          });
+      }
+
+      span.end();
+      return result;
+    } catch (error) {
+      const normalized = normalizeError(error);
+      span.recordException({
+        name: normalized.name,
+        message: normalized.message,
+        stack: normalized.stack,
+      });
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: normalized.message,
+      });
+      span.end();
+      throw error;
+    }
+  }
+
+  startSpan(name: string, options: ObservabilitySpanOptions = {}): Span {
+    if (this.tracing) {
+      return this.tracing.startSpan(name, options);
+    }
+
+    const tracer = this.getTracer();
+    const { attributes, status, ...spanOptions } = options;
+    const span = tracer.startSpan(name, spanOptions as SpanOptions);
+    if (attributes) {
+      span.setAttributes(toSpanAttributes(attributes));
+    }
+    if (status) {
+      span.setStatus(status);
+    }
+    return span;
+  }
+
+  getTracer(name?: string, version?: string): Tracer {
+    if (this.tracing) {
+      return this.tracing.getTracer(name, version);
+    }
+
+    const scopeName = name ?? this.instrumentationScope?.name ?? 'akari-observability';
+    const scopeVersion = version ?? this.instrumentationScope?.version ?? '0.1.0';
+    return trace.getTracer(scopeName, scopeVersion);
+  }
+
+  async flush() {
+    await this.logger.flush();
+    await this.tracing?.flush();
+  }
+
+  async shutdown() {
+    this.crashReporter?.uninstall();
+    await this.flush();
+    await this.tracing?.shutdown();
+  }
+}
+
+export const initializeObservability = (config: ObservabilityConfig): ObservabilityClient => {
+  return new Observability(config);
+};

--- a/packages/observability/src/logger.test.ts
+++ b/packages/observability/src/logger.test.ts
@@ -1,0 +1,92 @@
+import { trace } from '@opentelemetry/api';
+
+import { AxiomLogger, normalizeError } from './logger';
+
+const ingestMock = jest.fn();
+const flushMock = jest.fn();
+
+jest.mock('@axiomhq/js', () => ({
+  Axiom: jest.fn().mockImplementation(() => ({
+    ingest: ingestMock,
+    flush: flushMock,
+  })),
+}));
+
+describe('AxiomLogger', () => {
+  beforeEach(() => {
+    ingestMock.mockClear();
+    flushMock.mockClear();
+  });
+
+  it('normalizes errors', () => {
+    expect(normalizeError('failure')).toEqual({ name: 'Error', message: 'failure' });
+    const objectError = normalizeError({ message: 'boom', name: 'Custom' });
+    expect(objectError).toMatchObject({ name: 'Custom', message: 'boom' });
+  });
+
+  it('sends log events with merged attributes', async () => {
+    const logger = new AxiomLogger({
+      token: 'token',
+      dataset: 'app-logs',
+      globalAttributes: { appVersion: '1.0.0' },
+      flushOnError: false,
+    });
+
+    const timestamp = new Date('2024-01-01T00:00:00Z');
+
+    await logger.log('info', 'User signed in', { userId: '123' }, { timestamp });
+
+    expect(ingestMock).toHaveBeenCalledTimes(1);
+    const [dataset, events] = ingestMock.mock.calls[0];
+    expect(dataset).toBe('app-logs');
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      level: 'info',
+      message: 'User signed in',
+      userId: '123',
+      appVersion: '1.0.0',
+      _time: timestamp.toISOString(),
+    });
+    expect(flushMock).not.toHaveBeenCalled();
+  });
+
+  it('flushes automatically for error logs and exceptions', async () => {
+    const logger = new AxiomLogger({
+      token: 'token',
+      dataset: 'app-logs',
+      flushOnError: true,
+    });
+
+    await logger.log('error', 'Unhandled rejection');
+    expect(flushMock).toHaveBeenCalledTimes(1);
+
+    ingestMock.mockClear();
+    flushMock.mockClear();
+
+    const error = new Error('Boom');
+    await logger.captureException(error, { screen: 'Feed' });
+    expect(ingestMock).toHaveBeenCalledTimes(1);
+    const payload = ingestMock.mock.calls[0][1][0];
+    expect(payload).toMatchObject({
+      errorName: 'Error',
+      errorMessage: 'Boom',
+      screen: 'Feed',
+    });
+    expect(flushMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('records log events on the active span when available', async () => {
+    const logger = new AxiomLogger({ token: 'token', dataset: 'logs' });
+    const tracer = trace.getTracer('test');
+
+    await new Promise<void>((resolve) => {
+      tracer.startActiveSpan('parent', async (span) => {
+        await logger.log('debug', 'inside span');
+        span.end();
+        resolve();
+      });
+    });
+
+    expect(ingestMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/observability/src/logger.ts
+++ b/packages/observability/src/logger.ts
@@ -1,0 +1,169 @@
+import { Axiom } from '@axiomhq/js';
+import { SpanStatusCode, trace } from '@opentelemetry/api';
+
+import type { LogAttributes, LogLevel, LogOptions } from './types';
+
+export type LoggerConfig = {
+  token: string;
+  dataset: string;
+  baseUrl?: string;
+  orgId?: string;
+  globalAttributes?: LogAttributes;
+  flushOnError?: boolean;
+};
+
+export type NormalizedError = {
+  name: string;
+  message: string;
+  stack?: string;
+};
+
+const safeSerialize = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+export const normalizeError = (error: unknown): NormalizedError => {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack ?? undefined,
+    };
+  }
+
+  if (typeof error === 'string') {
+    return {
+      name: 'Error',
+      message: error,
+    };
+  }
+
+  if (typeof error === 'object' && error !== null) {
+    const candidate = error as { name?: string; message?: string };
+    return {
+      name: candidate.name ?? error.constructor?.name ?? 'Error',
+      message: candidate.message ?? safeSerialize(error),
+      stack: (candidate as { stack?: string }).stack,
+    };
+  }
+
+  return {
+    name: 'Error',
+    message: String(error),
+  };
+};
+
+export class AxiomLogger {
+  private readonly client: Axiom;
+  private readonly defaultDataset: string;
+  private readonly flushOnError: boolean;
+  private globalAttributes: LogAttributes;
+
+  constructor(config: LoggerConfig) {
+    this.client = new Axiom({
+      token: config.token,
+      ...(config.baseUrl ? { url: config.baseUrl } : {}),
+      ...(config.orgId ? { orgId: config.orgId } : {}),
+    });
+    this.defaultDataset = config.dataset;
+    this.flushOnError = config.flushOnError ?? true;
+    this.globalAttributes = { ...config.globalAttributes };
+  }
+
+  setGlobalAttributes(attributes: LogAttributes) {
+    this.globalAttributes = { ...attributes };
+  }
+
+  mergeGlobalAttributes(attributes: LogAttributes) {
+    this.globalAttributes = { ...this.globalAttributes, ...attributes };
+  }
+
+  async log(level: LogLevel, message: string, attributes: LogAttributes = {}, options: LogOptions = {}) {
+    const dataset = options.dataset ?? this.defaultDataset;
+
+    if (!dataset) {
+      console.warn('[observability] No dataset configured for log message');
+      return;
+    }
+
+    const timestamp = (options.timestamp ?? new Date()).toISOString();
+
+    const payload: Record<string, unknown> = {
+      _time: timestamp,
+      level,
+      message,
+      ...this.globalAttributes,
+      ...attributes,
+    };
+
+    const activeSpan = trace.getActiveSpan();
+    if (activeSpan) {
+      activeSpan.addEvent('log', {
+        level,
+        message,
+      });
+    }
+
+    try {
+      await this.client.ingest(dataset, [payload]);
+      if (options.flush) {
+        await this.client.flush();
+      }
+    } catch (error) {
+      console.warn('[observability] Failed to send log to Axiom', error);
+    }
+
+    if (!options.flush && (level === 'error' || level === 'fatal') && this.flushOnError) {
+      try {
+        await this.client.flush();
+      } catch (error) {
+        console.warn('[observability] Failed to flush Axiom client', error);
+      }
+    }
+  }
+
+  async captureException(error: unknown, attributes: LogAttributes = {}, options: LogOptions = {}) {
+    const normalized = normalizeError(error);
+
+    const combinedAttributes: LogAttributes = {
+      errorName: normalized.name,
+      errorMessage: normalized.message,
+      ...(normalized.stack ? { stack: normalized.stack } : {}),
+      ...attributes,
+    };
+
+    const activeSpan = trace.getActiveSpan();
+    if (activeSpan) {
+      activeSpan.recordException({
+        name: normalized.name,
+        message: normalized.message,
+        stack: normalized.stack,
+      });
+      activeSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: normalized.message,
+      });
+    }
+
+    await this.log('error', normalized.message, combinedAttributes, {
+      ...options,
+      flush: options.flush ?? this.flushOnError,
+    });
+  }
+
+  async flush() {
+    try {
+      await this.client.flush();
+    } catch (error) {
+      console.warn('[observability] Failed to flush Axiom client', error);
+    }
+  }
+}

--- a/packages/observability/src/tracing.ts
+++ b/packages/observability/src/tracing.ts
@@ -1,0 +1,199 @@
+import { diag, DiagConsoleLogger, DiagLogLevel, SpanStatusCode, trace } from '@opentelemetry/api';
+import type { Span, SpanAttributes, SpanOptions, Tracer } from '@opentelemetry/api';
+import {
+  AlwaysOffSampler,
+  AlwaysOnSampler,
+  BatchSpanProcessor,
+  BasicTracerProvider,
+  ParentBasedSampler,
+  TraceIdRatioBasedSampler,
+} from '@opentelemetry/sdk-trace-base';
+import { Resource } from '@opentelemetry/resources';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+
+import { normalizeError } from './logger';
+import type { ObservabilitySpanOptions, ObservabilityTracingConfig } from './types';
+
+export const toSpanAttributes = (attributes: Record<string, unknown>): SpanAttributes => {
+  const spanAttributes: SpanAttributes = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    if (value === null) {
+      spanAttributes[key] = 'null';
+      continue;
+    }
+
+    if (
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean'
+    ) {
+      spanAttributes[key] = value;
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      spanAttributes[key] = value.map((entry) => String(entry));
+      continue;
+    }
+
+    spanAttributes[key] = String(value);
+  }
+
+  return spanAttributes;
+};
+
+const createSampler = (config?: ObservabilityTracingConfig['traceSampler']) => {
+  if (!config || config === 'always_on') {
+    return new ParentBasedSampler({ root: new AlwaysOnSampler() });
+  }
+
+  if (config === 'always_off') {
+    return new AlwaysOffSampler();
+  }
+
+  if (config.type === 'ratio') {
+    return new ParentBasedSampler({ root: new TraceIdRatioBasedSampler(config.ratio) });
+  }
+
+  return new ParentBasedSampler({ root: new AlwaysOnSampler() });
+};
+
+export class TracingManager {
+  private readonly config: ObservabilityTracingConfig;
+  private provider?: BasicTracerProvider;
+  private exporter?: OTLPTraceExporter;
+
+  constructor(config: ObservabilityTracingConfig) {
+    this.config = config;
+  }
+
+  initialize() {
+    if (this.provider) {
+      return;
+    }
+
+    if (this.config.enableConsoleDiagnostics) {
+      diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
+    }
+
+    const resource = new Resource({
+      [SemanticResourceAttributes.SERVICE_NAME]: this.config.serviceName,
+      [SemanticResourceAttributes.DEPLOYMENT_ENVIRONMENT]: this.config.environment ?? 'development',
+      ...this.config.resourceAttributes,
+    });
+
+    const provider = new BasicTracerProvider({
+      resource,
+      sampler: createSampler(this.config.traceSampler),
+    });
+
+    this.exporter = new OTLPTraceExporter({
+      url: this.config.otlpEndpoint,
+    });
+
+    provider.addSpanProcessor(new BatchSpanProcessor(this.exporter));
+    provider.register();
+
+    this.provider = provider;
+  }
+
+  getTracer(name?: string, version?: string): Tracer {
+    const scopeName = name ?? this.config.instrumentationScope?.name ?? 'akari-observability';
+    const scopeVersion = version ?? this.config.instrumentationScope?.version ?? '0.1.0';
+    return trace.getTracer(scopeName, scopeVersion);
+  }
+
+  startSpan(name: string, options: ObservabilitySpanOptions = {}): Span {
+    const tracer = this.getTracer();
+    const { attributes, status, ...spanOptions } = options;
+    const span = tracer.startSpan(name, spanOptions as SpanOptions);
+    if (attributes) {
+      span.setAttributes(toSpanAttributes(attributes));
+    }
+    if (status) {
+      span.setStatus(status);
+    }
+    return span;
+  }
+
+  async withSpan<T>(
+    name: string,
+    handler: (span: Span) => Promise<T> | T,
+    options: ObservabilitySpanOptions = {},
+  ): Promise<T> {
+    const tracer = this.getTracer();
+    const { attributes, status, ...spanOptions } = options;
+    return tracer.startActiveSpan(name, spanOptions as SpanOptions, (span) => {
+      if (attributes) {
+        span.setAttributes(toSpanAttributes(attributes));
+      }
+      if (status) {
+        span.setStatus(status);
+      }
+
+      try {
+        const result = handler(span);
+        if (result instanceof Promise) {
+          return result
+            .then((value) => {
+              span.end();
+              return value;
+            })
+            .catch((error) => {
+              const normalized = normalizeError(error);
+              span.recordException({
+                name: normalized.name,
+                message: normalized.message,
+                stack: normalized.stack,
+              });
+              span.setStatus({
+                code: SpanStatusCode.ERROR,
+                message: normalized.message,
+              });
+              span.end();
+              throw error;
+            });
+        }
+
+        span.end();
+        return result;
+      } catch (error) {
+        const normalized = normalizeError(error);
+        span.recordException({
+          name: normalized.name,
+          message: normalized.message,
+          stack: normalized.stack,
+        });
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: normalized.message,
+        });
+        span.end();
+        throw error;
+      }
+    });
+  }
+
+  async flush() {
+    try {
+      await this.provider?.forceFlush();
+    } catch (error) {
+      console.warn('[observability] Failed to flush tracing provider', error);
+    }
+  }
+
+  async shutdown() {
+    try {
+      await this.provider?.shutdown();
+    } catch (error) {
+      console.warn('[observability] Failed to shutdown tracing provider', error);
+    }
+    this.provider = undefined;
+    this.exporter = undefined;
+  }
+}

--- a/packages/observability/src/types.ts
+++ b/packages/observability/src/types.ts
@@ -1,0 +1,68 @@
+import type { Span, SpanOptions, SpanStatusCode, Tracer } from '@opentelemetry/api';
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+
+export type LogAttributes = Record<string, unknown>;
+
+export type LogOptions = {
+  dataset?: string;
+  flush?: boolean;
+  timestamp?: Date;
+};
+
+export type ObservabilityTracingConfig = {
+  serviceName: string;
+  otlpEndpoint: string;
+  environment?: string;
+  resourceAttributes?: Record<string, string>;
+  instrumentationScope?: {
+    name?: string;
+    version?: string;
+  };
+  traceSampler?: 'always_on' | 'always_off' | {
+    type: 'ratio';
+    ratio: number;
+  };
+  enableConsoleDiagnostics?: boolean;
+};
+
+export type CrashReportingConfig = {
+  enableGlobalHandler?: boolean;
+  dataset?: string;
+  captureUnhandledRejections?: boolean;
+  passthrough?: boolean;
+  additionalAttributes?: () => Promise<LogAttributes> | LogAttributes;
+};
+
+export type ObservabilityConfig = {
+  axiomToken: string;
+  defaultDataset: string;
+  axiomUrl?: string;
+  orgId?: string;
+  flushOnError?: boolean;
+  globalAttributes?: LogAttributes;
+  tracing?: ObservabilityTracingConfig;
+  crashReporting?: CrashReportingConfig;
+};
+
+export type ObservabilitySpanOptions = Omit<SpanOptions, 'attributes'> & {
+  attributes?: LogAttributes;
+  status?: {
+    code: SpanStatusCode;
+    message?: string;
+  };
+};
+
+export type ObservabilityClient = {
+  log: (level: LogLevel, message: string, attributes?: LogAttributes, options?: LogOptions) => Promise<void>;
+  logDebug: (message: string, attributes?: LogAttributes, options?: LogOptions) => Promise<void>;
+  logInfo: (message: string, attributes?: LogAttributes, options?: LogOptions) => Promise<void>;
+  logWarn: (message: string, attributes?: LogAttributes, options?: LogOptions) => Promise<void>;
+  logError: (message: string, attributes?: LogAttributes, options?: LogOptions) => Promise<void>;
+  captureException: (error: unknown, attributes?: LogAttributes, options?: LogOptions) => Promise<void>;
+  withSpan: <T>(name: string, handler: (span: Span) => Promise<T> | T, options?: ObservabilitySpanOptions) => Promise<T>;
+  startSpan: (name: string, options?: ObservabilitySpanOptions) => Span;
+  getTracer: (name?: string, version?: string) => Tracer;
+  flush: () => Promise<void>;
+  shutdown: () => Promise<void>;
+};

--- a/packages/observability/tsconfig.build.json
+++ b/packages/observability/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/observability/tsconfig.json
+++ b/packages/observability/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- create an `@akari/observability` workspace package that wires Axiom logging, crash reporting, and OpenTelemetry tracing
- expose an `initializeObservability` helper along with span utilities, configuration types, and crash handling hooks
- add Jest coverage for the logger, crash reporter, and initialization flows

## Testing
- npm run lint --workspace=@akari/observability
- npm run test --workspace=@akari/observability

------
https://chatgpt.com/codex/tasks/task_e_68d1787a0460832bb8e1100ba6ed42d2