### PR TITLE
refactor: profile searching 

### DIFF
--- a/apps/akari/__tests__/app/profile/[handle].test.tsx
+++ b/apps/akari/__tests__/app/profile/[handle].test.tsx
@@ -11,6 +11,7 @@ import * as Clipboard from 'expo-clipboard';
 
 jest.mock('expo-router', () => ({
   useLocalSearchParams: jest.fn(),
+  router: { push: jest.fn() },
 }));
 
 jest.mock('@/hooks/queries/useCurrentAccount');
@@ -133,6 +134,8 @@ jest.mock('@/components/profile/StarterpacksTab', () => {
 
 const { ProfileHeader: ProfileHeaderMock } = require('@/components/ProfileHeader');
 
+const { router } = require('expo-router');
+const mockRouterPush = router.push as jest.Mock;
 const mockUseLocalSearchParams = useLocalSearchParams as jest.Mock;
 const mockUseCurrentAccount = useCurrentAccount as jest.Mock;
 const mockUseProfile = useProfile as jest.Mock;
@@ -145,6 +148,7 @@ let mockShowToast: jest.Mock;
 describe('ProfileScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRouterPush.mockClear();
     mockUseTranslation.mockReturnValue({ t: (k: string) => k });
     mockUseCurrentAccount.mockReturnValue({ data: { handle: 'alice' } });
     mockClipboardSetStringAsync.mockResolvedValue(undefined);
@@ -228,7 +232,7 @@ describe('ProfileScreen', () => {
 
     fireEvent.press(getByText('header'));
     fireEvent.press(getByText('search posts'));
-    expect(logSpy).toHaveBeenCalledWith('Search posts');
+    expect(mockRouterPush).toHaveBeenCalledWith('/(tabs)/search?query=from:alice');
 
     fireEvent.press(getByText('header'));
     fireEvent.press(getByText('add to lists'));

--- a/apps/akari/__tests__/app/tabs-profile.test.tsx
+++ b/apps/akari/__tests__/app/tabs-profile.test.tsx
@@ -25,6 +25,9 @@ jest.mock('@/contexts/ToastContext');
 jest.mock('expo-clipboard', () => ({
   setStringAsync: jest.fn(),
 }));
+jest.mock('expo-router', () => ({
+  router: { push: jest.fn() },
+}));
 
 jest.mock('@/utils/tabScrollRegistry', () => ({
   tabScrollRegistry: {
@@ -222,6 +225,8 @@ const mockUseBorderColor = useBorderColor as jest.Mock;
 const mockUseToast = useToast as jest.Mock;
 const mockClipboardSetStringAsync = Clipboard.setStringAsync as jest.Mock;
 const mockRegister = tabScrollRegistry.register as jest.Mock;
+const { router } = require('expo-router');
+const mockRouterPush = router.push as jest.Mock;
 
 let mockShowToast: jest.Mock;
 
@@ -237,6 +242,7 @@ beforeEach(() => {
   mockShowToast = jest.fn();
   mockUseToast.mockReturnValue({ showToast: mockShowToast, hideToast: jest.fn() });
   scrollToMock.mockClear();
+  mockRouterPush.mockClear();
 });
 
 describe('ProfileScreen', () => {
@@ -308,8 +314,12 @@ describe('ProfileScreen', () => {
       expect.objectContaining({ message: 'profile.linkCopied', type: 'success' })
     );
 
+    fireEvent.press(getByText('open dropdown'));
+    fireEvent.press(getByText('common.search'));
+    expect(mockRouterPush).toHaveBeenCalledWith('/(tabs)/search?query=from:alice');
+    expect(queryByTestId('profile-dropdown')).toBeNull();
+
     const remainingActions = [
-      'common.search',
       'profile.addToLists',
       'profile.muteAccount',
       'common.block',

--- a/apps/akari/app/(tabs)/profile/[handle].tsx
+++ b/apps/akari/app/(tabs)/profile/[handle].tsx
@@ -15,6 +15,7 @@ import { PostsTab } from '@/components/profile/PostsTab';
 import { RepliesTab } from '@/components/profile/RepliesTab';
 import { StarterpacksTab } from '@/components/profile/StarterpacksTab';
 import { VideosTab } from '@/components/profile/VideosTab';
+import { searchProfilePosts } from '@/components/profile/profileActions';
 import { ProfileHeaderSkeleton } from '@/components/skeletons';
 import { useToast } from '@/contexts/ToastContext';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
@@ -98,9 +99,10 @@ export default function ProfileScreen() {
   };
 
   const handleSearchPosts = () => {
-    // TODO: Implement search posts functionality
-    console.log('Search posts');
-    setShowDropdown(false);
+    searchProfilePosts({
+      handle: profile?.handle,
+      onComplete: () => setShowDropdown(false),
+    });
   };
 
   const handleAddToLists = () => {

--- a/apps/akari/app/(tabs)/profile/index.tsx
+++ b/apps/akari/app/(tabs)/profile/index.tsx
@@ -14,6 +14,7 @@ import { PostsTab } from '@/components/profile/PostsTab';
 import { RepliesTab } from '@/components/profile/RepliesTab';
 import { StarterpacksTab } from '@/components/profile/StarterpacksTab';
 import { VideosTab } from '@/components/profile/VideosTab';
+import { searchProfilePosts } from '@/components/profile/profileActions';
 import { useToast } from '@/contexts/ToastContext';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useProfile } from '@/hooks/queries/useProfile';
@@ -93,8 +94,10 @@ export default function ProfileScreen() {
   };
 
   const handleSearchPosts = () => {
-    // TODO: Implement search posts functionality
-    setShowDropdown(false);
+    searchProfilePosts({
+      handle: currentAccount?.handle || profile?.handle,
+      onComplete: () => setShowDropdown(false),
+    });
   };
 
   const handleTabChange = (tab: ProfileTabType) => {

--- a/apps/akari/components/ProfileHeader.tsx
+++ b/apps/akari/components/ProfileHeader.tsx
@@ -1,5 +1,4 @@
 import { Image } from 'expo-image';
-import { router } from 'expo-router';
 import React, { useState } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
 
@@ -18,6 +17,7 @@ import { useUpdateProfile } from '@/hooks/mutations/useUpdateProfile';
 import { useBorderColor } from '@/hooks/useBorderColor';
 import { useTranslation } from '@/hooks/useTranslation';
 import { showAlert } from '@/utils/alert';
+import { searchProfilePosts } from '@/components/profile/profileActions';
 
 type ProfileHeaderProps = {
   profile: {
@@ -134,7 +134,7 @@ export function ProfileHeader({ profile, isOwnProfile = false, onDropdownToggle,
   };
 
   const handleSearchPosts = () => {
-    router.push(`/(tabs)/search?query=from:${profile.handle}`);
+    searchProfilePosts({ handle: profile.handle });
   };
 
   const handleAddToLists = () => {

--- a/apps/akari/components/profile/profileActions.ts
+++ b/apps/akari/components/profile/profileActions.ts
@@ -1,0 +1,14 @@
+import { router } from 'expo-router';
+
+type SearchProfilePostsOptions = {
+  handle?: string | null;
+  onComplete?: () => void;
+};
+
+export function searchProfilePosts({ handle, onComplete }: SearchProfilePostsOptions) {
+  if (handle) {
+    router.push(`/(tabs)/search?query=from:${handle}`);
+  }
+
+  onComplete?.();
+}


### PR DESCRIPTION
## Summary
- extract the profile post search router logic into a reusable helper that pulls in the Expo router internally
- use the shared handler in the profile header and profile screens so "Search posts" navigates to the search tab
- update the profile integration tests to assert the router navigation occurs when selecting the search option

## Testing
- npm run lint -- --filter=akari
- npm run test -- --filter=akari -- --runTestsByPath __tests__/components/ProfileHeader.test.tsx __tests__/app/profile/[handle].test.tsx __tests__/app/tabs-profile.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d7b7ea7c40832bbb7018ec40e5301c