### PR TITLE
fix: polish media tab virtualization

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -5,6 +5,11 @@
 All pull request titles must follow [Conventional Commits](https://www.conventionalcommits.org/) syntax.
 Use prefixes such as `feat:`, `fix:`, or `docs:` to concisely describe the change.
 
+## Mandatory Quality Checks
+
+- Run `npm run lint -- --filter=akari` (and any other impacted scripts) before calling the PR tool.
+- Do not open or submit a PR while lint or test commands are failing—fix the issues first so everything passes locally.
+
 ## TypeScript Type Definitions
 
 **CRITICAL**: Always use `type` instead of `interface` for TypeScript definitions unless absolutely necessary.

--- a/apps/akari/__tests__/components/profile/MediaTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/MediaTab.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react-native';
-import { FlatList } from 'react-native';
 
 import { MediaTab } from '@/components/profile/MediaTab';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
 import { useAuthorMedia } from '@/hooks/queries/useAuthorMedia';
 import { router } from 'expo-router';
 
@@ -18,7 +18,7 @@ const PostCardMock = require('@/components/PostCard').PostCard as jest.Mock;
 const FeedSkeletonMock = require('@/components/skeletons').FeedSkeleton as jest.Mock;
 const mockUseAuthorMedia = useAuthorMedia as jest.Mock;
 
- type MediaItem = {
+type MediaItem = {
   uri?: string;
   indexedAt: string;
   record?: { text?: string };
@@ -55,6 +55,25 @@ describe('MediaTab', () => {
   it('shows empty state when no media is available', () => {
     mockUseAuthorMedia.mockReturnValue({
       data: [],
+      isLoading: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    const { getByText } = render(<MediaTab handle="alice" />);
+    expect(getByText('profile.noMedia')).toBeTruthy();
+  });
+
+  it('shows empty state when filtered media has no valid entries', () => {
+    mockUseAuthorMedia.mockReturnValue({
+      data: [
+        {
+          uri: undefined,
+          indexedAt: '2024-01-01T00:00:00Z',
+          author: { handle: 'user1' },
+        },
+      ],
       isLoading: false,
       fetchNextPage: jest.fn(),
       hasNextPage: false,
@@ -164,7 +183,7 @@ describe('MediaTab', () => {
     });
 
     const { UNSAFE_getByType } = render(<MediaTab handle="alice" />);
-    const list = UNSAFE_getByType(FlatList);
+    const list = UNSAFE_getByType(VirtualizedList);
     list.props.onEndReached();
     expect(fetchNextPage).toHaveBeenCalled();
   });
@@ -186,7 +205,7 @@ describe('MediaTab', () => {
     });
 
     const { UNSAFE_getByType, getByText } = render(<MediaTab handle="alice" />);
-    const list = UNSAFE_getByType(FlatList);
+    const list = UNSAFE_getByType(VirtualizedList);
     list.props.onEndReached();
     expect(fetchNextPage).not.toHaveBeenCalled();
     expect(getByText('common.loading')).toBeTruthy();
@@ -209,7 +228,7 @@ describe('MediaTab', () => {
     });
 
     const { UNSAFE_getByType } = render(<MediaTab handle="alice" />);
-    const list = UNSAFE_getByType(FlatList);
+    const list = UNSAFE_getByType(VirtualizedList);
     list.props.onEndReached();
     expect(fetchNextPage).not.toHaveBeenCalled();
   });

--- a/virtualized-list-migration.md
+++ b/virtualized-list-migration.md
@@ -24,7 +24,7 @@ The FlashList-backed `VirtualizedList` component in `apps/akari/components/ui/Vi
 - [x] `apps/akari/components/profile/PostsTab.tsx`
   - Replace the `FlatList` with `VirtualizedList`, disable scrolling the same way, and provide an `estimatedItemSize` suited to `PostCard` entries.
   - Confirm pagination still triggers via `onEndReached` and that the loading footer stays visible while fetching.
-- [ ] `apps/akari/components/profile/MediaTab.tsx`
+- [x] `apps/akari/components/profile/MediaTab.tsx`
   - Swap to `VirtualizedList` and adjust the filtered media list to provide an `estimatedItemSize`.
   - Keep `scrollEnabled={false}` behaviour and verify reply metadata still renders through the virtualization.
 - [ ] `apps/akari/components/profile/LikesTab.tsx`


### PR DESCRIPTION
## Summary
- memoize MediaTab pagination helpers and filtered data while preserving the virtualized list swap
- render an empty state when filtered media items disappear and reuse the loading footer element
- update the MediaTab test suite to target VirtualizedList directly and document mandatory lint/test checks for contributors

## Testing
- npm run lint -- --filter=akari
- npm run test -- --runTestsByPath __tests__/components/profile/MediaTab.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d1dc6e1758832b9e9b43b4456d6a3d