### PR TITLE
chore: migrate ts-jest configs to transform options

### DIFF
--- a/packages/bluesky-api/jest.config.cjs
+++ b/packages/bluesky-api/jest.config.cjs
@@ -25,10 +25,13 @@ module.exports = {
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
-  globals: {
-    'ts-jest': {
-      useESM: true,
-      tsconfig: jestTsconfig,
-    },
+  transform: {
+    '^.+\\.m?tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: jestTsconfig,
+      },
+    ],
   },
 };

--- a/packages/clearsky-api/jest.config.cjs
+++ b/packages/clearsky-api/jest.config.cjs
@@ -10,10 +10,13 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts', '!src/**/*.d.ts'],
   coverageReporters: ['text', 'lcov', 'html'],
   coverageDirectory: 'coverage',
-  globals: {
-    'ts-jest': {
-      useESM: true,
-      tsconfig: '<rootDir>/tsconfig.json',
-    },
+  transform: {
+    '^.+\\.m?tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: '<rootDir>/tsconfig.json',
+      },
+    ],
   },
 };

--- a/packages/libretranslate-api/jest.config.cjs
+++ b/packages/libretranslate-api/jest.config.cjs
@@ -2,11 +2,14 @@ module.exports = {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   extensionsToTreatAsEsm: ['.ts'],
-  globals: {
-    'ts-jest': {
-      useESM: true,
-      tsconfig: './tsconfig.json',
-    },
+  transform: {
+    '^.+\\.m?tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: './tsconfig.json',
+      },
+    ],
   },
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!**/*.d.ts'],

--- a/packages/tenor-api/jest.config.cjs
+++ b/packages/tenor-api/jest.config.cjs
@@ -2,11 +2,14 @@ module.exports = {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   extensionsToTreatAsEsm: ['.ts'],
-  globals: {
-    'ts-jest': {
-      useESM: true,
-      tsconfig: './tsconfig.json',
-    },
+  transform: {
+    '^.+\\.m?tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: './tsconfig.json',
+      },
+    ],
   },
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!**/*.d.ts'],


### PR DESCRIPTION
## Summary
- update the clearsky, bluesky, libretranslate, and tenor API packages to pass ts-jest options through the `transform` setting instead of the deprecated `globals`
- retain each package's existing ESM-related jest options while switching to the supported configuration shape

## Testing
- `npm run lint -- --filter=clearsky-api`
- `npm run lint -- --filter=bluesky-api`
- `npm run lint -- --filter=libretranslate-api`
- `npm run lint -- --filter=tenor-api`
- `npm run test -- --filter=clearsky-api` *(fails: msw depends on ESM-only node_modules/until-async)*
- `npm run test -- --filter=bluesky-api` *(fails: msw depends on ESM-only node_modules/until-async)*
- `npm run test -- --filter=libretranslate-api` *(fails: package has no matching tests configured)*
- `npm run test -- --filter=tenor-api` *(fails: msw depends on ESM-only node_modules/until-async)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b011549c832bae03daf661721984