### PR TITLE
ci: ensure release workflow triggers on release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,14 @@ name: release
 on:
   release:
     types: [published]
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to deploy'
+        required: true
 
 jobs:
   production-build:
@@ -12,7 +19,7 @@ jobs:
     permissions:
       contents: write
     env:
-      RELEASE_TAG: ${{ github.event.release.tag_name }}
+      RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || (startsWith(github.ref, 'refs/tags/') && github.ref_name) || github.event.inputs.release_tag || '' }}
     steps:
       - name: Check for EXPO_TOKEN
         run: |
@@ -26,15 +33,61 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'release' && format('refs/tags/{0}', github.event.release.tag_name) || github.ref }}
+          ref: ${{ env.RELEASE_TAG != '' && format('refs/tags/{0}', env.RELEASE_TAG) || github.sha }}
+
+      - name: Resolve release metadata
+        id: release_metadata
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$RELEASE_TAG" ]; then
+            echo "RELEASE_TAG is not set for event $EVENT_NAME" >&2
+            exit 1
+          fi
+
+          if [ "$EVENT_NAME" = "release" ]; then
+            upload_url='${{ github.event.release.upload_url }}'
+          else
+            attempts=0
+            while [ $attempts -lt 10 ]; do
+              response=$(curl -fsSL \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer $GITHUB_TOKEN" \
+                "https://api.github.com/repos/$REPOSITORY/releases/tags/$RELEASE_TAG" \
+                || true)
+
+              if [ -n "$response" ]; then
+                upload_url=$(echo "$response" | jq -r '.upload_url // empty')
+                if [ -n "$upload_url" ]; then
+                  break
+                fi
+              fi
+
+              attempts=$((attempts + 1))
+              echo "Release metadata not available yet, retrying in 5 seconds... ($attempts/10)" >&2
+              sleep 5
+            done
+
+            if [ -z "${upload_url:-}" ]; then
+              echo "Failed to resolve release metadata for tag $RELEASE_TAG" >&2
+              exit 1
+            fi
+          fi
+
+          echo "upload_url=$upload_url" >> "$GITHUB_OUTPUT"
 
       - name: Determine deploy commit
         id: deploy_commit
         env:
           EVENT_NAME: ${{ github.event_name }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
         run: |
-          if [ "$EVENT_NAME" = "release" ] && [ -n "$RELEASE_TAG" ]; then
+          if [ -n "$RELEASE_TAG" ]; then
             tag_commit=$(git rev-parse "${RELEASE_TAG}^{commit}")
             head_commit=$(git rev-parse HEAD)
             if [ "$tag_commit" != "$head_commit" ]; then
@@ -122,33 +175,36 @@ jobs:
           eas submit --latest --platform ios --profile production --non-interactive --wait
 
       - name: Upload Android bundle to GitHub Release
+        if: steps.release_metadata.outputs.upload_url != ''
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: apps/akari/dist/akari-${{ github.event.release.tag_name }}-android.aab
-          asset_name: akari-${{ github.event.release.tag_name }}-android.aab
+          upload_url: ${{ steps.release_metadata.outputs.upload_url }}
+          asset_path: apps/akari/dist/akari-${{ env.RELEASE_TAG }}-android.aab
+          asset_name: akari-${{ env.RELEASE_TAG }}-android.aab
           asset_content_type: application/vnd.android.package-archive
 
       - name: Upload iOS binary to GitHub Release
+        if: steps.release_metadata.outputs.upload_url != ''
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: apps/akari/dist/akari-${{ github.event.release.tag_name }}-ios.ipa
-          asset_name: akari-${{ github.event.release.tag_name }}-ios.ipa
+          upload_url: ${{ steps.release_metadata.outputs.upload_url }}
+          asset_path: apps/akari/dist/akari-${{ env.RELEASE_TAG }}-ios.ipa
+          asset_name: akari-${{ env.RELEASE_TAG }}-ios.ipa
           asset_content_type: application/octet-stream
 
       - name: Upload web bundle to GitHub Release
+        if: steps.release_metadata.outputs.upload_url != ''
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: apps/akari/dist/akari-${{ github.event.release.tag_name }}-web.tar.gz
-          asset_name: akari-${{ github.event.release.tag_name }}-web.tar.gz
+          upload_url: ${{ steps.release_metadata.outputs.upload_url }}
+          asset_path: apps/akari/dist/akari-${{ env.RELEASE_TAG }}-web.tar.gz
+          asset_name: akari-${{ env.RELEASE_TAG }}-web.tar.gz
           asset_content_type: application/gzip
 
       - name: Upload build manifest


### PR DESCRIPTION
## Summary
- trigger the release workflow when release tags are pushed or dispatched manually
- resolve release metadata so assets can be uploaded outside the release event payload
- guard asset uploads behind the resolved upload URL while reusing the computed release tag

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d80d729f94832b85c3fd74ef0d6121