### PR TITLE
docs: set current supported version

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported Versions
+
+We only provide security updates for the most recent Akari release. The
+`release-please` workflow updates the table below each time a new version is
+published so that it always reflects the currently supported release line.
+
+| Version | Status |
+| ------- | ------ |
+| <!-- x-release-please-version -->v1.2.0 | ✅ Active |
+
+All earlier releases are considered end-of-life and do not receive security
+fixes. Upgrade to the latest version to remain supported.
+
+## Reporting a Vulnerability
+
+Report potential vulnerabilities by opening a GitHub issue in this repository.
+Include as much detail as possible so we can reproduce and triage the problem.
+We aim to acknowledge new reports within two business days and will keep you
+informed as we validate, prioritize, and remediate the issue.
+
+If you believe you have discovered a highly sensitive vulnerability that needs
+real-time coordination, send a direct message on Bluesky to
+[@imlunahey.com](https://bsky.app/profile/imlunahey.com) in addition to filing
+the issue.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,10 @@
           "type": "json",
           "path": "package-lock.json",
           "jsonpath": "$.packages[\"apps/akari\"].version"
+        },
+        {
+          "type": "generic",
+          "path": "SECURITY.md"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- update the SECURITY policy table to reflect the currently supported Akari release so automation has the correct baseline

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d80e0e2750832bb79ec5d3ee42d190