### PR TITLE
fix: keep notifications header sticky

### DIFF
--- a/apps/akari/app/(tabs)/notifications.tsx
+++ b/apps/akari/app/(tabs)/notifications.tsx
@@ -41,6 +41,12 @@ type GroupedNotification = {
 
 type NotificationsTab = 'all' | 'mentions';
 
+type NotificationListItem =
+  | { type: 'header' }
+  | { type: 'loading' }
+  | { type: 'empty' }
+  | { type: 'notification'; notification: GroupedNotification };
+
 /**
  * Notification item component
  */
@@ -355,7 +361,7 @@ export default function NotificationsScreen() {
   const borderColor = useBorderColor();
   const { t } = useTranslation();
   const { isLargeScreen } = useResponsive();
-  const listRef = useRef<VirtualizedListHandle<GroupedNotification>>(null);
+  const listRef = useRef<VirtualizedListHandle<NotificationListItem>>(null);
   const [activeTab, setActiveTab] = useState<NotificationsTab>('all');
   const tabs = useMemo(
     () => [
@@ -424,18 +430,32 @@ export default function NotificationsScreen() {
     }
   }, []);
 
-  const renderNotification = useCallback(
-    ({ item }: { item: GroupedNotification }) => (
+  const renderNotificationItem = useCallback(
+    (notification: GroupedNotification) => (
       <NotificationItem
-        notification={item}
-        onPress={() => handleNotificationPress(item)}
+        notification={notification}
+        onPress={() => handleNotificationPress(notification)}
         borderColor={borderColor}
       />
     ),
     [borderColor, handleNotificationPress],
   );
 
-  const keyExtractor = useCallback((item: GroupedNotification) => item.id, []);
+  const keyExtractor = useCallback((item: NotificationListItem) => {
+    if (item.type === 'header') {
+      return 'notifications-header';
+    }
+
+    if (item.type === 'loading') {
+      return 'notifications-loading';
+    }
+
+    if (item.type === 'empty') {
+      return 'notifications-empty';
+    }
+
+    return item.notification.id;
+  }, []);
 
   const renderEmptyState = useCallback(() => (
     <View style={styles.emptyState}>
@@ -463,19 +483,44 @@ export default function NotificationsScreen() {
     [activeTab, borderColor, handleTabChange, tabs, t],
   );
 
-  const listEmptyComponent = useMemo(() => {
-    if (isLoading) {
-      return (
-        <ThemedView style={styles.skeletonContainer}>
-          {Array.from({ length: 12 }).map((_, index) => (
-            <NotificationSkeleton key={index} />
-          ))}
-        </ThemedView>
-      );
+  const listData = useMemo((): NotificationListItem[] => {
+    if (isLoading && filteredNotifications.length === 0) {
+      return [{ type: 'header' }, { type: 'loading' }];
     }
 
-    return renderEmptyState();
-  }, [isLoading, renderEmptyState]);
+    if (filteredNotifications.length === 0) {
+      return [{ type: 'header' }, { type: 'empty' }];
+    }
+
+    return [
+      { type: 'header' },
+      ...filteredNotifications.map((notification) => ({ type: 'notification', notification })),
+    ];
+  }, [filteredNotifications, isLoading]);
+
+  const renderListItem = useCallback(
+    ({ item }: { item: NotificationListItem }) => {
+      switch (item.type) {
+        case 'header':
+          return listHeaderComponent;
+        case 'loading':
+          return (
+            <ThemedView style={styles.skeletonContainer}>
+              {Array.from({ length: 12 }).map((_, index) => (
+                <NotificationSkeleton key={index} />
+              ))}
+            </ThemedView>
+          );
+        case 'empty':
+          return renderEmptyState();
+        case 'notification':
+          return renderNotificationItem(item.notification);
+        default:
+          return null;
+      }
+    },
+    [listHeaderComponent, renderEmptyState, renderNotificationItem],
+  );
 
   const listFooterComponent = useMemo(() => {
     if (!isFetchingNextPage) {
@@ -505,14 +550,12 @@ export default function NotificationsScreen() {
     <ThemedView style={styles.container}>
       <VirtualizedList
         ref={listRef}
-        data={filteredNotifications}
-        renderItem={renderNotification}
+        data={listData}
+        renderItem={renderListItem}
         keyExtractor={keyExtractor}
         estimatedItemSize={160}
         overscan={2}
-        ListHeaderComponent={listHeaderComponent}
         ListFooterComponent={listFooterComponent ?? undefined}
-        ListEmptyComponent={listEmptyComponent}
         contentContainerStyle={contentContainerStyle}
         style={[styles.list, { paddingTop: 0 }]}
         onEndReached={handleEndReached}


### PR DESCRIPTION
## Summary
- ensure the notifications list includes a dedicated header item so the tab bar stays sticky instead of the first notification
- render loading and empty states through list items to keep the header pinned regardless of data state

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d7fd07d704832b96c93ba5001e859b