### PR TITLE
chore: wrap app with safe area provider

### DIFF
--- a/apps/akari/__tests__/app/root-layout.test.tsx
+++ b/apps/akari/__tests__/app/root-layout.test.tsx
@@ -35,6 +35,21 @@ jest.mock('@tanstack/react-query-devtools', () => {
   return { ReactQueryDevtools: () => <Text>Devtools</Text> };
 });
 
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+
+  const EdgeInsetsContext = React.createContext({ top: 0, right: 0, bottom: 0, left: 0 });
+  const FrameContext = React.createContext({ x: 0, y: 0, width: 0, height: 0 });
+
+  return {
+    SafeAreaProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SafeAreaInsetsContext: EdgeInsetsContext,
+    SafeAreaFrameContext: FrameContext,
+    useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+    initialWindowMetrics: null,
+  };
+});
+
 jest.mock('@/contexts/LanguageContext', () => ({
   LanguageProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));

--- a/apps/akari/app/_layout.tsx
+++ b/apps/akari/app/_layout.tsx
@@ -13,6 +13,7 @@ import { StatusBar } from 'expo-status-bar';
 import { useEffect } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import 'react-native-reanimated';
+import { SafeAreaProvider, initialWindowMetrics } from 'react-native-safe-area-context';
 
 import { DialogProvider } from '@/contexts/DialogContext';
 import { ToastProvider } from '@/contexts/ToastContext';
@@ -118,12 +119,14 @@ export default function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <PersistQueryClientProvider client={queryClient} persistOptions={persistOptions}>
-        <AppProviders colorScheme={colorScheme} />
-        {Platform.OS === 'web' ? (
-          <ReactQueryDevtools initialIsOpen={false} position="left" buttonPosition="bottom-left" />
-        ) : null}
-      </PersistQueryClientProvider>
+      <SafeAreaProvider initialMetrics={initialWindowMetrics}>
+        <PersistQueryClientProvider client={queryClient} persistOptions={persistOptions}>
+          <AppProviders colorScheme={colorScheme} />
+          {Platform.OS === 'web' ? (
+            <ReactQueryDevtools initialIsOpen={false} position="left" buttonPosition="bottom-left" />
+          ) : null}
+        </PersistQueryClientProvider>
+      </SafeAreaProvider>
     </GestureHandlerRootView>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the Expo app with SafeAreaProvider so screens can read safe area insets

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d814a44218832b95d8be79da174ed4