### PR TITLE
fix: add background processing mode to Info.plist

### DIFF
--- a/apps/akari/app.json
+++ b/apps/akari/app.json
@@ -14,7 +14,8 @@
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "CFBundleAllowMixedLocalizations": true,
-        "ExpoLocalization_supportsRTL": true
+        "ExpoLocalization_supportsRTL": true,
+        "UIBackgroundModes": ["processing"]
       },
       "entitlements": {
         "aps-environment": "development",


### PR DESCRIPTION
## Summary
- add the required UIBackgroundModes entry so iOS background processing is permitted

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d82f188044832ba56fc299d266bd1c