### PR TITLE
feat: replace mobile tab bar with native tabs

### DIFF
--- a/apps/akari/__tests__/app/tabs-layout.test.tsx
+++ b/apps/akari/__tests__/app/tabs-layout.test.tsx
@@ -7,40 +7,73 @@ import { useAuthStatus } from '@/hooks/queries/useAuthStatus';
 import { useUnreadMessagesCount } from '@/hooks/queries/useUnreadMessagesCount';
 import { useUnreadNotificationsCount } from '@/hooks/queries/useUnreadNotificationsCount';
 import { useResponsive } from '@/hooks/useResponsive';
-import { TabBadge } from '@/components/TabBadge';
-import { useBorderColor } from '@/hooks/useBorderColor';
 import { useThemeColor } from '@/hooks/useThemeColor';
-import { useNavigationState } from '@react-navigation/native';
 import { tabScrollRegistry } from '@/utils/tabScrollRegistry';
+
+const navigationListeners: Record<string, (event: any) => void> = {};
+const createNavigationState = () => ({
+  index: 0,
+  routes: [
+    { key: 'index-key', name: 'index' },
+    { key: 'search-key', name: 'search' },
+    { key: 'messages-key', name: 'messages' },
+    { key: 'notifications-key', name: 'notifications' },
+    { key: 'bookmarks-key', name: 'bookmarks' },
+    { key: 'post-key', name: 'post' },
+    { key: 'profile-key', name: 'profile' },
+    { key: 'settings-key', name: 'settings' },
+  ],
+});
+let navigationState = createNavigationState();
+
+const addListenerMock = jest.fn((type: string, handler: (event: any) => void) => {
+  navigationListeners[type] = handler;
+  return () => {
+    delete navigationListeners[type];
+  };
+});
+
+const getStateMock = jest.fn(() => navigationState);
 
 jest.mock('expo-router', () => {
   const React = require('react');
   const { Text } = require('react-native');
   const Tabs = jest.fn(({ children }: { children: React.ReactNode }) => <>{children}</>);
   const Screen = jest.fn(() => null);
-  // @ts-ignore
   Tabs.Screen = Screen;
   const Redirect = ({ href }: { href: string }) => <Text>redirect:{href}</Text>;
-  return { Tabs, Redirect };
+  const useNavigation = jest.fn(() => ({
+    addListener: addListenerMock,
+    getState: getStateMock,
+  }));
+  return { Tabs, Redirect, useNavigation };
 });
 
-jest.mock('@react-navigation/native', () => ({
-  useNavigationState: jest.fn(),
+const NativeTabsMock = jest.fn(({ children }: { children: React.ReactNode }) => <>{children}</>);
+const TriggerMock = jest.fn(({ children }: { children?: React.ReactNode }) => <>{children}</>);
+(TriggerMock as any).TabBar = jest.fn(() => null);
+(NativeTabsMock as any).Trigger = TriggerMock;
+const IconMock = jest.fn(() => null);
+const LabelMock = jest.fn(({ children }: { children?: React.ReactNode }) => <>{children}</>);
+const BadgeMock = jest.fn(({ children, hidden }: { children?: React.ReactNode; hidden?: boolean }) =>
+  hidden ? null : <>{children}</>,
+);
+const VectorIconMock = jest.fn(() => null);
+
+jest.mock('expo-router/unstable-native-tabs', () => ({
+  NativeTabs: NativeTabsMock,
+  Icon: IconMock,
+  Label: LabelMock,
+  Badge: BadgeMock,
+  VectorIcon: VectorIconMock,
 }));
 
 jest.mock('@/hooks/queries/useAuthStatus');
 jest.mock('@/hooks/queries/useUnreadMessagesCount');
 jest.mock('@/hooks/queries/useUnreadNotificationsCount');
 jest.mock('@/hooks/useResponsive');
-jest.mock('@/hooks/useBorderColor');
 jest.mock('@/hooks/useThemeColor');
 jest.mock('@/hooks/usePushNotifications');
-
-jest.mock('@/components/HapticTab', () => {
-  const React = require('react');
-  const MockHapticTab = jest.fn(({ children }: { children?: React.ReactNode }) => <>{children}</>);
-  return { HapticTab: MockHapticTab };
-});
 
 jest.mock('@/components/AccountSwitcherSheet', () => {
   const React = require('react');
@@ -53,27 +86,10 @@ jest.mock('@/components/Sidebar', () => {
   return { Sidebar: () => <Text>Sidebar</Text> };
 });
 
-jest.mock('@/components/TabBadge', () => {
-  const React = require('react');
-  const { Text } = require('react-native');
-  return { TabBadge: jest.fn(({ count }: { count: number }) => <Text>badge{count}</Text>) };
-});
-
 jest.mock('@/components/ThemedView', () => {
   const React = require('react');
   const { View } = require('react-native');
   return { ThemedView: ({ children, ...props }: any) => <View {...props}>{children}</View> };
-});
-
-jest.mock('@/components/ui/IconSymbol', () => {
-  const React = require('react');
-  const { Text } = require('react-native');
-  return { IconSymbol: ({ name }: { name: string }) => <Text>{name}</Text> };
-});
-
-jest.mock('@/components/ui/TabBarBackground', () => {
-  const React = require('react');
-  return () => <></>;
 });
 
 jest.mock('@/utils/tabScrollRegistry', () => ({
@@ -86,33 +102,22 @@ const mockUseAuthStatus = useAuthStatus as jest.Mock;
 const mockUseUnreadMessagesCount = useUnreadMessagesCount as jest.Mock;
 const mockUseUnreadNotificationsCount = useUnreadNotificationsCount as jest.Mock;
 const mockUseResponsive = useResponsive as jest.Mock;
-const mockUseBorderColor = useBorderColor as jest.Mock;
 const mockUseThemeColor = useThemeColor as jest.Mock;
-const mockTabBadge = TabBadge as unknown as jest.Mock;
-const mockUseNavigationState = useNavigationState as jest.Mock;
 const mockHandleTabPress = tabScrollRegistry.handleTabPress as jest.Mock;
 
-const { HapticTab } = require('@/components/HapticTab');
-const mockHapticTab = HapticTab as jest.Mock;
 const { AccountSwitcherSheet } = require('@/components/AccountSwitcherSheet');
 const mockAccountSwitcherSheet = AccountSwitcherSheet as jest.Mock;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  navigationState = createNavigationState();
+  Object.keys(navigationListeners).forEach((event) => delete navigationListeners[event]);
   mockUseUnreadMessagesCount.mockReturnValue({ data: 0 });
   mockUseUnreadNotificationsCount.mockReturnValue({ data: 0 });
   mockUseResponsive.mockReturnValue({ isLargeScreen: false });
-  mockUseBorderColor.mockReturnValue('#ccc');
   mockUseThemeColor.mockImplementation(
     (props: { light?: string; dark?: string }) => props?.light ?? props?.dark ?? '#000',
   );
-  mockUseNavigationState.mockImplementation((selector: (state: any) => any) => {
-    const defaultState = {
-      index: 0,
-      routes: [{ name: 'index' }],
-    };
-    return selector ? selector(defaultState) : defaultState;
-  });
   mockAccountSwitcherSheet.mockClear();
 });
 
@@ -156,27 +161,13 @@ describe('TabLayout', () => {
 
   it('renders mobile tabs with badges', () => {
     mockUseAuthStatus.mockReturnValue({ data: { isAuthenticated: true }, isLoading: false });
-    mockUseResponsive.mockReturnValue({ isLargeScreen: false });
     mockUseUnreadMessagesCount.mockReturnValue({ data: 2 });
     mockUseUnreadNotificationsCount.mockReturnValue({ data: 3 });
+
     render(<TabLayout />);
-    const TabsModule = require('expo-router');
-    const screens = (TabsModule.Tabs.Screen as jest.Mock).mock.calls.map((call: any[]) => call[0]);
-    const screensWithIcons = screens.filter((screen) => typeof screen.options?.tabBarIcon === 'function');
-    const [indexOptions, searchOptions, messagesOptions, notificationsOptions, profileOptions, settingsOptions] =
-      screensWithIcons.map((screen) => screen.options);
-    // Invoke tabBarIcon functions to ensure badge rendering
-    render(indexOptions.tabBarIcon({ color: 'red' }));
-    render(searchOptions.tabBarIcon({ color: 'red' }));
-    render(messagesOptions.tabBarIcon({ color: 'red' }));
-    render(notificationsOptions.tabBarIcon({ color: 'red' }));
-    render(profileOptions.tabBarIcon({ color: 'red' }));
-    render(settingsOptions.tabBarIcon({ color: 'red' }));
-    expect(mockTabBadge.mock.calls[0][0].count).toBe(2);
-    expect(mockTabBadge.mock.calls[1][0].count).toBe(3);
-    expect(TabsModule.Tabs.mock.calls[0][0].screenOptions.tabBarShowLabel).toBe(false);
-    const names = (TabsModule.Tabs.Screen as jest.Mock).mock.calls.map((c: any[]) => c[0].name);
-    expect(names).toEqual([
+
+    const triggerCalls = (TriggerMock as jest.Mock).mock.calls.map((call) => call[0]);
+    expect(triggerCalls.map((props) => props.name)).toEqual([
       'index',
       'search',
       'messages',
@@ -186,44 +177,45 @@ describe('TabLayout', () => {
       'profile',
       'settings',
     ]);
+    expect(triggerCalls[4]).toMatchObject({ hidden: true, options: { href: null } });
+    expect(triggerCalls[5]).toMatchObject({ hidden: true, options: { href: null } });
+
+    const badgeCalls = (BadgeMock as jest.Mock).mock.calls;
+    expect(badgeCalls).toHaveLength(2);
+    expect(badgeCalls[0][0]).toMatchObject({ hidden: false, children: '2' });
+    expect(badgeCalls[1][0]).toMatchObject({ hidden: false, children: '3' });
+
+    const nativeTabsProps = (NativeTabsMock as jest.Mock).mock.calls[0][0];
+    expect(nativeTabsProps.tintColor).toBe('#7C8CF9');
+    expect(nativeTabsProps.iconColor).toBe('#6B7280');
+    expect(nativeTabsProps.backgroundColor).toBe('#F3F4F6');
   });
 
-  it('uses default tint and badge counts when data is unavailable', () => {
+  it('uses default tint and hides badges when counts are unavailable', () => {
     mockUseAuthStatus.mockReturnValue({ data: { isAuthenticated: true }, isLoading: false });
     mockUseUnreadMessagesCount.mockReturnValue({});
     mockUseUnreadNotificationsCount.mockReturnValue({});
+
     render(<TabLayout />);
-    const TabsModule = require('expo-router');
-    const screenOptions = TabsModule.Tabs.mock.calls[0][0].screenOptions;
-    expect(screenOptions.tabBarActiveTintColor).toBe('#7C8CF9');
-    const messagesOptions = (TabsModule.Tabs.Screen as jest.Mock).mock.calls[2][0].options;
-    const notificationsOptions = (TabsModule.Tabs.Screen as jest.Mock).mock.calls[3][0].options;
-    render(messagesOptions.tabBarIcon({ color: 'blue' }));
-    render(notificationsOptions.tabBarIcon({ color: 'blue' }));
-    expect(mockTabBadge.mock.calls[0][0].count).toBe(0);
-    expect(mockTabBadge.mock.calls[1][0].count).toBe(0);
+
+    const badgeCalls = (BadgeMock as jest.Mock).mock.calls;
+    expect(badgeCalls).toHaveLength(2);
+    expect(badgeCalls[0][0]).toMatchObject({ hidden: true });
+    expect(badgeCalls[1][0]).toMatchObject({ hidden: true });
   });
 
   it('opens the account switcher when the profile tab is long pressed', () => {
     mockUseAuthStatus.mockReturnValue({ data: { isAuthenticated: true }, isLoading: false });
     render(<TabLayout />);
 
-    const TabsModule = require('expo-router');
-    const screenCalls = (TabsModule.Tabs.Screen as jest.Mock).mock.calls;
-    const profileScreenCall = screenCalls.find((call: any[]) => call[0].name === 'profile');
-    expect(profileScreenCall).toBeTruthy();
-
-    const listeners = profileScreenCall?.[0].listeners;
-    expect(typeof listeners).toBe('function');
-
+    expect(navigationListeners.tabLongPress).toBeDefined();
     const preventDefault = jest.fn();
 
     act(() => {
-      listeners?.({} as any).tabLongPress?.({ preventDefault } as any);
+      navigationListeners.tabLongPress?.({ target: 'profile-key', preventDefault } as any);
     });
 
     expect(preventDefault).toHaveBeenCalled();
-    expect(mockAccountSwitcherSheet.mock.calls.length).toBeGreaterThanOrEqual(2);
     const latestCall = mockAccountSwitcherSheet.mock.calls.at(-1);
     expect(latestCall?.[0].visible).toBe(true);
 
@@ -234,100 +226,31 @@ describe('TabLayout', () => {
     const closeCall = mockAccountSwitcherSheet.mock.calls.at(-1);
     expect(closeCall?.[0].visible).toBe(false);
   });
-});
 
-describe('CustomTabButton', () => {
-  const renderTabBarButton = () => {
+  it('triggers scroll handlers when the active tab is pressed again', () => {
     mockUseAuthStatus.mockReturnValue({ data: { isAuthenticated: true }, isLoading: false });
     render(<TabLayout />);
-    const TabsModule = require('expo-router');
-    const TabBarButton = TabsModule.Tabs.mock.calls[0][0].screenOptions.tabBarButton as React.ComponentType<any>;
-    render(<TabBarButton />);
-    return (mockHapticTab.mock.calls[0][0].onTabPress as () => void) ?? (() => {});
-  };
 
-  afterEach(() => {
-    jest.useRealTimers();
-  });
-
-  it('triggers tab scroll when the same tab is pressed consecutively', () => {
-    jest.useFakeTimers();
-    const navigationState = {
-      index: 0,
-      routes: [{ name: 'messages' }],
-    };
-    mockUseNavigationState.mockImplementation((selector: (state: typeof navigationState) => any) =>
-      selector(navigationState),
-    );
-
-    const onTabPress = renderTabBarButton();
+    navigationState.index = 2; // messages
 
     act(() => {
-      onTabPress();
-      jest.advanceTimersByTime(50);
+      navigationListeners.tabPress?.({ target: 'messages-key' } as any);
     });
-    expect(mockHandleTabPress).not.toHaveBeenCalled();
 
-    act(() => {
-      onTabPress();
-      jest.advanceTimersByTime(50);
-    });
     expect(mockHandleTabPress).toHaveBeenCalledTimes(1);
     expect(mockHandleTabPress).toHaveBeenCalledWith('messages');
   });
 
-  it('updates the tracked tab without triggering scroll when switching tabs', () => {
-    jest.useFakeTimers();
-    const navigationState = {
-      index: 0,
-      routes: [{ name: 'messages' }, { name: 'settings' }],
-    };
-    mockUseNavigationState.mockImplementation((selector: (state: typeof navigationState) => any) =>
-      selector(navigationState),
-    );
+  it('ignores tab presses when a different tab is focused', () => {
+    mockUseAuthStatus.mockReturnValue({ data: { isAuthenticated: true }, isLoading: false });
+    render(<TabLayout />);
 
-    const onTabPress = renderTabBarButton();
+    navigationState.index = 0; // index focused
 
     act(() => {
-      onTabPress();
-      jest.advanceTimersByTime(50);
-    });
-    expect(mockHandleTabPress).not.toHaveBeenCalled();
-
-    navigationState.index = 1;
-
-    act(() => {
-      onTabPress();
-      jest.advanceTimersByTime(50);
-    });
-    expect(mockHandleTabPress).not.toHaveBeenCalled();
-
-    act(() => {
-      onTabPress();
-      jest.advanceTimersByTime(50);
-    });
-    expect(mockHandleTabPress).toHaveBeenCalledTimes(1);
-    expect(mockHandleTabPress).toHaveBeenCalledWith('settings');
-  });
-
-  it('ignores presses when the current route cannot be determined', () => {
-    jest.useFakeTimers();
-    const navigationState = {
-      index: 2,
-      routes: [{ name: 'messages' }],
-    };
-    mockUseNavigationState.mockImplementation((selector: (state: typeof navigationState) => any) =>
-      selector(navigationState),
-    );
-
-    const onTabPress = renderTabBarButton();
-
-    act(() => {
-      onTabPress();
-      jest.advanceTimersByTime(100);
+      navigationListeners.tabPress?.({ target: 'messages-key' } as any);
     });
 
     expect(mockHandleTabPress).not.toHaveBeenCalled();
   });
 });
-


### PR DESCRIPTION
## Summary
- replace the mobile Expo Router tab bar with NativeTabs using cross-platform icons and badge support
- subscribe to tabPress/tabLongPress events to keep scroll-to-top behaviour and open the account switcher
- update the tab layout tests to mock NativeTabs and cover the new badge and navigation listener logic

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d871395834832b8cf616042760bc58