### PR TITLE
feat: add constellation api package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8059,6 +8059,10 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/constellation-api": {
+      "resolved": "packages/constellation-api",
+      "link": true
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -20414,6 +20418,25 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/constellation-api": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@eslint/eslintrc": "^3.0.0",
+        "@eslint/js": "^9.25.0",
+        "@types/jest": "^30.0.0",
+        "eslint": "^9.25.0",
+        "eslint-config-expo": "~9.2.0",
+        "jest": "~29.7.0",
+        "msw": "^2.4.9",
+        "ts-jest": "^29.4.1",
+        "typescript": "~5.8.3"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-native": ">=0.70.0"
       }
     },
     "packages/libretranslate-api": {

--- a/packages/constellation-api/AGENTS.md
+++ b/packages/constellation-api/AGENTS.md
@@ -1,0 +1,5 @@
+# Constellation API Package Guidelines
+
+- Keep HTTP helpers inside `ConstellationApiClient`. Higher-level APIs should compose those helpers rather than calling `fetch` directly.
+- Define response and query `type` aliases in `types.ts` and re-export them through `src/index.ts`.
+- Cover happy paths and error handling in Jest tests with `msw` handlers.

--- a/packages/constellation-api/eslint.config.js
+++ b/packages/constellation-api/eslint.config.js
@@ -1,0 +1,18 @@
+import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+export default [
+  js.configs.recommended,
+  ...compat.extends('eslint-config-expo'),
+  {
+    rules: {},
+  },
+];

--- a/packages/constellation-api/jest.config.cjs
+++ b/packages/constellation-api/jest.config.cjs
@@ -1,0 +1,21 @@
+const isGithubActions = Boolean(process.env.GITHUB_ACTIONS);
+
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  transform: {
+    '^.+\\.m?tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: './tsconfig.json',
+      },
+    ],
+  },
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.{ts,tsx}', '!**/*.d.ts'],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'html'],
+  ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
+};

--- a/packages/constellation-api/package.json
+++ b/packages/constellation-api/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "constellation-api",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Constellation API client for exploring AT Protocol link relationships",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest --config ./jest.config.cjs",
+    "test:run": "jest --config ./jest.config.cjs",
+    "test:coverage": "jest --config ./jest.config.cjs --coverage --passWithNoTests",
+    "lint": "eslint src --ext .ts"
+  },
+  "keywords": ["constellation", "atproto", "api", "client"],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.0.0",
+    "@eslint/js": "^9.25.0",
+    "@types/jest": "^30.0.0",
+    "eslint": "^9.25.0",
+    "eslint-config-expo": "~9.2.0",
+    "jest": "~29.7.0",
+    "msw": "^2.4.9",
+    "ts-jest": "^29.4.1",
+    "typescript": "~5.8.3"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-native": ">=0.70.0"
+  }
+}

--- a/packages/constellation-api/src/api.test.ts
+++ b/packages/constellation-api/src/api.test.ts
@@ -1,0 +1,206 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from '@jest/globals';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { ConstellationApi } from './api';
+import { createConstellationApi } from './index';
+
+const baseUrl = 'https://constellation.test';
+const server = setupServer();
+
+type TestLinksQuery = {
+  target: string;
+  collection: string;
+  path: string;
+  cursor?: string;
+};
+
+type HeaderCollector = {
+  accept?: string;
+  custom?: string;
+};
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe('ConstellationApi', () => {
+  const createApi = () => new ConstellationApi(baseUrl, { userAgent: 'akari-tests' });
+
+  const buildQuery = (overrides: Partial<TestLinksQuery> = {}): TestLinksQuery => ({
+    target: 'did:plc:example',
+    collection: 'app.bsky.graph.follow',
+    path: '.subject',
+    ...overrides,
+  });
+
+  it('retrieves server information', async () => {
+    const payload = {
+      help: 'open this URL in a web browser',
+      days_indexed: 250,
+      stats: {
+        dids: 100,
+        targetables: 200,
+        linking_records: 300,
+      },
+    };
+
+    server.use(
+      http.get(`${baseUrl}/`, () => {
+        return HttpResponse.json(payload);
+      }),
+    );
+
+    await expect(createApi().getServerInfo()).resolves.toEqual(payload);
+  });
+
+  it('requests links with cursor support', async () => {
+    const query = buildQuery({ cursor: 'cursor-token' });
+    const response = {
+      total: 2,
+      linking_records: [
+        { did: 'did:plc:one', collection: 'app.bsky.graph.follow', rkey: '1' },
+        { did: 'did:plc:two', collection: 'app.bsky.graph.follow', rkey: '2' },
+      ],
+      cursor: 'next-cursor',
+    };
+
+    server.use(
+      http.get(`${baseUrl}/links`, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get('target')).toBe(query.target);
+        expect(url.searchParams.get('collection')).toBe(query.collection);
+        expect(url.searchParams.get('path')).toBe(query.path);
+        expect(url.searchParams.get('cursor')).toBe(query.cursor);
+
+        return HttpResponse.json(response);
+      }),
+    );
+
+    await expect(createApi().getLinks(query)).resolves.toEqual(response);
+  });
+
+  it('retrieves distinct dids for a target', async () => {
+    const query = buildQuery();
+    const response = {
+      total: 2,
+      linking_dids: ['did:plc:one', 'did:plc:two'],
+      cursor: null,
+    };
+
+    server.use(
+      http.get(`${baseUrl}/links/distinct-dids`, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get('target')).toBe(query.target);
+        expect(url.searchParams.get('collection')).toBe(query.collection);
+        expect(url.searchParams.get('path')).toBe(query.path);
+
+        return HttpResponse.json(response);
+      }),
+    );
+
+    await expect(createApi().getDistinctDids(query)).resolves.toEqual(response);
+  });
+
+  it('retrieves link counts', async () => {
+    const query = buildQuery();
+    const response = { total: 42 };
+
+    server.use(
+      http.get(`${baseUrl}/links/count`, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get('target')).toBe(query.target);
+        expect(url.searchParams.get('collection')).toBe(query.collection);
+        expect(url.searchParams.get('path')).toBe(query.path);
+
+        return HttpResponse.json(response);
+      }),
+    );
+
+    await expect(createApi().getLinkCount(query)).resolves.toEqual(response);
+  });
+
+  it('retrieves distinct did counts', async () => {
+    const query = buildQuery();
+    const response = { total: 21 };
+
+    server.use(
+      http.get(`${baseUrl}/links/count/distinct-dids`, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get('target')).toBe(query.target);
+        expect(url.searchParams.get('collection')).toBe(query.collection);
+        expect(url.searchParams.get('path')).toBe(query.path);
+
+        return HttpResponse.json(response);
+      }),
+    );
+
+    await expect(createApi().getDistinctDidCount(query)).resolves.toEqual(response);
+  });
+
+  it('retrieves aggregated link information', async () => {
+    const response = {
+      links: {
+        'app.bsky.graph.follow': {
+          '.subject': { records: 10, distinct_dids: 9 },
+        },
+      },
+    };
+
+    server.use(
+      http.get(`${baseUrl}/links/all`, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get('target')).toBe('did:plc:example');
+
+        return HttpResponse.json(response);
+      }),
+    );
+
+    await expect(createApi().getAllLinks({ target: 'did:plc:example' })).resolves.toEqual(response);
+  });
+
+  it('throws a descriptive error when the server responds with an error status', async () => {
+    const query = buildQuery();
+
+    server.use(
+      http.get(`${baseUrl}/links`, () => {
+        return HttpResponse.json({ message: 'nope' }, { status: 503, statusText: 'Service Unavailable' });
+      }),
+    );
+
+    await expect(createApi().getLinks(query)).rejects.toThrow(
+      'Constellation request failed with status 503 Service Unavailable',
+    );
+  });
+
+  it('supports the createConstellationApi helper with custom headers', async () => {
+    const query = buildQuery();
+    const response = { total: 5 };
+    const headers: HeaderCollector = {};
+
+    server.use(
+      http.get(`${baseUrl}/links/count`, ({ request }) => {
+        headers.accept = request.headers.get('accept') ?? undefined;
+        headers.custom = request.headers.get('x-akari-test') ?? undefined;
+
+        return HttpResponse.json(response);
+      }),
+    );
+
+    const api = createConstellationApi({
+      baseUrl: `${baseUrl}/`,
+      headers: { 'X-Akari-Test': 'constellation' },
+    });
+
+    await expect(api.getLinkCount(query)).resolves.toEqual(response);
+    expect(headers.accept).toBe('application/json');
+    expect(headers.custom).toBe('constellation');
+  });
+});

--- a/packages/constellation-api/src/api.ts
+++ b/packages/constellation-api/src/api.ts
@@ -1,0 +1,38 @@
+import { ConstellationApiClient } from './client';
+import type {
+  ConstellationAllLinksQuery,
+  ConstellationAllLinksResponse,
+  ConstellationCountQuery,
+  ConstellationCountResponse,
+  ConstellationDistinctDidCountResponse,
+  ConstellationDistinctDidsResponse,
+  ConstellationLinksQuery,
+  ConstellationLinksResponse,
+  ConstellationServerInfo,
+} from './types';
+
+export class ConstellationApi extends ConstellationApiClient {
+  async getServerInfo(): Promise<ConstellationServerInfo> {
+    return this.get<ConstellationServerInfo>('/');
+  }
+
+  async getLinks(query: ConstellationLinksQuery): Promise<ConstellationLinksResponse> {
+    return this.get<ConstellationLinksResponse>('/links', query);
+  }
+
+  async getDistinctDids(query: ConstellationLinksQuery): Promise<ConstellationDistinctDidsResponse> {
+    return this.get<ConstellationDistinctDidsResponse>('/links/distinct-dids', query);
+  }
+
+  async getLinkCount(query: ConstellationCountQuery): Promise<ConstellationCountResponse> {
+    return this.get<ConstellationCountResponse>('/links/count', query);
+  }
+
+  async getDistinctDidCount(query: ConstellationCountQuery): Promise<ConstellationDistinctDidCountResponse> {
+    return this.get<ConstellationDistinctDidCountResponse>('/links/count/distinct-dids', query);
+  }
+
+  async getAllLinks(query: ConstellationAllLinksQuery): Promise<ConstellationAllLinksResponse> {
+    return this.get<ConstellationAllLinksResponse>('/links/all', query);
+  }
+}

--- a/packages/constellation-api/src/client.ts
+++ b/packages/constellation-api/src/client.ts
@@ -1,0 +1,89 @@
+export const DEFAULT_CONSTELLATION_BASE_URL = 'https://constellation.microcosm.blue';
+
+export type ConstellationClientOptions = {
+  headers?: Record<string, string>;
+  userAgent?: string;
+};
+
+type QueryParams = Record<string, string | undefined>;
+
+export class ConstellationApiClient {
+  protected readonly baseUrl: string;
+  private readonly defaultHeaders: Record<string, string>;
+
+  constructor(baseUrl: string = DEFAULT_CONSTELLATION_BASE_URL, options: ConstellationClientOptions = {}) {
+    this.baseUrl = this.normalizeBaseUrl(baseUrl);
+    this.defaultHeaders = this.createDefaultHeaders(options);
+  }
+
+  protected async get<T>(path: string, params?: QueryParams, headers?: Record<string, string>): Promise<T> {
+    const url = this.buildUrl(path, params);
+    const response = await fetch(url, {
+      headers: this.mergeHeaders(headers),
+    });
+
+    if (!response.ok) {
+      throw new Error(this.createErrorMessage(response.status, response.statusText));
+    }
+
+    return (await response.json()) as T;
+  }
+
+  private buildUrl(path: string, params?: QueryParams): string {
+    const normalizedPath = path === '' ? '/' : path.startsWith('/') ? path : `/${path}`;
+    const url = new URL(`${this.baseUrl}${normalizedPath}`);
+
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        if (value !== undefined) {
+          url.searchParams.set(key, value);
+        }
+      }
+    }
+
+    return url.toString();
+  }
+
+  private mergeHeaders(additional?: Record<string, string>): Record<string, string> {
+    const headers: Record<string, string> = { ...this.defaultHeaders };
+
+    if (additional) {
+      for (const [key, value] of Object.entries(additional)) {
+        headers[key] = value;
+      }
+    }
+
+    return headers;
+  }
+
+  private createDefaultHeaders(options: ConstellationClientOptions): Record<string, string> {
+    const headers: Record<string, string> = { Accept: 'application/json' };
+
+    if (options.userAgent) {
+      headers['User-Agent'] = options.userAgent;
+    }
+
+    if (options.headers) {
+      for (const [key, value] of Object.entries(options.headers)) {
+        headers[key] = value;
+      }
+    }
+
+    return headers;
+  }
+
+  private createErrorMessage(status: number, statusText: string): string {
+    const suffix = statusText ? ` ${statusText}` : '';
+    return `Constellation request failed with status ${status}${suffix}`;
+  }
+
+  private normalizeBaseUrl(baseUrl: string): string {
+    const trimmed = baseUrl.trim();
+
+    if (!trimmed) {
+      return DEFAULT_CONSTELLATION_BASE_URL;
+    }
+
+    return trimmed.replace(/\/+$/, '');
+  }
+}

--- a/packages/constellation-api/src/index.ts
+++ b/packages/constellation-api/src/index.ts
@@ -1,0 +1,34 @@
+import { ConstellationApi } from './api';
+import { ConstellationApiClient, DEFAULT_CONSTELLATION_BASE_URL } from './client';
+import type { ConstellationClientOptions } from './client';
+
+export { ConstellationApi };
+export { ConstellationApiClient, DEFAULT_CONSTELLATION_BASE_URL };
+export type { ConstellationClientOptions };
+export type {
+  ConstellationAllLinksQuery,
+  ConstellationAllLinksResponse,
+  ConstellationCountQuery,
+  ConstellationCountResponse,
+  ConstellationDistinctDidCountResponse,
+  ConstellationDistinctDidsResponse,
+  ConstellationLinkAggregate,
+  ConstellationLinkRecord,
+  ConstellationLinksQuery,
+  ConstellationLinksResponse,
+  ConstellationServerInfo,
+  ConstellationStats,
+} from './types';
+
+export type ConstellationApiConfig = ConstellationClientOptions & {
+  baseUrl?: string;
+};
+
+export const createConstellationApi = (config: ConstellationApiConfig = {}): ConstellationApi => {
+  const { baseUrl, headers, userAgent } = config;
+
+  return new ConstellationApi(baseUrl ?? DEFAULT_CONSTELLATION_BASE_URL, {
+    headers,
+    userAgent,
+  });
+};

--- a/packages/constellation-api/src/types.ts
+++ b/packages/constellation-api/src/types.ts
@@ -1,0 +1,61 @@
+export type ConstellationStats = {
+  dids: number;
+  targetables: number;
+  linking_records: number;
+};
+
+export type ConstellationServerInfo = {
+  help: string;
+  days_indexed: number;
+  stats: ConstellationStats;
+};
+
+type ConstellationTargetedQuery = {
+  target: string;
+  collection: string;
+  path: string;
+};
+
+export type ConstellationLinksQuery = ConstellationTargetedQuery & {
+  cursor?: string;
+};
+
+export type ConstellationCountQuery = ConstellationLinksQuery;
+
+export type ConstellationLinkRecord = {
+  did: string;
+  collection: string;
+  rkey: string;
+};
+
+export type ConstellationLinksResponse = {
+  total: number;
+  linking_records: ConstellationLinkRecord[];
+  cursor: string | null;
+};
+
+export type ConstellationDistinctDidsResponse = {
+  total: number;
+  linking_dids: string[];
+  cursor: string | null;
+};
+
+export type ConstellationCountResponse = {
+  total: number;
+  cursor?: string | null;
+};
+
+export type ConstellationDistinctDidCountResponse = ConstellationCountResponse;
+
+export type ConstellationAllLinksQuery = {
+  target: string;
+};
+
+export type ConstellationLinkAggregate = {
+  records: number;
+  distinct_dids: number;
+};
+
+export type ConstellationAllLinksResponse = {
+  links: Record<string, Record<string, ConstellationLinkAggregate>>;
+};

--- a/packages/constellation-api/tsconfig.json
+++ b/packages/constellation-api/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}


### PR DESCRIPTION
## Summary
- add a dedicated constellation-api workspace with tooling configuration
- implement the ConstellationApi client, typed queries, and helper factory exports
- cover the new package with msw-powered Jest tests for success and error flows

## Testing
- npm run lint -- --filter=constellation-api
- npm run test -- --filter=constellation-api


------
https://chatgpt.com/codex/tasks/task_e_68d88297fc38832ba011b7c8620651da