### PR TITLE
fix: persist react query cache across sessions

### DIFF
--- a/apps/akari/__tests__/app/root-layout.test.tsx
+++ b/apps/akari/__tests__/app/root-layout.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react-native';
+import { render, waitFor } from '@testing-library/react-native';
 import React from 'react';
 import RootLayout from '@/app/_layout';
 import { ThemeProvider, DarkTheme, DefaultTheme } from '@react-navigation/native';
@@ -71,36 +71,44 @@ describe('RootLayout', () => {
     expect(toJSON()).toBeNull();
   });
 
-  it('renders stack screens without devtools on native platforms', () => {
+  it('renders stack screens without devtools on native platforms', async () => {
     mockUseFonts.mockReturnValue([true]);
     const { queryByText } = render(<RootLayout />);
+
+    await waitFor(() => {
+      expect(mockThemeProvider).toHaveBeenCalled();
+    });
+
     expect(queryByText('Devtools')).toBeNull();
     const { Stack } = require('expo-router');
-    expect(Stack.Screen).toHaveBeenCalledTimes(4);
+    await waitFor(() => {
+      expect(Stack.Screen).toHaveBeenCalledTimes(4);
+    });
     const names: string[] = [];
     for (const call of Stack.Screen.mock.calls) {
       names.push(call[0].name);
     }
     expect(names).toEqual(['(auth)', '(tabs)', 'debug', '+not-found']);
-    expect(mockThemeProvider).toHaveBeenCalled();
     const themeProps = mockThemeProvider.mock.calls[0][0];
     expect(themeProps.value).toBe(DefaultTheme);
   });
 
-  it('renders devtools on web', () => {
+  it('renders devtools on web', async () => {
     mockUseFonts.mockReturnValue([true]);
     setPlatform('web');
-    const { getByText } = render(<RootLayout />);
-    expect(getByText('Devtools')).toBeTruthy();
+    const { findByText } = render(<RootLayout />);
+    expect(await findByText('Devtools')).toBeTruthy();
   });
 
-  it('uses the dark theme when the color scheme is dark', () => {
+  it('uses the dark theme when the color scheme is dark', async () => {
     mockUseFonts.mockReturnValue([true]);
     mockUseColorScheme.mockReturnValue('dark');
 
     render(<RootLayout />);
 
-    expect(mockThemeProvider).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockThemeProvider).toHaveBeenCalled();
+    });
     const themeProps = mockThemeProvider.mock.calls[0][0];
     expect(themeProps.value).toBe(DarkTheme);
   });

--- a/apps/akari/app/_layout.tsx
+++ b/apps/akari/app/_layout.tsx
@@ -1,7 +1,12 @@
 import '@/utils/intl-polyfills'; // Initialize Intl polyfills
 
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, useIsRestoring } from '@tanstack/react-query';
+import {
+  PersistQueryClientProvider,
+  type PersistQueryClientProviderProps,
+  type Persister,
+} from '@tanstack/react-query-persist-client';
 import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
@@ -14,11 +19,85 @@ import { ToastProvider } from '@/contexts/ToastContext';
 import { LanguageProvider } from '@/contexts/LanguageContext';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { setupBackgroundUpdates } from '@/utils/backgroundUpdates';
+import { REACT_QUERY_CACHE_STORAGE_KEY, storage } from '@/utils/secureStorage';
 import '@/utils/i18n';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Platform } from 'react-native';
+import type { Query } from '@tanstack/query-core';
 
-const queryClient = new QueryClient();
+const REACT_QUERY_CACHE_MAX_AGE = 1000 * 60 * 60 * 24; // 24 hours
+const REACT_QUERY_CACHE_BUSTER = 'akari@1';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      gcTime: REACT_QUERY_CACHE_MAX_AGE,
+    },
+  },
+});
+
+const queryCachePersister: Persister = {
+  persistClient: async (client) => {
+    try {
+      storage.setItem(REACT_QUERY_CACHE_STORAGE_KEY, client);
+    } catch (error) {
+      console.error('Failed to persist React Query cache', error);
+    }
+  },
+  restoreClient: async () => {
+    try {
+      const cache = storage.getItem(REACT_QUERY_CACHE_STORAGE_KEY);
+      return cache ?? undefined;
+    } catch (error) {
+      console.error('Failed to restore React Query cache', error);
+      storage.removeItem(REACT_QUERY_CACHE_STORAGE_KEY);
+      return undefined;
+    }
+  },
+  removeClient: async () => {
+    storage.removeItem(REACT_QUERY_CACHE_STORAGE_KEY);
+  },
+};
+
+const persistOptions = {
+  persister: queryCachePersister,
+  maxAge: REACT_QUERY_CACHE_MAX_AGE,
+  buster: REACT_QUERY_CACHE_BUSTER,
+  dehydrateOptions: {
+    shouldDehydrateMutation: () => false,
+    shouldDehydrateQuery: (query: Query) => query.meta?.persist !== false,
+  },
+} satisfies PersistQueryClientProviderProps['persistOptions'];
+
+type ProvidersProps = {
+  colorScheme: ReturnType<typeof useColorScheme>;
+};
+
+function AppProviders({ colorScheme }: ProvidersProps) {
+  const isRestoring = useIsRestoring();
+
+  if (isRestoring) {
+    return null;
+  }
+
+  return (
+    <LanguageProvider>
+      <ToastProvider>
+        <DialogProvider>
+          <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+            <Stack>
+              <Stack.Screen name="(auth)" options={{ headerShown: false }} />
+              <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+              <Stack.Screen name="debug" options={{ headerShown: false }} />
+              <Stack.Screen name="+not-found" />
+            </Stack>
+            <StatusBar style="auto" />
+          </ThemeProvider>
+        </DialogProvider>
+      </ToastProvider>
+    </LanguageProvider>
+  );
+}
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
@@ -39,26 +118,12 @@ export default function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <QueryClientProvider client={queryClient}>
-        <LanguageProvider>
-          <ToastProvider>
-            <DialogProvider>
-              <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-                <Stack>
-                  <Stack.Screen name="(auth)" options={{ headerShown: false }} />
-                  <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-                  <Stack.Screen name="debug" options={{ headerShown: false }} />
-                  <Stack.Screen name="+not-found" />
-                </Stack>
-                <StatusBar style="auto" />
-              </ThemeProvider>
-            </DialogProvider>
-          </ToastProvider>
-        </LanguageProvider>
+      <PersistQueryClientProvider client={queryClient} persistOptions={persistOptions}>
+        <AppProviders colorScheme={colorScheme} />
         {Platform.OS === 'web' ? (
           <ReactQueryDevtools initialIsOpen={false} position="left" buttonPosition="bottom-left" />
         ) : null}
-      </QueryClientProvider>
+      </PersistQueryClientProvider>
     </GestureHandlerRootView>
   );
 }

--- a/apps/akari/utils/secureStorage.ts
+++ b/apps/akari/utils/secureStorage.ts
@@ -1,3 +1,4 @@
+import type { PersistedClient } from '@tanstack/react-query-persist-client';
 import { Account } from '@/types/account';
 import { Platform } from 'react-native';
 import { MMKV } from 'react-native-mmkv';
@@ -17,7 +18,10 @@ type Data = {
   jwtToken: string;
   refreshToken: string;
   selectedFeed: string;
+  reactQueryCache: PersistedClient;
 };
+
+export const REACT_QUERY_CACHE_STORAGE_KEY: keyof Data = 'reactQueryCache';
 
 export const storage = {
   getItem: <K extends keyof Data>(key: K): Data[K] | null => {


### PR DESCRIPTION
## Summary
- set up a persisted React Query client that rehydrates cached data before refetching
- store the dehydrated query cache in secure MMKV storage for reuse across launches

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d3f32998d0832bb4279e7cc6479949