### PR TITLE
refactor: migrate handle history modal to virtualized list

### DIFF
--- a/apps/akari/components/HandleHistoryModal.tsx
+++ b/apps/akari/components/HandleHistoryModal.tsx
@@ -1,8 +1,9 @@
-import { FlatList, Modal, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Modal, StyleSheet, TouchableOpacity, View } from 'react-native';
 
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { IconSymbol } from '@/components/ui/IconSymbol';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
 import { useBorderColor } from '@/hooks/useBorderColor';
 import { useHandleHistory } from '@/hooks/useHandleHistory';
 import { useThemeColor } from '@/hooks/useThemeColor';
@@ -83,12 +84,13 @@ export function HandleHistoryModal({ visible, onClose, did, currentHandle }: Han
             ) : handleHistory.length === 0 ? (
               renderEmptyState()
             ) : (
-              <FlatList
+              <VirtualizedList
                 data={handleHistory}
                 renderItem={renderHandleEntry}
                 keyExtractor={(item, index) => `${item.handle}-${index}`}
                 showsVerticalScrollIndicator={false}
                 contentContainerStyle={styles.listContent}
+                estimatedItemSize={72}
               />
             )}
           </View>

--- a/virtualized-list-migration.md
+++ b/virtualized-list-migration.md
@@ -48,7 +48,7 @@ The FlashList-backed `VirtualizedList` component in `apps/akari/components/ui/Vi
   - Swap the GIF grid to `VirtualizedList`, keeping `numColumns`, `ListFooterComponent`, and `ListEmptyComponent` working.
   - FlashList needs an `estimatedItemSize` for grid tiles—base it on the GIF thumbnail height.
   - Re-run the infinite scroll logic to ensure `onEndReached` continues to request additional Tenor pages.
-- [ ] `apps/akari/components/HandleHistoryModal.tsx`
+- [x] `apps/akari/components/HandleHistoryModal.tsx`
   - Use `VirtualizedList` for the history list, set an `estimatedItemSize`, and keep the modal layout constraints intact.
   - Verify the divider styling still renders between items when FlashList virtualizes them.
 


### PR DESCRIPTION
## Summary
- migrate the handle history modal to the shared VirtualizedList with an estimated row height
- mark the modal entry in the virtualized list migration checklist as complete

## Testing
- npm run test -- --runInBand --testPathPattern=HandleHistoryModal

------
https://chatgpt.com/codex/tasks/task_e_68d1d52f1154832b8a22f0392e1a4f9c