### PR TITLE
chore: add postinstall build step for akari app

### DIFF
--- a/apps/akari/package.json
+++ b/apps/akari/package.json
@@ -112,5 +112,8 @@
     "vitest": "^2.1.9",
     "vitest-react-native": "^0.1.5"
   },
+  "optionalDependencies": {
+    "@rollup/rollup-linux-x64-gnu": "4.50.1"
+  },
   "private": true
 }

--- a/apps/akari/package.json
+++ b/apps/akari/package.json
@@ -3,6 +3,7 @@
   "main": "expo-router/entry",
   "version": "1.2.2",
   "scripts": {
+    "postinstall": "cd ../.. && npm run build",
     "start": "expo start",
     "start:development": "APP_VARIANT=development expo start",
     "start:preview": "APP_VARIANT=preview expo start",


### PR DESCRIPTION
## Summary
- add a postinstall script to the Akari Expo app to rebuild the monorepo after dependency installation

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d939dc6614832bb6da5962bd738a84