### PR TITLE
fix: allow release deploy workflow to write contents

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,8 @@ jobs:
   deploy:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: write
     uses: ./.github/workflows/release.yml
     with:
       release_tag: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
## Summary
- grant the reusable deploy workflow write access when triggered by release-please to satisfy its job requirements

------
https://chatgpt.com/codex/tasks/task_e_68d81d6b62a0832b887c0a8a549df8fe