### PR TITLE
refactor: centralize reusable type aliases

### DIFF
--- a/apps/akari/components/NotificationSettings.tsx
+++ b/apps/akari/components/NotificationSettings.tsx
@@ -10,9 +10,9 @@ import { usePushNotifications } from '@/hooks/usePushNotifications';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
 
-interface NotificationSettingsProps {
+type NotificationSettingsProps = {
   onSettingsChange?: () => void;
-}
+};
 
 export function NotificationSettings({ onSettingsChange }: NotificationSettingsProps) {
   const { t } = useTranslation();

--- a/apps/akari/components/NotificationTest.tsx
+++ b/apps/akari/components/NotificationTest.tsx
@@ -8,9 +8,9 @@ import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
 import { scheduleLocalNotification } from '@/utils/notifications';
 
-interface NotificationTestProps {
+type NotificationTestProps = {
   onNotificationSent?: () => void;
-}
+};
 
 export function NotificationTest({ onNotificationSent }: NotificationTestProps) {
   const { t } = useTranslation();

--- a/apps/akari/components/settings/SettingsHeader.tsx
+++ b/apps/akari/components/settings/SettingsHeader.tsx
@@ -9,9 +9,9 @@ import { IconSymbol } from '@/components/ui/IconSymbol';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
 
-interface SettingsHeaderProps {
+type SettingsHeaderProps = {
   title: string;
-}
+};
 
 export function SettingsHeader({ title }: SettingsHeaderProps) {
   const insets = useSafeAreaInsets();

--- a/apps/akari/components/ui/IconSymbol.ios.tsx
+++ b/apps/akari/components/ui/IconSymbol.ios.tsx
@@ -1,19 +1,21 @@
 import { SymbolView, SymbolViewProps, SymbolWeight } from 'expo-symbols';
 import { StyleProp, ViewStyle } from 'react-native';
 
+type IconSymbolProps = {
+  name: SymbolViewProps['name'];
+  size?: number;
+  color: string;
+  style?: StyleProp<ViewStyle>;
+  weight?: SymbolWeight;
+};
+
 export function IconSymbol({
   name,
   size = 24,
   color,
   style,
   weight = 'regular',
-}: {
-  name: SymbolViewProps['name'];
-  size?: number;
-  color: string;
-  style?: StyleProp<ViewStyle>;
-  weight?: SymbolWeight;
-}) {
+}: IconSymbolProps) {
   return (
     <SymbolView
       weight={weight}

--- a/apps/akari/components/ui/IconSymbol.tsx
+++ b/apps/akari/components/ui/IconSymbol.tsx
@@ -7,6 +7,13 @@ import { OpaqueColorValue, type StyleProp, type TextStyle, View } from 'react-na
 
 type IconMapping = Record<SymbolViewProps['name'], ComponentProps<typeof MaterialIcons>['name']>;
 type IconSymbolName = keyof typeof MAPPING;
+type IconSymbolProps = {
+  name: IconSymbolName;
+  size?: number;
+  color: string | OpaqueColorValue;
+  style?: StyleProp<TextStyle>;
+  weight?: SymbolWeight;
+};
 
 /**
  * Add your SF Symbols to Material Icons mappings here.
@@ -101,13 +108,7 @@ export function IconSymbol({
   size = 24,
   color,
   style,
-}: {
-  name: IconSymbolName;
-  size?: number;
-  color: string | OpaqueColorValue;
-  style?: StyleProp<TextStyle>;
-  weight?: SymbolWeight;
-}) {
+}: IconSymbolProps) {
   return (
     <View style={{ width: size, height: size, alignItems: 'center', justifyContent: 'center' }}>
       <MaterialIcons color={color} size={size} name={MAPPING[name]} style={style} />

--- a/apps/akari/contexts/LanguageContext.tsx
+++ b/apps/akari/contexts/LanguageContext.tsx
@@ -3,11 +3,15 @@ import { getLocales } from "expo-localization";
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { MMKV } from "react-native-mmkv";
 
-interface LanguageContextType {
+type LanguageContextType = {
   currentLocale: string;
   changeLanguage: (locale: string) => void;
   availableLocales: string[];
-}
+};
+
+type LanguageProviderProps = {
+  children: React.ReactNode;
+};
 
 const LanguageContext = createContext<LanguageContextType | undefined>(
   undefined
@@ -19,9 +23,7 @@ const LANGUAGE_KEY = "app_language";
 
 export const LanguageProvider = ({
   children,
-}: {
-  children: React.ReactNode;
-}) => {
+}: LanguageProviderProps) => {
   const [currentLocale, setCurrentLocale] = useState<string>("en");
   const availableLocales = getAvailableLocales();
 

--- a/apps/akari/hooks/mutations/useBlockUser.ts
+++ b/apps/akari/hooks/mutations/useBlockUser.ts
@@ -7,6 +7,15 @@ import { BlueskyApi } from '@/bluesky-api';
 /**
  * Mutation hook for blocking and unblocking users
  */
+type BlockUserParams = {
+  /** The user's DID */
+  did: string;
+  /** The block URI (required for unblock) */
+  blockUri?: string;
+  /** Whether to block or unblock */
+  action: 'block' | 'unblock';
+};
+
 export function useBlockUser() {
   const queryClient = useQueryClient();
   const { data: token } = useJwtToken();
@@ -14,18 +23,7 @@ export function useBlockUser() {
 
   return useMutation({
     mutationKey: ['blockUser'],
-    mutationFn: async ({
-      did,
-      blockUri,
-      action,
-    }: {
-      /** The user's DID */
-      did: string;
-      /** The block URI (required for unblock) */
-      blockUri?: string;
-      /** Whether to block or unblock */
-      action: 'block' | 'unblock';
-    }) => {
+    mutationFn: async ({ did, blockUri, action }: BlockUserParams) => {
       if (!token) throw new Error('No access token');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 

--- a/apps/akari/hooks/mutations/useCreatePost.ts
+++ b/apps/akari/hooks/mutations/useCreatePost.ts
@@ -7,6 +7,22 @@ import { BlueskyApi } from '@/bluesky-api';
 /**
  * Mutation hook for creating posts
  */
+type CreatePostParams = {
+  /** The post text content */
+  text: string;
+  /** Optional reply context */
+  replyTo?: {
+    root: string;
+    parent: string;
+  };
+  /** Optional array of images to attach */
+  images?: {
+    uri: string;
+    alt: string;
+    mimeType: string;
+  }[];
+};
+
 export function useCreatePost() {
   const queryClient = useQueryClient();
   const { data: token } = useJwtToken();
@@ -14,25 +30,7 @@ export function useCreatePost() {
 
   return useMutation({
     mutationKey: ['createPost'],
-    mutationFn: async ({
-      text,
-      replyTo,
-      images,
-    }: {
-      /** The post text content */
-      text: string;
-      /** Optional reply context */
-      replyTo?: {
-        root: string;
-        parent: string;
-      };
-      /** Optional array of images to attach */
-      images?: {
-        uri: string;
-        alt: string;
-        mimeType: string;
-      }[];
-    }) => {
+    mutationFn: async ({ text, replyTo, images }: CreatePostParams) => {
       if (!token) throw new Error('No access token');
       if (!currentAccount?.did) throw new Error('No user DID available');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');

--- a/apps/akari/hooks/mutations/useRefreshSession.ts
+++ b/apps/akari/hooks/mutations/useRefreshSession.ts
@@ -7,18 +7,18 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
  * Mutation hook for refreshing the Bluesky session
  * Used to renew expired access tokens
  */
+type RefreshSessionParams = {
+  /** The refresh JWT token */
+  refreshToken: string;
+};
+
 export function useRefreshSession() {
   const queryClient = useQueryClient();
   const setAuthMutation = useSetAuthentication();
   const { data: currentAccount } = useCurrentAccount();
 
   return useMutation({
-    mutationFn: async ({
-      refreshToken,
-    }: {
-      /** The refresh JWT token */
-      refreshToken: string;
-    }) => {
+    mutationFn: async ({ refreshToken }: RefreshSessionParams) => {
       if (!currentAccount?.pdsUrl) {
         throw new Error('No PDS URL available for this account');
       }

--- a/apps/akari/hooks/mutations/useSendMessage.ts
+++ b/apps/akari/hooks/mutations/useSendMessage.ts
@@ -7,6 +7,13 @@ import { BlueskyApi } from '@/bluesky-api';
 /**
  * Mutation hook for sending messages in conversations
  */
+type SendMessageParams = {
+  /** The conversation ID */
+  convoId: string;
+  /** The message text content */
+  text: string;
+};
+
 export function useSendMessage() {
   const queryClient = useQueryClient();
   const { data: token } = useJwtToken();
@@ -14,15 +21,7 @@ export function useSendMessage() {
 
   return useMutation({
     mutationKey: ['sendMessage'],
-    mutationFn: async ({
-      convoId,
-      text,
-    }: {
-      /** The conversation ID */
-      convoId: string;
-      /** The message text content */
-      text: string;
-    }) => {
+    mutationFn: async ({ convoId, text }: SendMessageParams) => {
       if (!token) throw new Error('No access token');
       if (!currentAccount?.did) throw new Error('No user DID available');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');

--- a/apps/akari/hooks/queries/types.ts
+++ b/apps/akari/hooks/queries/types.ts
@@ -1,0 +1,3 @@
+export type CursorPageParam = {
+  pageParam: string | undefined;
+};

--- a/apps/akari/hooks/queries/useAuthorFeeds.ts
+++ b/apps/akari/hooks/queries/useAuthorFeeds.ts
@@ -2,6 +2,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { CursorPageParam } from '@/hooks/queries/types';
 import { BlueskyApi } from '@/bluesky-api';
 
 /**
@@ -15,7 +16,7 @@ export function useAuthorFeeds(identifier: string | undefined, limit: number = 5
 
   return useInfiniteQuery({
     queryKey: ['authorFeeds', identifier, limit, currentAccount?.pdsUrl],
-    queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
+    queryFn: async ({ pageParam }: CursorPageParam) => {
       if (!token) throw new Error('No access token');
       if (!identifier) throw new Error('No identifier provided');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');

--- a/apps/akari/hooks/queries/useAuthorLikes.ts
+++ b/apps/akari/hooks/queries/useAuthorLikes.ts
@@ -2,6 +2,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { CursorPageParam } from '@/hooks/queries/types';
 import { BlueskyApi } from '@/bluesky-api';
 
 /**
@@ -15,7 +16,7 @@ export function useAuthorLikes(identifier: string | undefined, limit: number = 2
 
   return useInfiniteQuery({
     queryKey: ['authorLikes', identifier, limit, currentAccount?.pdsUrl],
-    queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
+    queryFn: async ({ pageParam }: CursorPageParam) => {
       if (!token) throw new Error('No access token');
       if (!identifier) throw new Error('No identifier provided');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');

--- a/apps/akari/hooks/queries/useAuthorMedia.ts
+++ b/apps/akari/hooks/queries/useAuthorMedia.ts
@@ -2,6 +2,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { CursorPageParam } from '@/hooks/queries/types';
 import { BlueskyApi } from '@/bluesky-api';
 
 /**
@@ -15,7 +16,7 @@ export function useAuthorMedia(identifier: string | undefined, limit: number = 2
 
   return useInfiniteQuery({
     queryKey: ['authorMedia', identifier, limit, currentAccount?.pdsUrl],
-    queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
+    queryFn: async ({ pageParam }: CursorPageParam) => {
       if (!token) throw new Error('No access token');
       if (!identifier) throw new Error('No identifier provided');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');

--- a/apps/akari/hooks/queries/useAuthorPosts.ts
+++ b/apps/akari/hooks/queries/useAuthorPosts.ts
@@ -2,6 +2,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { CursorPageParam } from '@/hooks/queries/types';
 import { BlueskyApi } from '@/bluesky-api';
 
 /**
@@ -15,7 +16,7 @@ export function useAuthorPosts(identifier: string | undefined, limit: number = 2
 
   return useInfiniteQuery({
     queryKey: ['authorPosts', identifier, limit, currentAccount?.pdsUrl],
-    queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
+    queryFn: async ({ pageParam }: CursorPageParam) => {
       if (!token) throw new Error('No access token');
       if (!identifier) throw new Error('No identifier provided');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');

--- a/apps/akari/hooks/queries/useAuthorReplies.ts
+++ b/apps/akari/hooks/queries/useAuthorReplies.ts
@@ -2,6 +2,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { CursorPageParam } from '@/hooks/queries/types';
 import { BlueskyApi } from '@/bluesky-api';
 
 /**
@@ -15,7 +16,7 @@ export function useAuthorReplies(identifier: string | undefined, limit: number =
 
   return useInfiniteQuery({
     queryKey: ['authorReplies', identifier, limit, currentAccount?.pdsUrl],
-    queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
+    queryFn: async ({ pageParam }: CursorPageParam) => {
       if (!token) throw new Error('No access token');
       if (!identifier) throw new Error('No identifier provided');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');

--- a/apps/akari/hooks/queries/useAuthorStarterpacks.ts
+++ b/apps/akari/hooks/queries/useAuthorStarterpacks.ts
@@ -2,6 +2,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { CursorPageParam } from '@/hooks/queries/types';
 import { BlueskyApi } from '@/bluesky-api';
 
 /**
@@ -15,7 +16,7 @@ export function useAuthorStarterpacks(identifier: string | undefined, limit: num
 
   return useInfiniteQuery({
     queryKey: ['authorStarterpacks', identifier, limit, currentAccount?.pdsUrl],
-    queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
+    queryFn: async ({ pageParam }: CursorPageParam) => {
       if (!token) throw new Error('No access token');
       if (!identifier) throw new Error('No identifier provided');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');

--- a/apps/akari/hooks/queries/useAuthorVideos.ts
+++ b/apps/akari/hooks/queries/useAuthorVideos.ts
@@ -2,6 +2,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { CursorPageParam } from '@/hooks/queries/types';
 import { BlueskyApi } from '@/bluesky-api';
 
 /**
@@ -15,7 +16,7 @@ export function useAuthorVideos(identifier: string | undefined, limit: number = 
 
   return useInfiniteQuery({
     queryKey: ['authorVideos', identifier, limit, currentAccount?.pdsUrl],
-    queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
+    queryFn: async ({ pageParam }: CursorPageParam) => {
       if (!token) throw new Error('No access token');
       if (!identifier) throw new Error('No identifier provided');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');

--- a/apps/akari/hooks/queries/useBookmarks.ts
+++ b/apps/akari/hooks/queries/useBookmarks.ts
@@ -4,6 +4,7 @@ import { BlueskyApi } from '@/bluesky-api';
 import type { BlueskyBookmarksResponse } from '@/bluesky-api';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { CursorPageParam } from '@/hooks/queries/types';
 
 /**
  * Infinite query hook for fetching the authenticated user's bookmarks
@@ -15,7 +16,7 @@ export function useBookmarks(limit: number = 20) {
 
   return useInfiniteQuery<BlueskyBookmarksResponse>({
     queryKey: ['bookmarks', limit, currentAccount?.did],
-    queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
+    queryFn: async ({ pageParam }: CursorPageParam) => {
       if (!token) throw new Error('No access token');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 

--- a/apps/akari/hooks/queries/useFeed.ts
+++ b/apps/akari/hooks/queries/useFeed.ts
@@ -2,6 +2,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { CursorPageParam } from '@/hooks/queries/types';
 import { BlueskyApi } from '@/bluesky-api';
 
 /**
@@ -15,7 +16,7 @@ export function useFeed(feedUri: string | null, limit: number = 20) {
 
   return useInfiniteQuery({
     queryKey: ['feed', feedUri, currentAccount?.pdsUrl],
-    queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
+    queryFn: async ({ pageParam }: CursorPageParam) => {
       if (!token) throw new Error('No access token');
       if (!feedUri) throw new Error('No feed URI provided');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');

--- a/apps/akari/hooks/queries/useSearch.ts
+++ b/apps/akari/hooks/queries/useSearch.ts
@@ -1,5 +1,6 @@
 import { useJwtToken } from "@/hooks/queries/useJwtToken";
 import { useCurrentAccount } from "@/hooks/queries/useCurrentAccount";
+import { CursorPageParam } from "@/hooks/queries/types";
 import { BlueskyPostView, BlueskyProfile } from "@/utils/bluesky/types";
 import { BlueskyApi } from "@/bluesky-api";
 import { useInfiniteQuery } from "@tanstack/react-query";
@@ -33,7 +34,7 @@ export function useSearch(
 
   return useInfiniteQuery({
     queryKey: ["search", query, activeTab, limit, currentAccount?.pdsUrl],
-    queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
+    queryFn: async ({ pageParam }: CursorPageParam) => {
       if (!token) throw new Error("No access token");
       if (!query) throw new Error("No query provided");
       if (!currentAccount?.pdsUrl) throw new Error("No PDS URL available");

--- a/apps/akari/hooks/usePushNotifications.ts
+++ b/apps/akari/hooks/usePushNotifications.ts
@@ -10,13 +10,13 @@ import {
   requestNotificationPermissions,
 } from '@/utils/notifications';
 
-export interface PushNotificationState {
+export type PushNotificationState = {
   expoPushToken: string | null;
   devicePushToken: string | null;
   permissionStatus: Notifications.PermissionStatus | null;
   isLoading: boolean;
   error: string | null;
-}
+};
 
 export function usePushNotifications() {
   const router = useRouter();

--- a/apps/akari/utils/notifications.ts
+++ b/apps/akari/utils/notifications.ts
@@ -13,12 +13,12 @@ Notifications.setNotificationHandler({
   }),
 });
 
-export interface PushNotificationToken {
+export type PushNotificationToken = {
   expoPushToken: string;
   devicePushToken?: string;
-}
+};
 
-export interface NotificationChannel {
+export type NotificationChannel = {
   id: string;
   name: string;
   description?: string;
@@ -26,7 +26,7 @@ export interface NotificationChannel {
   sound?: string;
   vibrationPattern?: number[];
   lightColor?: string;
-}
+};
 
 /**
  * Request notification permissions and return the status

--- a/apps/akari/utils/translationLogger.ts
+++ b/apps/akari/utils/translationLogger.ts
@@ -1,9 +1,9 @@
-interface TranslationLog {
+type TranslationLog = {
   key: string;
   locale: string;
   timestamp: number;
   stack?: string;
-}
+};
 
 class TranslationLogger {
   private missingTranslations: TranslationLog[] = [];


### PR DESCRIPTION
## Summary
- replace interface-based props and models in notification components, context, and utilities with type aliases
- add shared CursorPageParam and mutation parameter types to eliminate inline object signatures in hooks

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d7aade1be0832ba57c1a529ca61ba4