### PR TITLE
fix: reuse coverage comment in CI

### DIFF
--- a/.github/actions/report-coverage/action.yml
+++ b/.github/actions/report-coverage/action.yml
@@ -19,10 +19,6 @@ inputs:
     description: 'Path to upload as the coverage artifact'
     required: false
     default: ''
-  html-preview-file:
-    description: 'Path to an HTML file to expose via the comment preview link'
-    required: false
-    default: ''
 runs:
   using: 'composite'
   steps:
@@ -40,9 +36,7 @@ runs:
         COVERAGE_SUMMARY_PATH: ${{ inputs.coverage-summary }}
         LCOV_PATH: ${{ inputs.lcov-path }}
         ARTIFACT_NAME: ${{ inputs.artifact-name }}
-        HTML_PREVIEW_FILE: ${{ inputs.html-preview-file }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
-        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_API_URL: ${{ github.api_url }}
       run: node "$GITHUB_ACTION_PATH/report-coverage.mjs"

--- a/.github/actions/report-coverage/action.yml
+++ b/.github/actions/report-coverage/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: 'Path to the coverage summary JSON file'
     required: false
     default: ''
+  coverage-json:
+    description: 'Path to the Istanbul coverage-final.json file'
+    required: false
+    default: ''
   lcov-path:
     description: 'Path to the merged LCOV report file'
     required: true
@@ -35,6 +39,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         COVERAGE_SUMMARY_PATH: ${{ inputs.coverage-summary }}
         LCOV_PATH: ${{ inputs.lcov-path }}
+        COVERAGE_JSON_PATH: ${{ inputs.coverage-json }}
         ARTIFACT_NAME: ${{ inputs.artifact-name }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/actions/report-coverage/action.yml
+++ b/.github/actions/report-coverage/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'Path to upload as the coverage artifact'
     required: false
     default: ''
+  html-preview-file:
+    description: 'Path to an HTML file to expose via the comment preview link'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -36,6 +40,7 @@ runs:
         COVERAGE_SUMMARY_PATH: ${{ inputs.coverage-summary }}
         LCOV_PATH: ${{ inputs.lcov-path }}
         ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        HTML_PREVIEW_FILE: ${{ inputs.html-preview-file }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_API_URL: ${{ github.api_url }}

--- a/.github/actions/report-coverage/action.yml
+++ b/.github/actions/report-coverage/action.yml
@@ -42,6 +42,7 @@ runs:
         ARTIFACT_NAME: ${{ inputs.artifact-name }}
         HTML_PREVIEW_FILE: ${{ inputs.html-preview-file }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_API_URL: ${{ github.api_url }}
       run: node "$GITHUB_ACTION_PATH/report-coverage.mjs"

--- a/.github/actions/report-coverage/action.yml
+++ b/.github/actions/report-coverage/action.yml
@@ -1,0 +1,42 @@
+name: 'Report coverage'
+description: 'Uploads coverage artifacts and updates the pull request coverage comment'
+inputs:
+  github-token:
+    description: 'GitHub token for API access'
+    required: true
+  coverage-summary:
+    description: 'Path to the coverage summary JSON file'
+    required: false
+    default: ''
+  lcov-path:
+    description: 'Path to the merged LCOV report file'
+    required: true
+  artifact-name:
+    description: 'Name for the uploaded coverage artifact'
+    required: false
+    default: ''
+  artifact-path:
+    description: 'Path to upload as the coverage artifact'
+    required: false
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - name: Upload coverage artifact
+      if: ${{ inputs.artifact-path != '' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name != '' && inputs.artifact-name || 'coverage-report' }}
+        path: ${{ inputs.artifact-path }}
+        if-no-files-found: warn
+    - name: Update coverage comment
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        COVERAGE_SUMMARY_PATH: ${{ inputs.coverage-summary }}
+        LCOV_PATH: ${{ inputs.lcov-path }}
+        ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_API_URL: ${{ github.api_url }}
+      run: node "$GITHUB_ACTION_PATH/report-coverage.mjs"

--- a/.github/actions/report-coverage/report-coverage.mjs
+++ b/.github/actions/report-coverage/report-coverage.mjs
@@ -357,7 +357,7 @@ function formatUncoveredLines(uncovered) {
   );
 
   if (sorted.length === 0) {
-    return '—';
+    return '';
   }
 
   const maxVisible = 20;

--- a/.github/actions/report-coverage/report-coverage.mjs
+++ b/.github/actions/report-coverage/report-coverage.mjs
@@ -92,7 +92,7 @@ if (Array.isArray(files) && files.length > 0) {
 
     if (directory !== currentDirectory) {
       currentDirectory = directory;
-      fileRows.push(`| **${escapeTableCell(directoryLabel)}** | — | — | — | — |`);
+      fileRows.push(`| **${escapeTableCell(directoryLabel)}** |  |  |  |  |`);
     }
 
     const cells = perFileMetrics

--- a/.github/actions/report-coverage/report-coverage.mjs
+++ b/.github/actions/report-coverage/report-coverage.mjs
@@ -27,7 +27,7 @@ if (!prNumber) {
 
 const [owner, repo] = repository.split('/');
 
-const totals = await loadCoverageTotals();
+const { totals, files } = await loadCoverage();
 
 const metrics = [
   { key: 'lines', label: 'Lines' },
@@ -66,15 +66,55 @@ if (artifactName) {
   body += `\n\nThe full HTML coverage report is available in the **${artifactName}** workflow artifact.`;
 }
 
+if (Array.isArray(files) && files.length > 0) {
+  const fileRows = [];
+
+  const sortedFiles = [...files].sort((a, b) => a.path.localeCompare(b.path));
+
+  for (const file of sortedFiles) {
+    const cells = metrics
+      .map((metric) => formatCoverageCell(file[metric.key]))
+      .join(' | ');
+    fileRows.push(`| ${escapeTableCell(file.path)} | ${cells} |`);
+  }
+
+  if (fileRows.length > 0) {
+    const fileTable = [
+      '| File | Lines | Statements | Branches | Functions |',
+      '| ---- | ----- | ---------- | -------- | --------- |',
+      ...fileRows,
+    ].join('\n');
+
+    body += `\n\n<details>\n<summary>Per-file coverage</summary>\n\n${fileTable}\n</details>`;
+  }
+}
+
 await upsertComment(body);
 
-async function loadCoverageTotals() {
+async function loadCoverage() {
   if (summaryPath) {
     try {
       const summaryContent = await readFile(summaryPath, 'utf8');
       const summaryJson = JSON.parse(summaryContent);
-      if (summaryJson?.total && typeof summaryJson.total === 'object') {
-        return normalizeTotals(summaryJson.total);
+      if (summaryJson && typeof summaryJson === 'object') {
+        const totals = summaryJson?.total && typeof summaryJson.total === 'object' ? normalizeTotals(summaryJson.total) : {};
+        const files = [];
+
+        for (const [filePath, data] of Object.entries(summaryJson)) {
+          if (filePath === 'total' || !data || typeof data !== 'object') {
+            continue;
+          }
+
+          const normalized = normalizeTotals(data);
+
+          if (Object.keys(normalized).length > 0) {
+            files.push({ path: filePath, ...normalized });
+          }
+        }
+
+        if (Object.keys(totals).length > 0) {
+          return { totals, files };
+        }
       }
     } catch (error) {
       console.warn(`Failed to read coverage summary at ${summaryPath}: ${error instanceof Error ? error.message : String(error)}`);
@@ -82,7 +122,7 @@ async function loadCoverageTotals() {
   }
 
   const lcovContent = await readFile(lcovPath, 'utf8');
-  return deriveTotalsFromLcov(lcovContent);
+  return deriveCoverageFromLcov(lcovContent);
 }
 
 function normalizeTotals(total) {
@@ -92,66 +132,100 @@ function normalizeTotals(total) {
       continue;
     }
     const { pct, covered, total: totalCount } = data;
+    const coveredNumber = typeof covered === 'number' ? covered : Number(covered);
+    const totalNumber = typeof totalCount === 'number' ? totalCount : Number(totalCount);
+    const percentNumber = typeof pct === 'number' ? pct : Number(pct);
     normalized[key] = {
-      pct: typeof pct === 'number' ? pct : Number(pct),
-      covered: typeof covered === 'number' ? covered : Number(covered),
-      total: typeof totalCount === 'number' ? totalCount : Number(totalCount),
+      pct: Number.isFinite(percentNumber) ? percentNumber : computePercent(coveredNumber, totalNumber),
+      covered: Number.isFinite(coveredNumber) ? coveredNumber : 0,
+      total: Number.isFinite(totalNumber) ? totalNumber : 0,
     };
   }
   return normalized;
 }
 
-function deriveTotalsFromLcov(lcov) {
-  const totals = {
-    lines: { covered: 0, total: 0 },
-    statements: { covered: 0, total: 0 },
-    branches: { covered: 0, total: 0 },
-    functions: { covered: 0, total: 0 },
-  };
+function deriveCoverageFromLcov(lcov) {
+  const totals = createEmptyCoverageMetrics();
+  const files = [];
+  let currentFile = null;
 
   const lines = lcov.split(/\r?\n/);
 
   for (const line of lines) {
-    if (line.startsWith('LH:')) {
+    if (line.startsWith('SF:')) {
+      if (currentFile) {
+        finalizeCoverageMetrics(currentFile);
+        files.push(currentFile);
+      }
+      const filePath = line.slice(3).trim();
+      currentFile = { path: filePath, ...createEmptyCoverageMetrics() };
+    } else if (line.startsWith('LH:')) {
       const value = Number.parseInt(line.slice(3), 10);
       if (!Number.isNaN(value)) {
         totals.lines.covered += value;
         totals.statements.covered += value;
+        if (currentFile) {
+          currentFile.lines.covered += value;
+          currentFile.statements.covered += value;
+        }
       }
     } else if (line.startsWith('LF:')) {
       const value = Number.parseInt(line.slice(3), 10);
       if (!Number.isNaN(value)) {
         totals.lines.total += value;
         totals.statements.total += value;
+        if (currentFile) {
+          currentFile.lines.total += value;
+          currentFile.statements.total += value;
+        }
       }
     } else if (line.startsWith('BRH:')) {
       const value = Number.parseInt(line.slice(4), 10);
       if (!Number.isNaN(value)) {
         totals.branches.covered += value;
+        if (currentFile) {
+          currentFile.branches.covered += value;
+        }
       }
     } else if (line.startsWith('BRF:')) {
       const value = Number.parseInt(line.slice(4), 10);
       if (!Number.isNaN(value)) {
         totals.branches.total += value;
+        if (currentFile) {
+          currentFile.branches.total += value;
+        }
       }
     } else if (line.startsWith('FNH:')) {
       const value = Number.parseInt(line.slice(4), 10);
       if (!Number.isNaN(value)) {
         totals.functions.covered += value;
+        if (currentFile) {
+          currentFile.functions.covered += value;
+        }
       }
     } else if (line.startsWith('FNF:')) {
       const value = Number.parseInt(line.slice(4), 10);
       if (!Number.isNaN(value)) {
         totals.functions.total += value;
+        if (currentFile) {
+          currentFile.functions.total += value;
+        }
       }
+    } else if (line === 'end_of_record' && currentFile) {
+      finalizeCoverageMetrics(currentFile);
+      files.push(currentFile);
+      currentFile = null;
     }
   }
 
-  for (const data of Object.values(totals)) {
-    data.pct = computePercent(data.covered, data.total);
+  if (currentFile) {
+    finalizeCoverageMetrics(currentFile);
+    files.push(currentFile);
   }
 
-  return totals;
+  finalizeCoverageMetrics(totals);
+
+  return { totals, files };
 }
 
 function computePercent(covered, total) {
@@ -173,6 +247,47 @@ function formatPercent(value) {
     return '—';
   }
   return `${value.toFixed(2)}%`;
+}
+
+function formatCoverageCell(data) {
+  if (!data || typeof data !== 'object') {
+    return '—';
+  }
+
+  const coveredText = formatNumber(data.covered);
+  const totalText = formatNumber(data.total);
+  const percentText = formatPercent(data.pct);
+
+  if (coveredText === '—' && totalText === '—') {
+    return percentText;
+  }
+
+  return `${coveredText}/${totalText} (${percentText})`;
+}
+
+function escapeTableCell(text) {
+  if (typeof text !== 'string') {
+    return formatNumber(text);
+  }
+  return text.replace(/\|/g, '\\|');
+}
+
+function createEmptyCoverageMetrics() {
+  return {
+    lines: { covered: 0, total: 0, pct: 0 },
+    statements: { covered: 0, total: 0, pct: 0 },
+    branches: { covered: 0, total: 0, pct: 0 },
+    functions: { covered: 0, total: 0, pct: 0 },
+  };
+}
+
+function finalizeCoverageMetrics(metrics) {
+  for (const [key, data] of Object.entries(metrics)) {
+    if (!data || typeof data !== 'object' || key === 'path') {
+      continue;
+    }
+    data.pct = computePercent(data.covered, data.total);
+  }
 }
 
 async function upsertComment(bodyContent) {

--- a/.github/actions/report-coverage/report-coverage.mjs
+++ b/.github/actions/report-coverage/report-coverage.mjs
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, access, appendFile } from 'node:fs/promises';
 
 const workspaceRoot = process.cwd().replace(/\\/g, '/');
 
@@ -7,9 +7,11 @@ const token = process.env.GITHUB_TOKEN;
 const summaryPath = process.env.COVERAGE_SUMMARY_PATH;
 const lcovPath = process.env.LCOV_PATH;
 const artifactName = process.env.ARTIFACT_NAME;
+const previewFile = process.env.HTML_PREVIEW_FILE;
 const prNumber = process.env.PR_NUMBER;
 const repository = process.env.GITHUB_REPOSITORY;
 const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
+const commitSha = process.env.GITHUB_SHA;
 
 if (!token) {
   throw new Error('GITHUB_TOKEN is required.');
@@ -30,6 +32,7 @@ if (!prNumber) {
 const [owner, repo] = repository.split('/');
 
 const { totals, files } = await loadCoverage();
+const previewLink = await createPreviewLink(previewFile);
 
 const summaryMetrics = [
   { key: 'lines', label: 'Lines' },
@@ -70,8 +73,19 @@ const table = [
 
 let body = `${marker}\n### Coverage Report\n\n${table}`;
 
+const resourceLines = [];
+
 if (artifactName) {
-  body += `\n\nThe full HTML coverage report is available in the **${artifactName}** workflow artifact.`;
+  resourceLines.push(`- Download the **${artifactName}** workflow artifact for the complete HTML report.`);
+}
+
+if (previewLink) {
+  resourceLines.push(`- [Open the HTML coverage preview ↗︎](${previewLink.url})`);
+  await writePreviewSummary(previewLink);
+}
+
+if (resourceLines.length > 0) {
+  body += `\n\n${resourceLines.join('\n')}`;
 }
 
 if (Array.isArray(files) && files.length > 0) {
@@ -171,6 +185,66 @@ async function loadCoverage() {
   }
 
   return lcovCoverage;
+}
+
+async function createPreviewLink(filePath) {
+  if (typeof filePath !== 'string') {
+    return null;
+  }
+
+  const trimmed = filePath.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    await access(trimmed);
+  } catch {
+    console.warn(`Preview file ${trimmed} was not found. Skipping preview link.`);
+    return null;
+  }
+
+  if (!commitSha) {
+    console.warn('GITHUB_SHA is not available. Skipping preview link.');
+    return null;
+  }
+
+  const normalized = normalizeFilePath(trimmed);
+  if (!normalized) {
+    return null;
+  }
+
+  const encodedPath = normalized
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+
+  return {
+    url: `https://htmlpreview.github.io/?https://github.com/${owner}/${repo}/blob/${commitSha}/${encodedPath}`,
+    path: normalized,
+  };
+}
+
+async function writePreviewSummary(previewLink) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) {
+    return;
+  }
+
+  const lines = [
+    '### Coverage HTML Preview',
+    '',
+    `Using HTML file: ${previewLink.path}`,
+    '',
+    `[Click here to preview the HTML page in your browser](${previewLink.url})`,
+    '',
+  ];
+
+  try {
+    await appendFile(summaryPath, `${lines.join('\n')}\n`);
+  } catch (error) {
+    console.warn(`Failed to write preview summary: ${error instanceof Error ? error.message : String(error)}`);
+  }
 }
 
 function normalizeTotals(total) {

--- a/.github/actions/report-coverage/report-coverage.mjs
+++ b/.github/actions/report-coverage/report-coverage.mjs
@@ -423,7 +423,7 @@ function finalizeCoverageMetrics(metrics) {
 
 function formatUncoveredLines(uncovered) {
   if (!Array.isArray(uncovered) || uncovered.length === 0) {
-    return '—';
+    return '';
   }
 
   const sorted = [...new Set(uncovered.filter((value) => typeof value === 'number' && Number.isFinite(value)))].sort(

--- a/.github/actions/report-coverage/report-coverage.mjs
+++ b/.github/actions/report-coverage/report-coverage.mjs
@@ -1,0 +1,242 @@
+import { readFile } from 'node:fs/promises';
+
+const marker = '<!-- coverage-report -->';
+const token = process.env.GITHUB_TOKEN;
+const summaryPath = process.env.COVERAGE_SUMMARY_PATH;
+const lcovPath = process.env.LCOV_PATH;
+const artifactName = process.env.ARTIFACT_NAME;
+const prNumber = process.env.PR_NUMBER;
+const repository = process.env.GITHUB_REPOSITORY;
+const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
+
+if (!token) {
+  throw new Error('GITHUB_TOKEN is required.');
+}
+
+if (!lcovPath) {
+  throw new Error('LCOV_PATH is required.');
+}
+
+if (!repository) {
+  throw new Error('GITHUB_REPOSITORY is required.');
+}
+
+if (!prNumber) {
+  throw new Error('PR_NUMBER is required when reporting coverage.');
+}
+
+const [owner, repo] = repository.split('/');
+
+const totals = await loadCoverageTotals();
+
+const metrics = [
+  { key: 'lines', label: 'Lines' },
+  { key: 'statements', label: 'Statements' },
+  { key: 'branches', label: 'Branches' },
+  { key: 'functions', label: 'Functions' },
+];
+
+const rows = [];
+
+for (const metric of metrics) {
+  const data = totals[metric.key];
+  if (!data) {
+    continue;
+  }
+
+  const covered = formatNumber(data.covered);
+  const totalCount = formatNumber(data.total);
+  const pct = formatPercent(data.pct);
+  rows.push(`| ${metric.label} | ${covered} | ${totalCount} | ${pct} |`);
+}
+
+if (rows.length === 0) {
+  throw new Error('Coverage summary did not include any totals to report.');
+}
+
+const table = [
+  '| Metric | Covered | Total | % |',
+  '| ------ | ------- | ----- | - |',
+  ...rows,
+].join('\n');
+
+let body = `${marker}\n### Coverage Report\n\n${table}`;
+
+if (artifactName) {
+  body += `\n\nThe full HTML coverage report is available in the **${artifactName}** workflow artifact.`;
+}
+
+await upsertComment(body);
+
+async function loadCoverageTotals() {
+  if (summaryPath) {
+    try {
+      const summaryContent = await readFile(summaryPath, 'utf8');
+      const summaryJson = JSON.parse(summaryContent);
+      if (summaryJson?.total && typeof summaryJson.total === 'object') {
+        return normalizeTotals(summaryJson.total);
+      }
+    } catch (error) {
+      console.warn(`Failed to read coverage summary at ${summaryPath}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  const lcovContent = await readFile(lcovPath, 'utf8');
+  return deriveTotalsFromLcov(lcovContent);
+}
+
+function normalizeTotals(total) {
+  const normalized = {};
+  for (const [key, data] of Object.entries(total)) {
+    if (!data) {
+      continue;
+    }
+    const { pct, covered, total: totalCount } = data;
+    normalized[key] = {
+      pct: typeof pct === 'number' ? pct : Number(pct),
+      covered: typeof covered === 'number' ? covered : Number(covered),
+      total: typeof totalCount === 'number' ? totalCount : Number(totalCount),
+    };
+  }
+  return normalized;
+}
+
+function deriveTotalsFromLcov(lcov) {
+  const totals = {
+    lines: { covered: 0, total: 0 },
+    statements: { covered: 0, total: 0 },
+    branches: { covered: 0, total: 0 },
+    functions: { covered: 0, total: 0 },
+  };
+
+  const lines = lcov.split(/\r?\n/);
+
+  for (const line of lines) {
+    if (line.startsWith('LH:')) {
+      const value = Number.parseInt(line.slice(3), 10);
+      if (!Number.isNaN(value)) {
+        totals.lines.covered += value;
+        totals.statements.covered += value;
+      }
+    } else if (line.startsWith('LF:')) {
+      const value = Number.parseInt(line.slice(3), 10);
+      if (!Number.isNaN(value)) {
+        totals.lines.total += value;
+        totals.statements.total += value;
+      }
+    } else if (line.startsWith('BRH:')) {
+      const value = Number.parseInt(line.slice(4), 10);
+      if (!Number.isNaN(value)) {
+        totals.branches.covered += value;
+      }
+    } else if (line.startsWith('BRF:')) {
+      const value = Number.parseInt(line.slice(4), 10);
+      if (!Number.isNaN(value)) {
+        totals.branches.total += value;
+      }
+    } else if (line.startsWith('FNH:')) {
+      const value = Number.parseInt(line.slice(4), 10);
+      if (!Number.isNaN(value)) {
+        totals.functions.covered += value;
+      }
+    } else if (line.startsWith('FNF:')) {
+      const value = Number.parseInt(line.slice(4), 10);
+      if (!Number.isNaN(value)) {
+        totals.functions.total += value;
+      }
+    }
+  }
+
+  for (const data of Object.values(totals)) {
+    data.pct = computePercent(data.covered, data.total);
+  }
+
+  return totals;
+}
+
+function computePercent(covered, total) {
+  if (typeof total !== 'number' || total <= 0) {
+    return 0;
+  }
+  return (covered / total) * 100;
+}
+
+function formatNumber(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return '—';
+  }
+  return value.toLocaleString('en-US');
+}
+
+function formatPercent(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return '—';
+  }
+  return `${value.toFixed(2)}%`;
+}
+
+async function upsertComment(bodyContent) {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'User-Agent': 'akari-coverage-action',
+  };
+
+  const existingCommentId = await findExistingComment(headers);
+
+  if (existingCommentId) {
+    await request(`${apiBase}/repos/${owner}/${repo}/issues/comments/${existingCommentId}`, {
+      method: 'PATCH',
+      headers,
+      body: JSON.stringify({ body: bodyContent }),
+    });
+    return;
+  }
+
+  await request(`${apiBase}/repos/${owner}/${repo}/issues/${prNumber}/comments`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ body: bodyContent }),
+  });
+}
+
+async function findExistingComment(headers) {
+  let page = 1;
+  while (true) {
+    const response = await request(`${apiBase}/repos/${owner}/${repo}/issues/${prNumber}/comments?per_page=100&page=${page}`, {
+      method: 'GET',
+      headers,
+    });
+
+    const comments = await response.json();
+
+    if (!Array.isArray(comments) || comments.length === 0) {
+      return null;
+    }
+
+    for (const comment of comments) {
+      if (typeof comment?.body === 'string' && comment.body.includes(marker)) {
+        return comment.id;
+      }
+    }
+
+    page += 1;
+  }
+}
+
+async function request(url, options) {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options?.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`GitHub API request failed with ${response.status} ${response.statusText}: ${text}`);
+  }
+
+  return response;
+}

--- a/.github/actions/report-coverage/report-coverage.mjs
+++ b/.github/actions/report-coverage/report-coverage.mjs
@@ -6,12 +6,11 @@ const marker = '<!-- coverage-report -->';
 const token = process.env.GITHUB_TOKEN;
 const summaryPath = process.env.COVERAGE_SUMMARY_PATH;
 const lcovPath = process.env.LCOV_PATH;
-const artifactName = process.env.ARTIFACT_NAME;
 const previewFile = process.env.HTML_PREVIEW_FILE;
 const prNumber = process.env.PR_NUMBER;
 const repository = process.env.GITHUB_REPOSITORY;
 const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
-const commitSha = process.env.GITHUB_SHA;
+const commitSha = process.env.PR_HEAD_SHA || process.env.GITHUB_SHA;
 
 if (!token) {
   throw new Error('GITHUB_TOKEN is required.');
@@ -74,10 +73,6 @@ const table = [
 let body = `${marker}\n### Coverage Report\n\n${table}`;
 
 const resourceLines = [];
-
-if (artifactName) {
-  resourceLines.push(`- Download the **${artifactName}** workflow artifact for the complete HTML report.`);
-}
 
 if (previewLink) {
   resourceLines.push(`- [Open the HTML coverage preview ↗︎](${previewLink.url})`);

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
           lcov-path: coverage/lcov.info
           artifact-name: coverage-report
           artifact-path: coverage
+          html-preview-file: coverage/index.html
   e2e:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,6 @@ jobs:
           lcov-path: coverage/lcov.info
           artifact-name: coverage-report
           artifact-path: coverage
-          html-preview-file: coverage/index.html
   e2e:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Merge coverage reports
         run: node ./scripts/merge-coverage.cjs
       - name: Report coverage
-        uses: vebr/jest-lcov-reporter@v0.2.0
+        uses: zgosalvez/github-actions-report-lcov@v4
         with:
           github-token: ${{ github.token }}
-          lcov-file: coverage/lcov.info
-          name: akari-monorepo
+          coverage-files: coverage/lcov.info
+          artifact-name: coverage-report
           update-comment: true
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           github-token: ${{ github.token }}
           coverage-summary: coverage/coverage-summary.json
+          coverage-json: coverage/coverage-final.json
           lcov-path: coverage/lcov.info
           artifact-name: coverage-report
           artifact-path: coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,12 +26,13 @@ jobs:
       - name: Merge coverage reports
         run: node ./scripts/merge-coverage.cjs
       - name: Report coverage
-        uses: zgosalvez/github-actions-report-lcov@v4
+        uses: ./.github/actions/report-coverage
         with:
           github-token: ${{ github.token }}
-          coverage-files: coverage/lcov.info
+          coverage-summary: coverage/coverage-summary.json
+          lcov-path: coverage/lcov.info
           artifact-name: coverage-report
-          update-comment: true
+          artifact-path: coverage
   e2e:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- replace the deprecated coverage reporter with zgosalvez/github-actions-report-lcov@v4
- configure the action to update the existing pull request coverage comment
- enable uploading the HTML coverage artifact so the comment links to the report

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d7ae7b1bdc832bb7a891938b91cda1