### PR TITLE
fix: render like-via-repost notifications like likes

### DIFF
--- a/apps/akari/app/(tabs)/notifications.tsx
+++ b/apps/akari/app/(tabs)/notifications.tsx
@@ -24,7 +24,7 @@ import { formatRelativeTime } from '@/utils/timeUtils';
  */
 type GroupedNotification = {
   id: string;
-  type: 'like' | 'repost' | 'follow' | 'reply' | 'mention' | 'quote';
+  type: 'like' | 'like-via-repost' | 'repost' | 'follow' | 'reply' | 'mention' | 'quote';
   subject?: string; // Post URI for post-related notifications
   postContent?: string; // Content of the post being interacted with
   embed?: BlueskyEmbed; // Embed data for the post
@@ -72,6 +72,8 @@ function NotificationItem({ notification, onPress, borderColor }: NotificationIt
     switch (type) {
       case 'like':
         return { name: 'heart.fill' as const, color: likeColor };
+      case 'like-via-repost':
+        return { name: 'heart.fill' as const, color: likeColor };
       case 'repost':
         return { name: 'arrow.2.squarepath' as const, color: repostColor };
       case 'follow':
@@ -91,6 +93,8 @@ function NotificationItem({ notification, onPress, borderColor }: NotificationIt
     const action = (() => {
       switch (type) {
         case 'like':
+          return t('notifications.likedYourPost');
+        case 'like-via-repost':
           return t('notifications.likedYourPost');
         case 'repost':
           return t('notifications.repostedYourPost');


### PR DESCRIPTION
## Summary
- keep the new like-via-repost notification type separate from like groups
- reuse the like icon and copy when rendering like-via-repost notifications

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d873857564832bb78f4a6fff02645e