### PR TITLE
fix: refresh Bluesky sessions within client

### DIFF
--- a/apps/akari/__tests__/hooks/mutations/useRefreshSession.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useRefreshSession.test.tsx
@@ -60,6 +60,7 @@ describe('useRefreshSession mutation hook', () => {
       refreshToken: 'refresh',
       did: 'did',
       handle: 'handle',
+      pdsUrl: 'url',
     });
     expect(invalidateSpy).toHaveBeenCalled();
   });

--- a/apps/akari/__tests__/hooks/queries/useAccountProfiles.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useAccountProfiles.test.tsx
@@ -5,6 +5,7 @@ import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { useAccountProfiles } from '@/hooks/queries/useAccountProfiles';
 import { useAccounts } from '@/hooks/queries/useAccounts';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 
 const mockGetProfile = jest.fn();
 const mockBlueskyApi = jest.fn(() => ({ getProfile: mockGetProfile }));
@@ -15,6 +16,10 @@ jest.mock('@/hooks/queries/useAccounts', () => ({
 
 jest.mock('@/hooks/queries/useJwtToken', () => ({
   useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
 }));
 
 jest.mock('@/bluesky-api', () => ({
@@ -35,6 +40,7 @@ describe('useAccountProfiles', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did1' } });
   });
 
   it('returns empty object when no accounts', async () => {
@@ -81,8 +87,12 @@ describe('useAccountProfiles', () => {
     });
 
     expect(mockBlueskyApi).toHaveBeenCalledTimes(2);
-    expect(mockBlueskyApi).toHaveBeenNthCalledWith(1, 'https://pds1');
-    expect(mockBlueskyApi).toHaveBeenNthCalledWith(2, 'https://pds2');
+
+    const [[firstUrl, firstOptions], [secondUrl, secondOptions]] = mockBlueskyApi.mock.calls;
+    expect(firstUrl).toBe('https://pds1');
+    expect(firstOptions).toEqual({});
+    expect(secondUrl).toBe('https://pds2');
+    expect(secondOptions).toEqual({});
     expect(mockGetProfile).toHaveBeenNthCalledWith(1, 'token1', 'alice');
     expect(mockGetProfile).toHaveBeenNthCalledWith(2, 'token2', 'bob');
   });

--- a/apps/akari/__tests__/hooks/queries/usePostThread.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/usePostThread.test.tsx
@@ -57,7 +57,9 @@ describe('usePostThread', () => {
       expect(result.current.data).toEqual(mockThread);
     });
 
-    expect(jest.mocked(BlueskyApi)).toHaveBeenCalledWith('https://pds');
+    const [[pdsUrl, options]] = jest.mocked(BlueskyApi).mock.calls;
+    expect(pdsUrl).toBe('https://pds');
+    expect(options).toEqual({});
     expect(mockGetPostThread).toHaveBeenCalledWith('token', 'at://post/1');
   });
 

--- a/apps/akari/__tests__/hooks/queries/useUnreadMessagesCount.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useUnreadMessagesCount.test.tsx
@@ -55,7 +55,9 @@ describe('useUnreadMessagesCount', () => {
       expect(result.current.data).toBe(5);
     });
 
-    expect(mockBlueskyApi).toHaveBeenCalledWith('https://pds');
+    const [[pdsUrl, options]] = mockBlueskyApi.mock.calls;
+    expect(pdsUrl).toBe('https://pds');
+    expect(options).toEqual({});
     expect(mockListConversations).toHaveBeenCalledWith(
       'token',
       100,

--- a/apps/akari/hooks/mutations/useBlockUser.ts
+++ b/apps/akari/hooks/mutations/useBlockUser.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Mutation hook for blocking and unblocking users
@@ -20,6 +21,7 @@ export function useBlockUser() {
   const queryClient = useQueryClient();
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useMutation({
     mutationKey: ['blockUser'],
@@ -27,7 +29,7 @@ export function useBlockUser() {
       if (!token) throw new Error('No access token');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
 
       if (action === 'block') {
         return await api.blockUser(token, did);

--- a/apps/akari/hooks/mutations/useCreatePost.ts
+++ b/apps/akari/hooks/mutations/useCreatePost.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Mutation hook for creating posts
@@ -27,6 +28,7 @@ export function useCreatePost() {
   const queryClient = useQueryClient();
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useMutation({
     mutationKey: ['createPost'],
@@ -35,7 +37,7 @@ export function useCreatePost() {
       if (!currentAccount?.did) throw new Error('No user DID available');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       return await api.createPost(token, currentAccount.did, {
         text,
         replyTo,

--- a/apps/akari/hooks/mutations/useFollowUser.ts
+++ b/apps/akari/hooks/mutations/useFollowUser.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Mutation hook for following and unfollowing users
@@ -11,6 +12,7 @@ export function useFollowUser() {
   const queryClient = useQueryClient();
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useMutation({
     mutationKey: ['followUser'],
@@ -29,7 +31,7 @@ export function useFollowUser() {
       if (!token) throw new Error('No access token');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
 
       if (action === 'follow') {
         return await api.followUser(token, did);

--- a/apps/akari/hooks/mutations/useLikePost.ts
+++ b/apps/akari/hooks/mutations/useLikePost.ts
@@ -10,6 +10,7 @@ import type {
   BlueskyUnlikeResponse,
 } from '@/bluesky-api';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Mutation hook for liking and unliking posts
@@ -18,6 +19,7 @@ export function useLikePost() {
   const queryClient = useQueryClient();
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useMutation({
     mutationFn: async ({
@@ -39,7 +41,7 @@ export function useLikePost() {
       if (!currentAccount?.did) throw new Error('No user DID available');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
 
       if (action === 'like') {
         if (!postCid) throw new Error('Post CID is required for like');

--- a/apps/akari/hooks/mutations/useRefreshSession.ts
+++ b/apps/akari/hooks/mutations/useRefreshSession.ts
@@ -32,6 +32,7 @@ export function useRefreshSession() {
         refreshToken: session.refreshJwt,
         did: session.did,
         handle: session.handle,
+        pdsUrl: currentAccount?.pdsUrl,
       });
 
       // Invalidate auth queries with the new user-specific key

--- a/apps/akari/hooks/mutations/useSendMessage.ts
+++ b/apps/akari/hooks/mutations/useSendMessage.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Mutation hook for sending messages in conversations
@@ -18,6 +19,7 @@ export function useSendMessage() {
   const queryClient = useQueryClient();
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useMutation({
     mutationKey: ['sendMessage'],
@@ -26,7 +28,7 @@ export function useSendMessage() {
       if (!currentAccount?.did) throw new Error('No user DID available');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       return await api.sendMessage(token, convoId, { text });
     },
     onMutate: async ({ convoId, text }) => {

--- a/apps/akari/hooks/mutations/useUpdateProfile.ts
+++ b/apps/akari/hooks/mutations/useUpdateProfile.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Mutation hook for updating user profile information
@@ -11,6 +12,7 @@ export function useUpdateProfile() {
   const queryClient = useQueryClient();
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useMutation({
     mutationKey: ['updateProfile'],
@@ -28,7 +30,7 @@ export function useUpdateProfile() {
       if (!token) throw new Error('No access token');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       return await api.updateProfile(token, {
         displayName,
         description,

--- a/apps/akari/hooks/queries/useAccountProfiles.ts
+++ b/apps/akari/hooks/queries/useAccountProfiles.ts
@@ -2,6 +2,8 @@ import { BlueskyApi } from '@/bluesky-api';
 import { useQuery } from '@tanstack/react-query';
 import { useAccounts } from './useAccounts';
 import { useJwtToken } from './useJwtToken';
+import { useCurrentAccount } from './useCurrentAccount';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Hook to fetch profile data for all accounts (for account switcher UI)
@@ -9,6 +11,8 @@ import { useJwtToken } from './useJwtToken';
 export function useAccountProfiles() {
   const { data: accounts } = useAccounts();
   const { data: token } = useJwtToken();
+  const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useQuery({
     queryKey: ['accountProfiles', accounts?.map((a) => a.did)],
@@ -24,7 +28,8 @@ export function useAccountProfiles() {
             console.warn(`No PDS URL for account ${account.handle}, skipping profile fetch`);
             continue;
           }
-          const api = new BlueskyApi(account.pdsUrl);
+          const isCurrentAccount = account.did === currentAccount?.did;
+          const api = new BlueskyApi(account.pdsUrl, isCurrentAccount ? apiOptions : {});
           const profile = await api.getProfile(account.jwtToken, account.handle);
 
           if (profile) {

--- a/apps/akari/hooks/queries/useAuthStatus.ts
+++ b/apps/akari/hooks/queries/useAuthStatus.ts
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useCurrentAccount } from './useCurrentAccount';
 import { useJwtToken } from './useJwtToken';
 import { useRefreshToken } from './useRefreshToken';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Query hook for checking authentication status
@@ -16,6 +17,7 @@ export function useAuthStatus() {
   const { data: currentAccount } = useCurrentAccount();
   const setAuthMutation = useSetAuthentication();
   const clearAuthMutation = useClearAuthentication();
+  const apiOptions = useAuthenticatedBluesky();
 
   const currentUserDid = currentAccount?.did || null;
 
@@ -31,7 +33,7 @@ export function useAuthStatus() {
         if (!currentAccount?.pdsUrl) {
           throw new Error('No PDS URL available for this account');
         }
-        const api = new BlueskyApi(currentAccount.pdsUrl);
+        const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
         const session = await api.refreshSession(refreshToken);
 
         // Update stored tokens with fresh ones

--- a/apps/akari/hooks/queries/useAuthorFeeds.ts
+++ b/apps/akari/hooks/queries/useAuthorFeeds.ts
@@ -4,6 +4,7 @@ import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { CursorPageParam } from '@/hooks/queries/types';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Infinite query hook for fetching feeds created by a user
@@ -13,6 +14,7 @@ import { BlueskyApi } from '@/bluesky-api';
 export function useAuthorFeeds(identifier: string | undefined, limit: number = 50) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useInfiniteQuery({
     queryKey: ['authorFeeds', identifier, limit, currentAccount?.pdsUrl],
@@ -21,7 +23,7 @@ export function useAuthorFeeds(identifier: string | undefined, limit: number = 5
       if (!identifier) throw new Error('No identifier provided');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       const feeds = await api.getAuthorFeeds(token, identifier, limit, pageParam);
 
       return {

--- a/apps/akari/hooks/queries/useAuthorLikes.ts
+++ b/apps/akari/hooks/queries/useAuthorLikes.ts
@@ -4,6 +4,7 @@ import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { CursorPageParam } from '@/hooks/queries/types';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Infinite query hook for fetching posts that a user has liked
@@ -13,6 +14,7 @@ import { BlueskyApi } from '@/bluesky-api';
 export function useAuthorLikes(identifier: string | undefined, limit: number = 20) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useInfiniteQuery({
     queryKey: ['authorLikes', identifier, limit, currentAccount?.pdsUrl],
@@ -21,7 +23,7 @@ export function useAuthorLikes(identifier: string | undefined, limit: number = 2
       if (!identifier) throw new Error('No identifier provided');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       const feed = await api.getAuthorFeed(token, identifier, limit, pageParam);
 
       // Filter to only show posts that the user has liked

--- a/apps/akari/hooks/queries/useAuthorMedia.ts
+++ b/apps/akari/hooks/queries/useAuthorMedia.ts
@@ -4,6 +4,7 @@ import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { CursorPageParam } from '@/hooks/queries/types';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Infinite query hook for fetching a user's posts with media
@@ -13,6 +14,7 @@ import { BlueskyApi } from '@/bluesky-api';
 export function useAuthorMedia(identifier: string | undefined, limit: number = 20) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useInfiniteQuery({
     queryKey: ['authorMedia', identifier, limit, currentAccount?.pdsUrl],
@@ -21,7 +23,7 @@ export function useAuthorMedia(identifier: string | undefined, limit: number = 2
       if (!identifier) throw new Error('No identifier provided');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       const feed = await api.getAuthorFeed(token, identifier, limit, pageParam, 'posts_with_media');
 
       // Map the feed items to posts (they should already be filtered for media by the API)

--- a/apps/akari/hooks/queries/useAuthorPosts.ts
+++ b/apps/akari/hooks/queries/useAuthorPosts.ts
@@ -4,6 +4,7 @@ import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { CursorPageParam } from '@/hooks/queries/types';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Infinite query hook for fetching a user's original posts (not replies or reposts)
@@ -13,6 +14,7 @@ import { BlueskyApi } from '@/bluesky-api';
 export function useAuthorPosts(identifier: string | undefined, limit: number = 20) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useInfiniteQuery({
     queryKey: ['authorPosts', identifier, limit, currentAccount?.pdsUrl],
@@ -21,7 +23,7 @@ export function useAuthorPosts(identifier: string | undefined, limit: number = 2
       if (!identifier) throw new Error('No identifier provided');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       const feed = await api.getAuthorFeed(token, identifier, limit, pageParam);
 
       // Filter to only show original posts (not reposts or replies)

--- a/apps/akari/hooks/queries/useAuthorReplies.ts
+++ b/apps/akari/hooks/queries/useAuthorReplies.ts
@@ -4,6 +4,7 @@ import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { CursorPageParam } from '@/hooks/queries/types';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Infinite query hook for fetching a user's replies
@@ -13,6 +14,7 @@ import { BlueskyApi } from '@/bluesky-api';
 export function useAuthorReplies(identifier: string | undefined, limit: number = 20) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useInfiniteQuery({
     queryKey: ['authorReplies', identifier, limit, currentAccount?.pdsUrl],
@@ -21,7 +23,7 @@ export function useAuthorReplies(identifier: string | undefined, limit: number =
       if (!identifier) throw new Error('No identifier provided');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       const feed = await api.getAuthorFeed(token, identifier, limit, pageParam, 'posts_with_replies');
 
       // Map the feed items to posts (they should already be filtered for replies by the API)

--- a/apps/akari/hooks/queries/useAuthorStarterpacks.ts
+++ b/apps/akari/hooks/queries/useAuthorStarterpacks.ts
@@ -4,6 +4,7 @@ import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { CursorPageParam } from '@/hooks/queries/types';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Infinite query hook for fetching starterpacks created by a user
@@ -13,6 +14,7 @@ import { BlueskyApi } from '@/bluesky-api';
 export function useAuthorStarterpacks(identifier: string | undefined, limit: number = 50) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useInfiniteQuery({
     queryKey: ['authorStarterpacks', identifier, limit, currentAccount?.pdsUrl],
@@ -21,7 +23,7 @@ export function useAuthorStarterpacks(identifier: string | undefined, limit: num
       if (!identifier) throw new Error('No identifier provided');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       const starterpacks = await api.getAuthorStarterpacks(token, identifier, limit, pageParam);
 
       return {

--- a/apps/akari/hooks/queries/useAuthorVideos.ts
+++ b/apps/akari/hooks/queries/useAuthorVideos.ts
@@ -4,6 +4,7 @@ import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { CursorPageParam } from '@/hooks/queries/types';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Infinite query hook for fetching a user's posts with videos
@@ -13,6 +14,7 @@ import { BlueskyApi } from '@/bluesky-api';
 export function useAuthorVideos(identifier: string | undefined, limit: number = 20) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useInfiniteQuery({
     queryKey: ['authorVideos', identifier, limit, currentAccount?.pdsUrl],
@@ -21,7 +23,7 @@ export function useAuthorVideos(identifier: string | undefined, limit: number = 
       if (!identifier) throw new Error('No identifier provided');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       const feed = await api.getAuthorVideos(token, identifier, limit, pageParam);
 
       // Map the feed items to posts (they should already be filtered for videos by the API)

--- a/apps/akari/hooks/queries/useBookmarks.ts
+++ b/apps/akari/hooks/queries/useBookmarks.ts
@@ -5,6 +5,7 @@ import type { BlueskyBookmarksResponse } from '@/bluesky-api';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { CursorPageParam } from '@/hooks/queries/types';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Infinite query hook for fetching the authenticated user's bookmarks
@@ -13,6 +14,7 @@ import { CursorPageParam } from '@/hooks/queries/types';
 export function useBookmarks(limit: number = 20) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useInfiniteQuery<BlueskyBookmarksResponse>({
     queryKey: ['bookmarks', limit, currentAccount?.did],
@@ -20,7 +22,7 @@ export function useBookmarks(limit: number = 20) {
       if (!token) throw new Error('No access token');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       return await api.getBookmarks(token, limit, pageParam);
     },
     enabled: !!token && !!currentAccount?.did,

--- a/apps/akari/hooks/queries/useConversations.ts
+++ b/apps/akari/hooks/queries/useConversations.ts
@@ -3,6 +3,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 type ConversationError = {
   type: 'permission' | 'network' | 'unknown';
@@ -24,6 +25,7 @@ export function useConversations(
 ) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
   const currentUserDid = currentAccount?.did;
 
   return useInfiniteQuery({
@@ -33,7 +35,7 @@ export function useConversations(
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
       try {
-        const api = new BlueskyApi(currentAccount.pdsUrl);
+        const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
         const response = await api.listConversations(
           token,
           limit,

--- a/apps/akari/hooks/queries/useFeed.ts
+++ b/apps/akari/hooks/queries/useFeed.ts
@@ -4,6 +4,7 @@ import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { CursorPageParam } from '@/hooks/queries/types';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Infinite query hook for fetching feed posts
@@ -13,6 +14,7 @@ import { BlueskyApi } from '@/bluesky-api';
 export function useFeed(feedUri: string | null, limit: number = 20) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useInfiniteQuery({
     queryKey: ['feed', feedUri, currentAccount?.pdsUrl],
@@ -21,7 +23,7 @@ export function useFeed(feedUri: string | null, limit: number = 20) {
       if (!feedUri) throw new Error('No feed URI provided');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       return await api.getFeed(token, feedUri, limit, pageParam);
     },
     enabled: !!feedUri && !!token,

--- a/apps/akari/hooks/queries/useFeedGenerators.ts
+++ b/apps/akari/hooks/queries/useFeedGenerators.ts
@@ -1,18 +1,24 @@
-import { BlueskyApi, type BlueskyFeed } from '@/bluesky-api';
+import { BlueskyApi, type BlueskyApiClientOptions, type BlueskyFeed } from '@/bluesky-api';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { useQuery } from '@tanstack/react-query';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 const FEED_GENERATORS_STALE_TIME = 10 * 60 * 1000; // 10 minutes
 
-export const feedGeneratorsQueryOptions = (feedUris: string[], token: string, pdsUrl: string) => ({
+export const feedGeneratorsQueryOptions = (
+  feedUris: string[],
+  token: string,
+  pdsUrl: string,
+  apiOptions: BlueskyApiClientOptions,
+) => ({
   queryKey: ['feedGenerators', feedUris, pdsUrl] as const,
   queryFn: async (): Promise<{ feeds: BlueskyFeed[] }> => {
     if (!token) throw new Error('No access token');
     if (!pdsUrl) throw new Error('No PDS URL available');
     if (feedUris.length === 0) return { feeds: [] };
 
-    const api = new BlueskyApi(pdsUrl);
+    const api = new BlueskyApi(pdsUrl, apiOptions);
     return await api.getFeedGenerators(token, feedUris);
   },
   staleTime: FEED_GENERATORS_STALE_TIME,
@@ -25,9 +31,10 @@ export const feedGeneratorsQueryOptions = (feedUris: string[], token: string, pd
 export function useFeedGenerators(feedUris: string[]) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useQuery({
-    ...feedGeneratorsQueryOptions(feedUris, token ?? '', currentAccount?.pdsUrl ?? ''),
+    ...feedGeneratorsQueryOptions(feedUris, token ?? '', currentAccount?.pdsUrl ?? '', apiOptions),
     enabled: !!token && !!currentAccount?.pdsUrl && feedUris.length > 0,
   });
 }

--- a/apps/akari/hooks/queries/useFeeds.ts
+++ b/apps/akari/hooks/queries/useFeeds.ts
@@ -1,6 +1,7 @@
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { BlueskyApi, type BlueskyFeedsResponse } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 import { useQuery } from '@tanstack/react-query';
 
 /**
@@ -12,6 +13,7 @@ import { useQuery } from '@tanstack/react-query';
 export function useFeeds(actor: string | undefined, limit: number = 50, cursor?: string) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useQuery({
     queryKey: ['feeds', actor, limit, cursor, currentAccount?.pdsUrl],
@@ -20,7 +22,7 @@ export function useFeeds(actor: string | undefined, limit: number = 50, cursor?:
       if (!actor) throw new Error('No actor provided');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       return await api.getFeeds(token, actor, limit, cursor);
     },
     enabled: !!actor && !!token,

--- a/apps/akari/hooks/queries/useMessages.ts
+++ b/apps/akari/hooks/queries/useMessages.ts
@@ -3,6 +3,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 type MessageError = {
   type: 'permission' | 'network' | 'unknown';
@@ -17,6 +18,7 @@ type MessageError = {
 export function useMessages(convoId: string | undefined, limit: number = 50) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
   const currentUserDid = currentAccount?.did;
 
   return useInfiniteQuery({
@@ -27,7 +29,7 @@ export function useMessages(convoId: string | undefined, limit: number = 50) {
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
       try {
-        const api = new BlueskyApi(currentAccount.pdsUrl);
+        const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
         const response = await api.getMessages(
           token,
           convoId,

--- a/apps/akari/hooks/queries/useNotifications.ts
+++ b/apps/akari/hooks/queries/useNotifications.ts
@@ -4,6 +4,7 @@ import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { BlueskyEmbed } from '@/bluesky-api';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 type NotificationError = {
   type: 'permission' | 'network' | 'unknown';
@@ -21,6 +22,7 @@ export function useNotifications(limit: number = 50, reasons?: string[], priorit
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
   const currentUserDid = currentAccount?.did;
+  const apiOptions = useAuthenticatedBluesky();
 
   return useInfiniteQuery({
     queryKey: ['notifications', limit, reasons, priority, currentUserDid],
@@ -29,7 +31,7 @@ export function useNotifications(limit: number = 50, reasons?: string[], priorit
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
       try {
-        const api = new BlueskyApi(currentAccount.pdsUrl);
+        const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
         const response = await api.listNotifications(
           token,
           limit,

--- a/apps/akari/hooks/queries/usePost.ts
+++ b/apps/akari/hooks/queries/usePost.ts
@@ -3,10 +3,12 @@ import { useQuery } from "@tanstack/react-query";
 import { useJwtToken } from "@/hooks/queries/useJwtToken";
 import { useCurrentAccount } from "@/hooks/queries/useCurrentAccount";
 import { BlueskyApi } from "@/bluesky-api";
+import { useAuthenticatedBluesky } from "@/hooks/useAuthenticatedBluesky";
 
 export function usePost(postUri: string | null) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useQuery({
     queryKey: ["post", postUri, currentAccount?.pdsUrl],
@@ -14,7 +16,7 @@ export function usePost(postUri: string | null) {
       if (!token || !postUri) throw new Error("No access token or post URI");
       if (!currentAccount?.pdsUrl) throw new Error("No PDS URL available");
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       return await api.getPost(token, postUri);
     },
     enabled: !!postUri,
@@ -28,6 +30,7 @@ export function usePost(postUri: string | null) {
 export function useParentPost(parentUri: string | null) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   const {
     data: parentPost,
@@ -39,7 +42,7 @@ export function useParentPost(parentUri: string | null) {
       if (!parentUri) return null;
       if (!token) throw new Error("No access token");
       if (!currentAccount?.pdsUrl) throw new Error("No PDS URL available");
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       const result = await api.getPost(token, parentUri);
       return result;
     },
@@ -55,6 +58,7 @@ export function useParentPost(parentUri: string | null) {
 export function useRootPost(rootUri: string | null) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   const {
     data: rootPost,
@@ -66,7 +70,7 @@ export function useRootPost(rootUri: string | null) {
       if (!rootUri) return null;
       if (!token) throw new Error("No access token");
       if (!currentAccount?.pdsUrl) throw new Error("No PDS URL available");
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       const result = await api.getPost(token, rootUri);
       return result;
     },

--- a/apps/akari/hooks/queries/usePostThread.ts
+++ b/apps/akari/hooks/queries/usePostThread.ts
@@ -3,10 +3,12 @@ import { useQuery } from "@tanstack/react-query";
 import { useJwtToken } from "@/hooks/queries/useJwtToken";
 import { useCurrentAccount } from "@/hooks/queries/useCurrentAccount";
 import { BlueskyApi } from "@/bluesky-api";
+import { useAuthenticatedBluesky } from "@/hooks/useAuthenticatedBluesky";
 
 export function usePostThread(postUri: string | null) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useQuery({
     queryKey: ["postThread", postUri, currentAccount?.pdsUrl],
@@ -14,7 +16,7 @@ export function usePostThread(postUri: string | null) {
       if (!token || !postUri) throw new Error("No access token or post URI");
       if (!currentAccount?.pdsUrl) throw new Error("No PDS URL available");
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       return await api.getPostThread(token, postUri);
     },
     enabled: !!postUri && !!token,

--- a/apps/akari/hooks/queries/useProfile.ts
+++ b/apps/akari/hooks/queries/useProfile.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { useJwtToken } from "@/hooks/queries/useJwtToken";
 import { BlueskyApi } from "@/bluesky-api";
+import { useAuthenticatedBluesky } from "@/hooks/useAuthenticatedBluesky";
 import { useCurrentAccount } from "./useCurrentAccount";
 
 /**
@@ -11,6 +12,7 @@ import { useCurrentAccount } from "./useCurrentAccount";
 export function useProfile(identifier: string | undefined) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useQuery({
     queryKey: ["profile", identifier, currentAccount?.pdsUrl],
@@ -19,7 +21,7 @@ export function useProfile(identifier: string | undefined) {
       if (!identifier) throw new Error("No identifier provided");
       if (!currentAccount?.pdsUrl) throw new Error("No PDS URL available");
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       const profile = await api.getProfile(token, identifier);
 
       return profile;

--- a/apps/akari/hooks/queries/useSearch.ts
+++ b/apps/akari/hooks/queries/useSearch.ts
@@ -3,6 +3,7 @@ import { useCurrentAccount } from "@/hooks/queries/useCurrentAccount";
 import { CursorPageParam } from "@/hooks/queries/types";
 import { BlueskyPostView, BlueskyProfile } from "@/utils/bluesky/types";
 import { BlueskyApi } from "@/bluesky-api";
+import { useAuthenticatedBluesky } from "@/hooks/useAuthenticatedBluesky";
 import { useInfiniteQuery } from "@tanstack/react-query";
 
 type SearchTabType = "all" | "users" | "posts";
@@ -31,6 +32,7 @@ export function useSearch(
 ) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
 
   return useInfiniteQuery({
     queryKey: ["search", query, activeTab, limit, currentAccount?.pdsUrl],
@@ -39,7 +41,7 @@ export function useSearch(
       if (!query) throw new Error("No query provided");
       if (!currentAccount?.pdsUrl) throw new Error("No PDS URL available");
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
 
       try {
         // Check if this is a "from:handle" search

--- a/apps/akari/hooks/queries/useTimeline.ts
+++ b/apps/akari/hooks/queries/useTimeline.ts
@@ -2,6 +2,7 @@ import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { useQuery } from '@tanstack/react-query';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Query hook for fetching the user's timeline feed
@@ -11,6 +12,7 @@ import { BlueskyApi } from '@/bluesky-api';
 export function useTimeline(limit: number = 20, enabled: boolean = true) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
+  const apiOptions = useAuthenticatedBluesky();
   const currentUserDid = currentAccount?.did;
 
   return useQuery({
@@ -19,7 +21,7 @@ export function useTimeline(limit: number = 20, enabled: boolean = true) {
       if (!token) throw new Error('No access token');
       if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
 
-      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
       return await api.getTimeline(token, limit);
     },
     enabled: enabled && !!token && !!currentUserDid,

--- a/apps/akari/hooks/queries/useUnreadMessagesCount.ts
+++ b/apps/akari/hooks/queries/useUnreadMessagesCount.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Hook to get the total count of unread messages across all conversations
@@ -12,6 +13,7 @@ export function useUnreadMessagesCount(enabled: boolean = true) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
   const currentUserDid = currentAccount?.did;
+  const apiOptions = useAuthenticatedBluesky();
 
   return useQuery({
     queryKey: ['unreadMessagesCount', currentUserDid],
@@ -21,7 +23,7 @@ export function useUnreadMessagesCount(enabled: boolean = true) {
 
       try {
         // Fetch conversations to get unread counts
-        const api = new BlueskyApi(currentAccount.pdsUrl);
+        const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
         const response = await api.listConversations(
           token,
           100, // Fetch up to 100 conversations to get a good sample

--- a/apps/akari/hooks/queries/useUnreadNotificationsCount.ts
+++ b/apps/akari/hooks/queries/useUnreadNotificationsCount.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { BlueskyApi } from '@/bluesky-api';
+import { useAuthenticatedBluesky } from '@/hooks/useAuthenticatedBluesky';
 
 /**
  * Hook to get the count of unread notifications
@@ -12,6 +13,7 @@ export function useUnreadNotificationsCount(enabled: boolean = true) {
   const { data: token } = useJwtToken();
   const { data: currentAccount } = useCurrentAccount();
   const currentUserDid = currentAccount?.did;
+  const apiOptions = useAuthenticatedBluesky();
 
   return useQuery({
     queryKey: ['unreadNotificationsCount', currentUserDid],
@@ -21,7 +23,7 @@ export function useUnreadNotificationsCount(enabled: boolean = true) {
 
       try {
         // Use the dedicated unread count endpoint
-        const api = new BlueskyApi(currentAccount.pdsUrl);
+        const api = new BlueskyApi(currentAccount.pdsUrl, apiOptions);
         const response = await api.getUnreadNotificationsCount(token);
         return response.count;
       } catch (error: unknown) {

--- a/apps/akari/hooks/useAuthenticatedBluesky.ts
+++ b/apps/akari/hooks/useAuthenticatedBluesky.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { useSetAuthentication } from '@/hooks/mutations/useSetAuthentication';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useRefreshToken } from '@/hooks/queries/useRefreshToken';
+import type { BlueskyApiClientOptions, BlueskySession } from '@/bluesky-api';
+
+/**
+ * Provides Bluesky API client options that supply refresh metadata for automatic retries.
+ */
+export function useAuthenticatedBluesky(): BlueskyApiClientOptions {
+  const { data: refreshToken } = useRefreshToken();
+  const { data: currentAccount } = useCurrentAccount();
+  const setAuthentication = useSetAuthentication();
+  const queryClient = useQueryClient();
+
+  return useMemo<BlueskyApiClientOptions>(() => {
+    if (!refreshToken) {
+      return {};
+    }
+
+    const persistSession = async (session: BlueskySession) => {
+      await setAuthentication.mutateAsync({
+        token: session.accessJwt,
+        refreshToken: session.refreshJwt,
+        did: session.did,
+        handle: session.handle,
+        pdsUrl: currentAccount?.pdsUrl,
+      });
+
+      queryClient.invalidateQueries({ queryKey: ['auth', session.did] });
+    };
+
+    return {
+      getRefreshToken: async () => refreshToken,
+      onSessionRefreshed: persistSession,
+    } satisfies BlueskyApiClientOptions;
+  }, [currentAccount?.pdsUrl, queryClient, refreshToken, setAuthentication]);
+}

--- a/apps/akari/jest.setup.js
+++ b/apps/akari/jest.setup.js
@@ -31,13 +31,20 @@ jest.mock('@/contexts/ToastContext', () => ({
   useToast: jest.fn(() => mockToastContext),
 }));
 
+const mockUseAuthenticatedBluesky = jest.fn(() => ({}));
+
+jest.mock('@/hooks/useAuthenticatedBluesky', () => ({
+  __esModule: true,
+  useAuthenticatedBluesky: mockUseAuthenticatedBluesky,
+}));
+
 const { act } = require('@testing-library/react-native');
 const { useToast } = require('@/contexts/ToastContext');
-
 beforeEach(() => {
   mockToastContext.showToast = jest.fn();
   mockToastContext.hideToast = jest.fn();
   useToast.mockReturnValue(mockToastContext);
+  mockUseAuthenticatedBluesky.mockReturnValue({});
   jest.useFakeTimers();
 });
 

--- a/packages/bluesky-api/jest.config.cjs
+++ b/packages/bluesky-api/jest.config.cjs
@@ -28,7 +28,7 @@ module.exports = {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   transform: {
-    '^.+\\.m?tsx?$': [
+    '^.+\\.m?[tj]sx?$': [
       'ts-jest',
       {
         useESM: true,
@@ -36,5 +36,6 @@ module.exports = {
       },
     ],
   },
+  transformIgnorePatterns: ['/node_modules/(?!(msw|@mswjs/.*|until-async)/)'],
   ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
 };

--- a/packages/bluesky-api/src/actors.ts
+++ b/packages/bluesky-api/src/actors.ts
@@ -1,4 +1,4 @@
-import { BlueskyApiClient } from './client';
+import { BlueskyApiClient, type BlueskyApiClientOptions } from './client';
 import type {
   BlueskyPreferencesResponse,
   BlueskyProfileResponse,
@@ -9,6 +9,10 @@ import type {
  * Bluesky API actor/profile methods
  */
 export class BlueskyActors extends BlueskyApiClient {
+  constructor(pdsUrl: string, options: BlueskyApiClientOptions = {}) {
+    super(pdsUrl, options);
+  }
+
   /**
    * Gets a user's profile information
    * @param accessJwt - Valid access JWT token

--- a/packages/bluesky-api/src/auth.ts
+++ b/packages/bluesky-api/src/auth.ts
@@ -1,10 +1,14 @@
-import { BlueskyApiClient } from "./client";
+import { BlueskyApiClient, type BlueskyApiClientOptions } from "./client";
 import type { BlueskySession } from "./types";
 
 /**
  * Bluesky API authentication methods
  */
 export class BlueskyAuth extends BlueskyApiClient {
+  constructor(pdsUrl: string, options: BlueskyApiClientOptions = {}) {
+    super(pdsUrl, options);
+  }
+
   /**
    * Creates a new session with the Bluesky API
    * @param identifier - User's handle or email

--- a/packages/bluesky-api/src/conversations.ts
+++ b/packages/bluesky-api/src/conversations.ts
@@ -1,4 +1,4 @@
-import { BlueskyApiClient } from './client';
+import { BlueskyApiClient, type BlueskyApiClientOptions } from './client';
 import type {
   BlueskyConvosResponse,
   BlueskyMessagesResponse,
@@ -10,6 +10,10 @@ import type {
  * Bluesky API conversation methods
  */
 export class BlueskyConversations extends BlueskyApiClient {
+  constructor(pdsUrl: string, options: BlueskyApiClientOptions = {}) {
+    super(pdsUrl, options);
+  }
+
   /**
    * Gets a list of conversations
    * @param accessJwt - Valid access JWT token

--- a/packages/bluesky-api/src/feeds.ts
+++ b/packages/bluesky-api/src/feeds.ts
@@ -1,4 +1,4 @@
-import { BlueskyApiClient } from './client';
+import { BlueskyApiClient, type BlueskyApiClientOptions } from './client';
 import type {
   BlueskyBookmarksResponse,
   BlueskyFeedResponse,
@@ -19,6 +19,10 @@ import type {
  * Bluesky API feed methods
  */
 export class BlueskyFeeds extends BlueskyApiClient {
+  constructor(pdsUrl: string, options: BlueskyApiClientOptions = {}) {
+    super(pdsUrl, options);
+  }
+
   /**
    * Gets the user's timeline feed
    * @param accessJwt - Valid access JWT token

--- a/packages/bluesky-api/src/graph.ts
+++ b/packages/bluesky-api/src/graph.ts
@@ -1,9 +1,13 @@
-import { BlueskyApiClient } from './client';
+import { BlueskyApiClient, type BlueskyApiClientOptions } from './client';
 
 /**
  * Bluesky API graph methods (follows, blocks, mutes, etc.)
  */
 export class BlueskyGraph extends BlueskyApiClient {
+  constructor(pdsUrl: string, options: BlueskyApiClientOptions = {}) {
+    super(pdsUrl, options);
+  }
+
   /**
    * Follows a user
    * @param accessJwt - Valid access JWT token

--- a/packages/bluesky-api/src/notifications.test.ts
+++ b/packages/bluesky-api/src/notifications.test.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 
 import { BlueskyNotifications } from './notifications';
+import { BlueskyRequestError } from './client';
 
 describe('BlueskyNotifications', () => {
   const server = setupServer();
@@ -50,7 +51,10 @@ describe('BlueskyNotifications', () => {
 
     const client = new BlueskyNotifications();
 
-    await expect(client.listNotifications('jwt-token')).rejects.toThrow('Request failed');
+    await expect(client.listNotifications('jwt-token')).rejects.toMatchObject<Partial<BlueskyRequestError>>({
+      message: 'Request failed',
+      status: 500,
+    });
   });
 
   it('fetches unread notification counts', async () => {

--- a/packages/bluesky-api/src/notifications.ts
+++ b/packages/bluesky-api/src/notifications.ts
@@ -1,14 +1,12 @@
+import { BlueskyApiClient, type BlueskyApiClientOptions } from './client';
 import type { BlueskyNotificationsResponse, BlueskyUnreadNotificationCount } from './types';
 
 /**
  * Bluesky notifications API client
  */
-export class BlueskyNotifications {
-  private pdsUrl: string;
-
-  constructor(pdsUrl: string = 'https://bsky.social') {
-    // Ensure the PDS URL doesn't end with /xrpc (it will be added in API calls)
-    this.pdsUrl = pdsUrl.endsWith('/xrpc') ? pdsUrl.slice(0, -5) : pdsUrl;
+export class BlueskyNotifications extends BlueskyApiClient {
+  constructor(pdsUrl: string = 'https://bsky.social', options: BlueskyApiClientOptions = {}) {
+    super(pdsUrl, options);
   }
 
   /**
@@ -28,31 +26,22 @@ export class BlueskyNotifications {
     priority?: boolean,
     seenAt?: string,
   ): Promise<BlueskyNotificationsResponse> {
-    const url = `${this.pdsUrl}/xrpc/app.bsky.notification.listNotifications`;
+    const params: Record<string, string | string[]> = {
+      limit: limit.toString(),
+    };
 
-    const params = new URLSearchParams();
-    if (limit) params.append('limit', limit.toString());
-    if (cursor) params.append('cursor', cursor);
-    if (priority !== undefined) params.append('priority', priority.toString());
-    if (seenAt) params.append('seenAt', seenAt);
+    if (cursor) params.cursor = cursor;
+    if (priority !== undefined) params.priority = priority.toString();
+    if (seenAt) params.seenAt = seenAt;
     if (reasons && reasons.length > 0) {
-      reasons.forEach((reason) => params.append('reasons', reason));
+      params.reasons = reasons;
     }
 
-    const response = await fetch(`${url}?${params.toString()}`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${accessJwt}`,
-        'Content-Type': 'application/json',
-      },
-    });
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || `HTTP ${response.status}: ${response.statusText}`);
-    }
-
-    return response.json();
+    return this.makeAuthenticatedRequest<BlueskyNotificationsResponse>(
+      '/app.bsky.notification.listNotifications',
+      accessJwt,
+      { params },
+    );
   }
 
   /**
@@ -61,21 +50,9 @@ export class BlueskyNotifications {
    * @returns Object containing the unread notification total.
    */
   async getUnreadCount(accessJwt: string): Promise<BlueskyUnreadNotificationCount> {
-    const url = `${this.pdsUrl}/xrpc/app.bsky.notification.getUnreadCount`;
-
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${accessJwt}`,
-        'Content-Type': 'application/json',
-      },
-    });
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || `HTTP ${response.status}: ${response.statusText}`);
-    }
-
-    return response.json();
+    return this.makeAuthenticatedRequest<BlueskyUnreadNotificationCount>(
+      '/app.bsky.notification.getUnreadCount',
+      accessJwt,
+    );
   }
 }

--- a/packages/bluesky-api/src/search.ts
+++ b/packages/bluesky-api/src/search.ts
@@ -1,4 +1,4 @@
-import { BlueskyApiClient } from "./client";
+import { BlueskyApiClient, type BlueskyApiClientOptions } from "./client";
 import type {
   BlueskySearchActorsResponse,
   BlueskySearchPostsResponse,
@@ -8,6 +8,10 @@ import type {
  * Bluesky API search methods
  */
 export class BlueskySearch extends BlueskyApiClient {
+  constructor(pdsUrl: string, options: BlueskyApiClientOptions = {}) {
+    super(pdsUrl, options);
+  }
+
   /**
    * Searches for profiles
    * @param accessJwt - Valid access JWT token


### PR DESCRIPTION
## Summary
- push the automatic session refresh logic into the Bluesky API client using refresh-token callbacks
- expose refresh metadata from `useAuthenticatedBluesky` so the app persists updated credentials after retries
- cover the retry behaviour with an integration test exercising the MSW-backed timeline call

## Testing
- npm run lint -- --filter=akari
- npm run test -- --filter=bluesky-api

------
https://chatgpt.com/codex/tasks/task_e_68d81463b0e4832ba677903757dacef2