### PR TITLE
ci: publish production builds on release

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -46,6 +46,26 @@ jobs:
 
       - name: Create preview
         uses: expo/expo-github-action/preview@v8
+        env:
+          APP_VARIANT: preview
         with:
           command: eas update --auto
           working-directory: apps/akari
+
+      - name: Export preview web bundle
+        working-directory: apps/akari
+        env:
+          APP_VARIANT: preview
+        run: |
+          set -euo pipefail
+          npm run build:preview -- --platform web --output-dir dist/web
+
+      - name: Deploy preview web bundle to Expo Hosting
+        working-directory: apps/akari
+        env:
+          APP_VARIANT: preview
+          EXPO_CLI_NO_PROMPT: 1
+          EXPO_NO_TELEMETRY: 1
+        run: |
+          set -euo pipefail
+          eas deploy --environment preview --alias pr-${{ github.event.pull_request.number }} --export-dir dist/web --non-interactive

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -61,6 +61,7 @@ jobs:
           npm run build:preview -- --platform web --output-dir dist/web
 
       - name: Deploy preview web bundle to Expo Hosting
+        id: deploy_preview
         working-directory: apps/akari
         env:
           APP_VARIANT: preview
@@ -68,4 +69,45 @@ jobs:
           EXPO_NO_TELEMETRY: 1
         run: |
           set -euo pipefail
-          eas deploy --environment preview --alias pr-${{ github.event.pull_request.number }} --export-dir dist/web --non-interactive
+          tmpfile="$(mktemp)"
+          trap 'rm -f "$tmpfile"' EXIT
+          eas deploy --environment preview --alias pr-${{ github.event.pull_request.number }} --export-dir dist/web --non-interactive --json | tee "$tmpfile"
+          url=$(jq -r '
+            if type == "array" then
+              (.[0].deployment.url // .[0].deploymentUrl // .[0].url // empty)
+            else
+              (.deployment.url // .deploymentUrl // .url // empty)
+            end
+          ' "$tmpfile")
+          if [ -z "$url" ]; then
+            echo "Unable to locate Expo Hosting URL in deploy output" >&2
+            exit 1
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Comment with Expo Hosting preview link
+        if: steps.deploy_preview.outputs.url != ''
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request?.number;
+            if (!prNumber) {
+              core.info('No pull request context detected; skipping comment.');
+              return;
+            }
+
+            const previewUrl = process.env.PREVIEW_URL;
+            if (!previewUrl) {
+              core.info('No Expo Hosting preview URL available; skipping comment.');
+              return;
+            }
+            const body = `🚀 Expo Hosting preview: ${previewUrl}`;
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: prNumber,
+              body,
+            });
+        env:
+          PREVIEW_URL: ${{ steps.deploy_preview.outputs.url }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -102,7 +102,40 @@ jobs:
               core.info('No Expo Hosting preview URL available; skipping comment.');
               return;
             }
-            const body = `🚀 Expo Hosting preview: ${previewUrl}`;
+
+            const marker = '<!-- expo-hosting-preview -->';
+            const body = `${marker}\n🚀 Expo Hosting preview: ${previewUrl}`;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) => {
+              if (comment.user?.login !== 'github-actions[bot]') {
+                return false;
+              }
+
+              if (typeof comment.body !== 'string') {
+                return false;
+              }
+
+              if (comment.body.includes(marker)) {
+                return true;
+              }
+
+              return comment.body.startsWith('🚀 Expo Hosting preview:');
+            });
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body,
+              });
+              return;
+            }
 
             await github.rest.issues.createComment({
               ...context.repo,

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,9 +25,22 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Determine deploy commit
+        id: deploy_commit
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ -n "$PR_HEAD_SHA" ]; then
+            echo "sha=$PR_HEAD_SHA" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Record commit metadata
-        run: echo "EXPO_PUBLIC_COMMIT_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+        run: echo "EXPO_PUBLIC_COMMIT_SHA=${{ steps.deploy_commit.outputs.sha }}" >> "$GITHUB_ENV"
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Record commit metadata
+        run: echo "EXPO_PUBLIC_COMMIT_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Record commit metadata
+        run: echo "EXPO_PUBLIC_COMMIT_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
           EXPO_NO_TELEMETRY: 1
         run: |
           set -euo pipefail
-          expo deploy --prod --export-dir dist/web --non-interactive
+          eas deploy --prod --export-dir dist/web --non-interactive
 
       - name: Publish Android build to Play Store
         working-directory: apps/akari

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,9 @@ jobs:
     name: EAS Production Build
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
     steps:
       - name: Check for EXPO_TOKEN
         run: |
@@ -46,6 +48,63 @@ jobs:
         run: |
           set -o pipefail
           eas build --profile production --platform all --non-interactive --wait --json | tee production-build-result.json
+
+      - name: Download native build artifacts
+        working-directory: apps/akari
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          ios_path="dist/akari-${RELEASE_TAG}-ios.ipa"
+          android_path="dist/akari-${RELEASE_TAG}-android.aab"
+          eas build:download --latest --platform ios --profile production --non-interactive --path "$ios_path"
+          eas build:download --latest --platform android --profile production --non-interactive --path "$android_path"
+
+      - name: Build production web bundle
+        working-directory: apps/akari
+        run: |
+          set -euo pipefail
+          npm run build:production -- --platform web --output-dir dist/web
+          tar -czf "dist/akari-${RELEASE_TAG}-web.tar.gz" -C dist/web .
+
+      - name: Publish Android build to Play Store
+        working-directory: apps/akari
+        run: |
+          eas submit --latest --platform android --profile production --non-interactive --wait
+
+      - name: Publish iOS build to App Store
+        working-directory: apps/akari
+        run: |
+          eas submit --latest --platform ios --profile production --non-interactive --wait
+
+      - name: Upload Android bundle to GitHub Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: apps/akari/dist/akari-${{ github.event.release.tag_name }}-android.aab
+          asset_name: akari-${{ github.event.release.tag_name }}-android.aab
+          asset_content_type: application/vnd.android.package-archive
+
+      - name: Upload iOS binary to GitHub Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: apps/akari/dist/akari-${{ github.event.release.tag_name }}-ios.ipa
+          asset_name: akari-${{ github.event.release.tag_name }}-ios.ipa
+          asset_content_type: application/octet-stream
+
+      - name: Upload web bundle to GitHub Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: apps/akari/dist/akari-${{ github.event.release.tag_name }}-web.tar.gz
+          asset_name: akari-${{ github.event.release.tag_name }}-web.tar.gz
+          asset_content_type: application/gzip
 
       - name: Upload build manifest
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,27 @@ jobs:
           npm run build:production -- --platform web --output-dir dist/web
           tar -czf "dist/akari-${RELEASE_TAG}-web.tar.gz" -C dist/web .
 
+      - name: Publish EAS update for native apps
+        working-directory: apps/akari
+        env:
+          APP_VARIANT: production
+          EXPO_CLI_NO_PROMPT: 1
+          EXPO_NO_TELEMETRY: 1
+          EAS_NO_VCS: 1
+        run: |
+          set -euo pipefail
+          eas update --branch production --platform all --message "Release ${RELEASE_TAG}" --non-interactive
+
+      - name: Deploy web bundle to Expo Hosting
+        working-directory: apps/akari
+        env:
+          APP_VARIANT: production
+          EXPO_CLI_NO_PROMPT: 1
+          EXPO_NO_TELEMETRY: 1
+        run: |
+          set -euo pipefail
+          expo deploy --prod --export-dir dist/web --non-interactive
+
       - name: Publish Android build to Play Store
         working-directory: apps/akari
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,30 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'release' && format('refs/tags/{0}', github.event.release.tag_name) || github.ref }}
+
+      - name: Determine deploy commit
+        id: deploy_commit
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ "$EVENT_NAME" = "release" ] && [ -n "$RELEASE_TAG" ]; then
+            tag_commit=$(git rev-parse "${RELEASE_TAG}^{commit}")
+            head_commit=$(git rev-parse HEAD)
+            if [ "$tag_commit" != "$head_commit" ]; then
+              echo "Checked out commit $head_commit does not match release tag $RELEASE_TAG ($tag_commit)" >&2
+              exit 1
+            fi
+            echo "sha=$tag_commit" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Record commit metadata
-        run: echo "EXPO_PUBLIC_COMMIT_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+        run: echo "EXPO_PUBLIC_COMMIT_SHA=${{ steps.deploy_commit.outputs.sha }}" >> "$GITHUB_ENV"
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/apps/akari/app.config.ts
+++ b/apps/akari/app.config.ts
@@ -90,6 +90,8 @@ const createConfigForVariant = (
 export default ({ config }: ConfigContext): ExpoConfig => {
   const variant = resolveVariant();
   const variantConfig = createConfigForVariant(variant, config as ExpoConfig);
+  const rawCommitSha = process.env.EXPO_PUBLIC_COMMIT_SHA?.trim();
+  const commitSha = rawCommitSha && rawCommitSha.length > 0 ? rawCommitSha : null;
 
   return {
     ...config,
@@ -114,6 +116,13 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     extra: {
       ...(config.extra ?? {}),
       ...(variantConfig.extra ?? {}),
+      buildMetadata: {
+        // @ts-expect-error - `extra` is `Record<string, any>` so nested keys are untyped.
+        ...(config.extra?.buildMetadata ?? {}),
+        // @ts-expect-error - `extra` is `Record<string, any>` so nested keys are untyped.
+        ...(variantConfig.extra?.buildMetadata ?? {}),
+        commitSha,
+      },
     },
     updates: {
       ...(config.updates ?? {}),

--- a/apps/akari/app.config.ts
+++ b/apps/akari/app.config.ts
@@ -93,6 +93,15 @@ export default ({ config }: ConfigContext): ExpoConfig => {
   const rawCommitSha = process.env.EXPO_PUBLIC_COMMIT_SHA?.trim();
   const commitSha = rawCommitSha && rawCommitSha.length > 0 ? rawCommitSha : null;
 
+  const configExtra = config.extra as
+    | { buildMetadata?: { commitSha?: string | null } }
+    | undefined;
+  const variantExtra = variantConfig.extra as
+    | { buildMetadata?: { commitSha?: string | null } }
+    | undefined;
+  const configBuildMetadata = configExtra?.buildMetadata ?? {};
+  const variantBuildMetadata = variantExtra?.buildMetadata ?? {};
+
   return {
     ...config,
     ...variantConfig,
@@ -117,10 +126,8 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       ...(config.extra ?? {}),
       ...(variantConfig.extra ?? {}),
       buildMetadata: {
-        // @ts-expect-error - `extra` is `Record<string, any>` so nested keys are untyped.
-        ...(config.extra?.buildMetadata ?? {}),
-        // @ts-expect-error - `extra` is `Record<string, any>` so nested keys are untyped.
-        ...(variantConfig.extra?.buildMetadata ?? {}),
+        ...configBuildMetadata,
+        ...variantBuildMetadata,
         commitSha,
       },
     },

--- a/apps/akari/app/(tabs)/settings/about.tsx
+++ b/apps/akari/app/(tabs)/settings/about.tsx
@@ -30,6 +30,22 @@ export default function AboutSettingsScreen() {
   const version = Constants.expoConfig?.version ?? t('common.unknown');
   const iosBuildNumber = Constants.expoConfig?.ios?.buildNumber;
   const androidVersionCode = Constants.expoConfig?.android?.versionCode;
+  const extra = Constants.expoConfig?.extra as
+    | {
+        buildMetadata?: {
+          commitSha?: string | null;
+        };
+      }
+    | undefined;
+  const commitSha =
+    typeof extra?.buildMetadata?.commitSha === 'string' && extra.buildMetadata.commitSha.length > 0
+      ? extra.buildMetadata.commitSha
+      : undefined;
+  const shortCommitSha = commitSha?.slice(0, 7);
+  const versionDisplay = useMemo(
+    () => (shortCommitSha ? `${version} (${shortCommitSha})` : version),
+    [shortCommitSha, version],
+  );
   const buildNumber =
     typeof iosBuildNumber === 'string'
       ? iosBuildNumber
@@ -91,7 +107,7 @@ export default function AboutSettingsScreen() {
         key: 'version',
         icon: 'info.circle.fill',
         label: t('settings.version'),
-        value: version,
+        value: versionDisplay,
       },
       ...(buildNumber
         ? [
@@ -104,7 +120,7 @@ export default function AboutSettingsScreen() {
           ]
         : []),
     ],
-    [buildNumber, openExternalLink, showNotImplemented, t, version],
+    [buildNumber, openExternalLink, showNotImplemented, t, versionDisplay],
   );
 
   return (


### PR DESCRIPTION
## Summary
- add release workflow steps to download production build artifacts for iOS, Android, and the web
- publish native binaries to the respective app stores through EAS submit after each release build
- attach the native binaries and web bundle to the GitHub Release for convenient distribution

## Testing
- [ ] `npm test`
- [x] `npm run lint -- --filter=akari`


------
https://chatgpt.com/codex/tasks/task_e_68d7c3edafcc832b88fc959aff049ad2