### PR TITLE
fix: add pull-to-refresh to notifications list

### DIFF
--- a/apps/akari/app/(tabs)/notifications.tsx
+++ b/apps/akari/app/(tabs)/notifications.tsx
@@ -357,6 +357,7 @@ export default function NotificationsScreen() {
   const { isLargeScreen } = useResponsive();
   const listRef = useRef<VirtualizedListHandle<GroupedNotification>>(null);
   const [activeTab, setActiveTab] = useState<NotificationsTab>('all');
+  const [refreshing, setRefreshing] = useState(false);
   const tabs = useMemo(
     () => [
       { key: 'all' as const, label: t('notifications.all') },
@@ -389,6 +390,7 @@ export default function NotificationsScreen() {
     isFetchingNextPage,
     fetchNextPage,
     hasNextPage,
+    refetch,
   } = useNotifications();
 
   const notifications = useMemo(
@@ -480,6 +482,15 @@ export default function NotificationsScreen() {
     fetchNextPage();
   }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await refetch();
+    } finally {
+      setRefreshing(false);
+    }
+  }, [refetch]);
+
   if (isError) {
     return <ThemedView style={[styles.container, { paddingTop: insets.top }]}>{renderErrorState()}</ThemedView>;
   }
@@ -506,6 +517,8 @@ export default function NotificationsScreen() {
         style={styles.list}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
+        refreshing={refreshing}
+        onRefresh={handleRefresh}
         showsVerticalScrollIndicator={false}
         keyboardDismissMode="on-drag"
       />


### PR DESCRIPTION
## Summary
- track a refreshing state on the notifications screen
- hook the notifications query refetch into pull-to-refresh on the list

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d8117cb780832bb914a0ee4d94068b