### PR TITLE
chore(ci): rename coverage job to unit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,8 @@ on:
       - '**/docs/**'
 
 jobs:
-  coverage:
+  unit:
+    name: unit
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- rename the `test` workflow's coverage job to `unit` so GitHub displays the check as test/unit

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d7b1005ce4832ba70302b4b83490ff