### PR TITLE
fix: send repeated feed generator params

### DIFF
--- a/packages/bluesky-api/src/actors.test.ts
+++ b/packages/bluesky-api/src/actors.test.ts
@@ -9,7 +9,7 @@ describe('BlueskyActors', () => {
       options: {
         method?: 'GET' | 'POST';
         body?: Record<string, unknown> | FormData | Blob;
-        params?: Record<string, string>;
+        params?: Record<string, string | string[]>;
         headers?: Record<string, string>;
       };
     };
@@ -26,7 +26,7 @@ describe('BlueskyActors', () => {
       options: {
         method?: 'GET' | 'POST';
         body?: Record<string, unknown> | FormData | Blob;
-        params?: Record<string, string>;
+        params?: Record<string, string | string[]>;
         headers?: Record<string, string>;
       } = {},
     ): Promise<T> {

--- a/packages/bluesky-api/src/auth.test.ts
+++ b/packages/bluesky-api/src/auth.test.ts
@@ -9,7 +9,7 @@ describe('BlueskyAuth', () => {
         method?: 'GET' | 'POST';
         headers?: Record<string, string>;
         body?: Record<string, unknown> | FormData | Blob;
-        params?: Record<string, string>;
+        params?: Record<string, string | string[]>;
       };
     };
 
@@ -25,7 +25,7 @@ describe('BlueskyAuth', () => {
         method?: 'GET' | 'POST';
         headers?: Record<string, string>;
         body?: Record<string, unknown> | FormData | Blob;
-        params?: Record<string, string>;
+        params?: Record<string, string | string[]>;
       } = {},
     ): Promise<T> {
       this.lastCall = { endpoint, options };

--- a/packages/bluesky-api/src/client.ts
+++ b/packages/bluesky-api/src/client.ts
@@ -26,7 +26,7 @@ export class BlueskyApiClient {
       method?: 'GET' | 'POST';
       headers?: Record<string, string>;
       body?: Record<string, unknown> | FormData | Blob;
-      params?: Record<string, string>;
+      params?: Record<string, string | string[]>;
     } = {},
   ): Promise<T> {
     const { method = 'GET', headers = {}, body, params } = options;
@@ -36,7 +36,17 @@ export class BlueskyApiClient {
     if (params && Object.keys(params).length > 0) {
       const searchParams = new URLSearchParams();
       Object.entries(params).forEach(([key, value]) => {
-        if (value !== undefined && value !== null) {
+        if (value === undefined || value === null) {
+          return;
+        }
+
+        if (Array.isArray(value)) {
+          for (const item of value) {
+            if (item !== undefined && item !== null) {
+              searchParams.append(key, item);
+            }
+          }
+        } else {
           searchParams.append(key, value);
         }
       });
@@ -79,7 +89,7 @@ export class BlueskyApiClient {
     options: {
       method?: 'GET' | 'POST';
       body?: Record<string, unknown> | FormData | Blob;
-      params?: Record<string, string>;
+      params?: Record<string, string | string[]>;
       headers?: Record<string, string>;
     } = {},
   ): Promise<T> {

--- a/packages/bluesky-api/src/conversations.test.ts
+++ b/packages/bluesky-api/src/conversations.test.ts
@@ -14,7 +14,7 @@ describe('BlueskyConversations', () => {
       options: {
         method?: 'GET' | 'POST';
         body?: Record<string, unknown> | FormData | Blob;
-        params?: Record<string, string>;
+        params?: Record<string, string | string[]>;
         headers?: Record<string, string>;
       };
     };
@@ -31,7 +31,7 @@ describe('BlueskyConversations', () => {
       options: {
         method?: 'GET' | 'POST';
         body?: Record<string, unknown> | FormData | Blob;
-        params?: Record<string, string>;
+        params?: Record<string, string | string[]>;
         headers?: Record<string, string>;
       } = {},
     ): Promise<T> {

--- a/packages/bluesky-api/src/feeds.test.ts
+++ b/packages/bluesky-api/src/feeds.test.ts
@@ -20,7 +20,7 @@ describe('BlueskyFeeds', () => {
       options: {
         method?: 'GET' | 'POST';
         body?: Record<string, unknown> | FormData | Blob;
-        params?: Record<string, string>;
+        params?: Record<string, string | string[]>;
         headers?: Record<string, string>;
       };
     }[] = [];
@@ -30,7 +30,7 @@ describe('BlueskyFeeds', () => {
       options: {
         method?: 'GET' | 'POST';
         body?: Record<string, unknown> | FormData | Blob;
-        params?: Record<string, string>;
+        params?: Record<string, string | string[]>;
         headers?: Record<string, string>;
       };
     }[] = [];
@@ -47,7 +47,7 @@ describe('BlueskyFeeds', () => {
       options: {
         method?: 'GET' | 'POST';
         body?: Record<string, unknown> | FormData | Blob;
-        params?: Record<string, string>;
+        params?: Record<string, string | string[]>;
         headers?: Record<string, string>;
       } = {},
     ): Promise<T> {
@@ -60,7 +60,7 @@ describe('BlueskyFeeds', () => {
       options: {
         method?: 'GET' | 'POST';
         body?: Record<string, unknown> | FormData | Blob;
-        params?: Record<string, string>;
+        params?: Record<string, string | string[]>;
         headers?: Record<string, string>;
       } = {},
     ): Promise<T> {
@@ -159,7 +159,7 @@ describe('BlueskyFeeds', () => {
       accessJwt: 'jwt',
       options: {
         params: {
-          feeds: 'at://feed/a,at://feed/b',
+          feeds: ['at://feed/a', 'at://feed/b'],
         },
       },
     });

--- a/packages/bluesky-api/src/feeds.ts
+++ b/packages/bluesky-api/src/feeds.ts
@@ -95,13 +95,15 @@ export class BlueskyFeeds extends BlueskyApiClient {
    * @returns Promise resolving to feed generators data
    */
   async getFeedGenerators(accessJwt: string, feeds: string[]): Promise<BlueskyFeedGeneratorsResponse> {
-    const params: Record<string, string> = {
-      feeds: feeds.join(','),
-    };
-
-    return this.makeAuthenticatedRequest<BlueskyFeedGeneratorsResponse>('/app.bsky.feed.getFeedGenerators', accessJwt, {
-      params,
-    });
+    return this.makeAuthenticatedRequest<BlueskyFeedGeneratorsResponse>(
+      '/app.bsky.feed.getFeedGenerators',
+      accessJwt,
+      {
+        params: {
+          feeds,
+        },
+      },
+    );
   }
 
   /**

--- a/packages/bluesky-api/src/graph.test.ts
+++ b/packages/bluesky-api/src/graph.test.ts
@@ -8,7 +8,7 @@ describe('BlueskyGraph', () => {
       options: {
         method?: 'GET' | 'POST';
         body?: Record<string, unknown> | FormData | Blob;
-        params?: Record<string, string>;
+        params?: Record<string, string | string[]>;
         headers?: Record<string, string>;
       };
     }[] = [];
@@ -25,7 +25,7 @@ describe('BlueskyGraph', () => {
       options: {
         method?: 'GET' | 'POST';
         body?: Record<string, unknown> | FormData | Blob;
-        params?: Record<string, string>;
+        params?: Record<string, string | string[]>;
         headers?: Record<string, string>;
       } = {},
     ): Promise<T> {

--- a/packages/bluesky-api/src/search.test.ts
+++ b/packages/bluesky-api/src/search.test.ts
@@ -11,7 +11,7 @@ describe('BlueskySearch', () => {
       accessJwt: string;
       options: {
         method?: 'GET' | 'POST';
-        params?: Record<string, string>;
+        params?: Record<string, string | string[]>;
         headers?: Record<string, string>;
         body?: Record<string, unknown> | FormData | Blob;
       };
@@ -28,7 +28,7 @@ describe('BlueskySearch', () => {
       accessJwt: string,
       options: {
         method?: 'GET' | 'POST';
-        params?: Record<string, string>;
+        params?: Record<string, string | string[]>;
         headers?: Record<string, string>;
         body?: Record<string, unknown> | FormData | Blob;
       } = {},


### PR DESCRIPTION
## Summary
- allow the Bluesky API client to send repeated query parameters when values are provided as arrays
- update getFeedGenerators to forward feed URIs without joining and adjust tests for the new parameter handling

## Testing
- npm run lint -- --filter=bluesky-api
- npm run test --workspace=bluesky-api -- feeds.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d804f862cc832b90959ee638b32e6d