### PR TITLE
fix: rely on ts helper for jsdoc text

### DIFF
--- a/scripts/generate-docs.cjs
+++ b/scripts/generate-docs.cjs
@@ -99,19 +99,7 @@ const getCommentText = (comment) => {
     return undefined;
   }
 
-  if (typeof comment === 'string') {
-    return comment.trim().replace(/^-\s*/, '');
-  }
-
-  let text = '';
-  for (const part of comment) {
-    if (ts.isJSDocText(part)) {
-      text += part.text;
-    } else {
-      text += part.getText();
-    }
-  }
-
+  const text = typeof comment === 'string' ? comment : ts.getTextOfJSDocComment(comment) ?? '';
   const trimmed = text.trim().replace(/^-\s*/, '');
   return trimmed.length > 0 ? trimmed : undefined;
 };


### PR DESCRIPTION
## Summary
- use TypeScript's built-in `getTextOfJSDocComment` helper to flatten comment nodes without custom guards

## Testing
- npm run generate-docs --prefix apps/docs
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d4880d91cc832bacf1ada7def49343