### PR TITLE
fix: remove VirtualizedList style props

### DIFF
--- a/apps/akari/app/(tabs)/index.tsx
+++ b/apps/akari/app/(tabs)/index.tsx
@@ -301,7 +301,6 @@ export default function HomeScreen() {
         ListHeaderComponent={listHeaderComponent}
         ListFooterComponent={listFooterComponent ?? undefined}
         contentContainerStyle={styles.listContent}
-        style={styles.list}
         onEndReached={loadMorePosts}
         onEndReachedThreshold={0.4}
         refreshing={refreshing}
@@ -324,9 +323,6 @@ export default function HomeScreen() {
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
-  },
-  list: {
     flex: 1,
   },
   listContent: {

--- a/apps/akari/app/(tabs)/messages/[handle].tsx
+++ b/apps/akari/app/(tabs)/messages/[handle].tsx
@@ -525,7 +525,6 @@ export default function ConversationScreen() {
               data={messages}
               renderItem={renderMessage}
               keyExtractor={(item) => item.id}
-              style={styles.messagesList}
               contentContainerStyle={styles.messagesContent}
               showsVerticalScrollIndicator={false}
               onEndReached={handleLoadMore}
@@ -617,9 +616,6 @@ const styles = StyleSheet.create({
   headerHandle: {
     fontSize: 14,
     opacity: 0.6,
-  },
-  messagesList: {
-    flex: 1,
   },
   messagesContent: {
     paddingVertical: 16,

--- a/apps/akari/app/(tabs)/messages/index.tsx
+++ b/apps/akari/app/(tabs)/messages/index.tsx
@@ -185,7 +185,6 @@ export function MessagesListScreen({
         data={conversations}
         renderItem={renderConversation}
         keyExtractor={(item) => item.id}
-        style={styles.list}
         contentContainerStyle={styles.conversationsContent}
         showsVerticalScrollIndicator={false}
         onEndReached={handleLoadMore}
@@ -267,9 +266,6 @@ const styles = StyleSheet.create({
     color: 'white',
     fontSize: 14,
     fontWeight: '600',
-  },
-  list: {
-    flex: 1,
   },
   conversationsContent: {
     paddingBottom: 100, // Add extra padding to account for tab bar

--- a/apps/akari/app/(tabs)/notifications.tsx
+++ b/apps/akari/app/(tabs)/notifications.tsx
@@ -514,7 +514,6 @@ export default function NotificationsScreen() {
         ListFooterComponent={listFooterComponent ?? undefined}
         ListEmptyComponent={listEmptyComponent}
         contentContainerStyle={styles.listContent}
-        style={styles.list}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
         refreshing={refreshing}
@@ -532,9 +531,6 @@ const styles = StyleSheet.create({
   },
   headerContainer: {
     paddingBottom: 12,
-  },
-  list: {
-    flex: 1,
   },
   listContent: {
     paddingBottom: 100,

--- a/apps/akari/app/(tabs)/search.tsx
+++ b/apps/akari/app/(tabs)/search.tsx
@@ -293,7 +293,6 @@ export default function SearchScreen() {
         data={filteredResults}
         renderItem={renderResult}
         keyExtractor={(item, index) => `${item.type}-${index}`}
-        style={styles.resultsList}
         contentContainerStyle={styles.resultsListContent}
         refreshing={isRefetching}
         onRefresh={handleRefresh}
@@ -356,9 +355,6 @@ const styles = StyleSheet.create({
     color: '#ffffff',
     fontSize: 16,
     fontWeight: '600',
-  },
-  resultsList: {
-    flex: 1,
   },
   resultsListContent: {
     paddingBottom: 100,

--- a/apps/akari/components/profile/FeedsTab.tsx
+++ b/apps/akari/components/profile/FeedsTab.tsx
@@ -111,16 +111,12 @@ export function FeedsTab({ handle }: FeedsTabProps) {
       ListFooterComponent={renderFooter}
       showsVerticalScrollIndicator={false}
       scrollEnabled={false}
-      style={styles.flatList}
       estimatedItemSize={ESTIMATED_FEED_CARD_HEIGHT}
     />
   );
 }
 
 const styles = StyleSheet.create({
-  flatList: {
-    flex: 1,
-  },
   emptyContainer: {
     paddingVertical: 60,
     alignItems: 'center',

--- a/apps/akari/components/profile/LikesTab.tsx
+++ b/apps/akari/components/profile/LikesTab.tsx
@@ -101,16 +101,12 @@ export function LikesTab({ handle }: LikesTabProps) {
       ListFooterComponent={renderFooter}
       showsVerticalScrollIndicator={false}
       scrollEnabled={false}
-      style={styles.flatList}
       estimatedItemSize={ESTIMATED_POST_CARD_HEIGHT}
     />
   );
 }
 
 const styles = StyleSheet.create({
-  flatList: {
-    flex: 1,
-  },
   emptyContainer: {
     paddingVertical: 40,
     alignItems: 'center',

--- a/apps/akari/components/profile/MediaTab.tsx
+++ b/apps/akari/components/profile/MediaTab.tsx
@@ -105,16 +105,12 @@ export function MediaTab({ handle }: MediaTabProps) {
       ListFooterComponent={footer}
       showsVerticalScrollIndicator={false}
       scrollEnabled={false}
-      style={styles.flatList}
       estimatedItemSize={ESTIMATED_MEDIA_POST_CARD_HEIGHT}
     />
   );
 }
 
 const styles = StyleSheet.create({
-  flatList: {
-    flex: 1,
-  },
   emptyContainer: {
     paddingVertical: 40,
     alignItems: 'center',

--- a/apps/akari/components/profile/PostsTab.tsx
+++ b/apps/akari/components/profile/PostsTab.tsx
@@ -101,16 +101,12 @@ export function PostsTab({ handle }: PostsTabProps) {
       ListFooterComponent={renderFooter}
       showsVerticalScrollIndicator={false}
       scrollEnabled={false}
-      style={styles.flatList}
       estimatedItemSize={ESTIMATED_POST_CARD_HEIGHT}
     />
   );
 }
 
 const styles = StyleSheet.create({
-  flatList: {
-    flex: 1,
-  },
   emptyContainer: {
     paddingVertical: 40,
     alignItems: 'center',

--- a/apps/akari/components/profile/RepliesTab.tsx
+++ b/apps/akari/components/profile/RepliesTab.tsx
@@ -101,7 +101,6 @@ export function RepliesTab({ handle }: RepliesTabProps) {
       ListFooterComponent={renderFooter}
       showsVerticalScrollIndicator={false}
       scrollEnabled={false}
-      style={styles.flatList}
       estimatedItemSize={ESTIMATED_POST_CARD_HEIGHT}
       accessibilityRole="list"
       accessible
@@ -110,9 +109,6 @@ export function RepliesTab({ handle }: RepliesTabProps) {
 }
 
 const styles = StyleSheet.create({
-  flatList: {
-    flex: 1,
-  },
   emptyContainer: {
     paddingVertical: 40,
     alignItems: 'center',

--- a/apps/akari/components/profile/StarterpacksTab.tsx
+++ b/apps/akari/components/profile/StarterpacksTab.tsx
@@ -108,16 +108,12 @@ export function StarterpacksTab({ handle }: StarterpacksTabProps) {
       ListFooterComponent={renderFooter}
       showsVerticalScrollIndicator={false}
       scrollEnabled={false}
-      style={styles.flatList}
       estimatedItemSize={ESTIMATED_STARTERPACK_CARD_HEIGHT}
     />
   );
 }
 
 const styles = StyleSheet.create({
-  flatList: {
-    flex: 1,
-  },
   emptyContainer: {
     paddingVertical: 60,
     alignItems: 'center',

--- a/apps/akari/components/profile/VideosTab.tsx
+++ b/apps/akari/components/profile/VideosTab.tsx
@@ -101,16 +101,12 @@ export function VideosTab({ handle }: VideosTabProps) {
       ListFooterComponent={renderFooter}
       showsVerticalScrollIndicator={false}
       scrollEnabled={false}
-      style={styles.flatList}
       estimatedItemSize={ESTIMATED_VIDEO_POST_CARD_HEIGHT}
     />
   );
 }
 
 const styles = StyleSheet.create({
-  flatList: {
-    flex: 1,
-  },
   emptyContainer: {
     paddingVertical: 40,
     alignItems: 'center',

--- a/apps/akari/components/ui/VirtualizedList.tsx
+++ b/apps/akari/components/ui/VirtualizedList.tsx
@@ -7,7 +7,7 @@ const DEFAULT_OVERSCAN = 2;
 
 export type VirtualizedListHandle<T> = FlashList<T>;
 
-export type VirtualizedListProps<T> = Omit<FlashListProps<T>, 'estimatedItemSize'> & {
+export type VirtualizedListProps<T> = Omit<FlashListProps<T>, 'estimatedItemSize' | 'style'> & {
   estimatedItemSize?: number;
   overscan?: number;
 };


### PR DESCRIPTION
## Summary
- remove unsupported `style` props from VirtualizedList usages across Akari screens and profile tabs to avoid FlashList warnings
- drop the now-unused style definitions associated with those lists

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d8167d872c832ba9e16d1b5fad5ed7