### PR TITLE
ci: annotate test failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,4 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npx playwright install --with-deps chromium
-      - run: npm run test:e2e
+      - run: npm run test:e2e -- --reporter=github

--- a/apps/akari/jest.config.js
+++ b/apps/akari/jest.config.js
@@ -1,3 +1,5 @@
+const isGithubActions = Boolean(process.env.GITHUB_ACTIONS);
+
 module.exports = {
   preset: 'jest-expo',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
@@ -23,4 +25,5 @@ module.exports = {
     '^@/libretranslate-api$': '<rootDir>/../../packages/libretranslate-api/src',
     '^@/tenor-api$': '<rootDir>/../../packages/tenor-api/src',
   },
+  ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
 };

--- a/packages/bluesky-api/jest.config.cjs
+++ b/packages/bluesky-api/jest.config.cjs
@@ -11,6 +11,8 @@ const jestTsconfig = {
   ],
 };
 
+const isGithubActions = Boolean(process.env.GITHUB_ACTIONS);
+
 /** @type {import('jest').Config} */
 module.exports = {
   preset: 'ts-jest/presets/default-esm',
@@ -31,4 +33,5 @@ module.exports = {
       tsconfig: jestTsconfig,
     },
   },
+  ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
 };

--- a/packages/clearsky-api/jest.config.cjs
+++ b/packages/clearsky-api/jest.config.cjs
@@ -1,4 +1,6 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
+const isGithubActions = Boolean(process.env.GITHUB_ACTIONS);
+
 module.exports = {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
@@ -16,4 +18,5 @@ module.exports = {
       tsconfig: '<rootDir>/tsconfig.json',
     },
   },
+  ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
 };

--- a/packages/libretranslate-api/jest.config.cjs
+++ b/packages/libretranslate-api/jest.config.cjs
@@ -1,3 +1,5 @@
+const isGithubActions = Boolean(process.env.GITHUB_ACTIONS);
+
 module.exports = {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
@@ -12,4 +14,5 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!**/*.d.ts'],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'html'],
+  ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
 };

--- a/packages/tenor-api/jest.config.cjs
+++ b/packages/tenor-api/jest.config.cjs
@@ -1,3 +1,5 @@
+const isGithubActions = Boolean(process.env.GITHUB_ACTIONS);
+
 module.exports = {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
@@ -12,4 +14,5 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!**/*.d.ts'],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'html'],
+  ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
 };


### PR DESCRIPTION
## Summary
- enable the built-in GitHub Actions reporter across Jest projects when running under CI
- run Playwright end-to-end tests with the GitHub reporter so failures create workflow annotations

## Testing
- npm run lint -- --filter=akari
- npm run test -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d7ae8ae580832b8adc3e7f541b2b56