### PR TITLE
feat: manage profile list memberships

### DIFF
--- a/apps/akari/__tests__/app/profile/[handle].test.tsx
+++ b/apps/akari/__tests__/app/profile/[handle].test.tsx
@@ -112,6 +112,17 @@ jest.mock('@/components/profile/LikesTab', () => {
   return { LikesTab: ({ handle }: any) => <Text>{`likes ${handle}`}</Text> };
 });
 
+jest.mock('@/components/profile/ProfileListManagerModal', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    ProfileListManagerModal: ({ visible, actorHandle, onClose }: any) =>
+      visible ? (
+        <Text accessibilityRole="button" onPress={onClose}>{`lists modal ${actorHandle}`}</Text>
+      ) : null,
+  };
+});
+
 jest.mock('@/components/profile/MediaTab', () => {
   const { Text } = require('react-native');
   return { MediaTab: ({ handle }: any) => <Text>{`media ${handle}`}</Text> };
@@ -236,7 +247,8 @@ describe('ProfileScreen', () => {
 
     fireEvent.press(getByText('header'));
     fireEvent.press(getByText('add to lists'));
-    expect(logSpy).toHaveBeenCalledWith('Add to lists');
+    expect(getByText('lists modal alice')).toBeTruthy();
+    fireEvent.press(getByText('lists modal alice'));
 
     fireEvent.press(getByText('header'));
     fireEvent.press(getByText('mute account'));

--- a/apps/akari/__tests__/app/tabs-profile.test.tsx
+++ b/apps/akari/__tests__/app/tabs-profile.test.tsx
@@ -174,6 +174,17 @@ jest.mock('@/components/profile/LikesTab', () => {
   return { LikesTab: ({ handle }: any) => <Text>likes {handle}</Text> };
 });
 
+jest.mock('@/components/profile/ProfileListManagerModal', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    ProfileListManagerModal: ({ visible, actorHandle, onClose }: any) =>
+      visible ? (
+        <Text accessibilityRole="button" onPress={onClose}>{`lists modal ${actorHandle}`}</Text>
+      ) : null,
+  };
+});
+
 jest.mock('@/components/profile/RepliesTab', () => {
   const React = require('react');
   const { Text } = require('react-native');
@@ -319,12 +330,13 @@ describe('ProfileScreen', () => {
     expect(mockRouterPush).toHaveBeenCalledWith('/(tabs)/search?query=from:alice');
     expect(queryByTestId('profile-dropdown')).toBeNull();
 
-    const remainingActions = [
-      'profile.addToLists',
-      'profile.muteAccount',
-      'common.block',
-      'profile.reportAccount',
-    ];
+    fireEvent.press(getByText('open dropdown'));
+    fireEvent.press(getByText('profile.addToLists'));
+    expect(getByText('lists modal alice')).toBeTruthy();
+    fireEvent.press(getByText('lists modal alice'));
+    expect(queryByTestId('profile-dropdown')).toBeNull();
+
+    const remainingActions = ['profile.muteAccount', 'common.block', 'profile.reportAccount'];
 
     remainingActions.forEach((action) => {
       fireEvent.press(getByText('open dropdown'));

--- a/apps/akari/__tests__/components/profile/ProfileListManagerModal.test.tsx
+++ b/apps/akari/__tests__/components/profile/ProfileListManagerModal.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import { ProfileListManagerModal } from '@/components/profile/ProfileListManagerModal';
+import { useViewerLists } from '@/hooks/queries/useViewerLists';
+import { useActorListMemberships } from '@/hooks/queries/useActorListMemberships';
+import { useUpdateListMembership } from '@/hooks/mutations/useUpdateListMembership';
+import { useToast } from '@/contexts/ToastContext';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+jest.mock('@/hooks/queries/useViewerLists');
+jest.mock('@/hooks/queries/useActorListMemberships');
+jest.mock('@/hooks/mutations/useUpdateListMembership');
+jest.mock('@/contexts/ToastContext');
+jest.mock('@/hooks/useThemeColor');
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockUseViewerLists = useViewerLists as jest.Mock;
+const mockUseActorListMemberships = useActorListMemberships as jest.Mock;
+const mockUseUpdateListMembership = useUpdateListMembership as jest.Mock;
+const mockUseToast = useToast as jest.Mock;
+const mockUseThemeColor = useThemeColor as jest.Mock;
+
+describe('ProfileListManagerModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseViewerLists.mockReturnValue({
+      data: { lists: [{ uri: 'at://list/1', name: 'Friends', description: 'Close friends' }] },
+      isLoading: false,
+      error: null,
+    });
+    mockUseActorListMemberships.mockReturnValue({
+      data: { listUris: [], recordUrisByListUri: {} },
+      isLoading: false,
+      error: null,
+    });
+    mockUseUpdateListMembership.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+    mockUseToast.mockReturnValue({ showToast: jest.fn(), hideToast: jest.fn() });
+    mockUseThemeColor.mockImplementation((values, _role) => {
+      if (values && typeof values.light === 'string') {
+        return values.light;
+      }
+      return '#000000';
+    });
+  });
+
+  it('adds membership when list not selected', async () => {
+    const mutateAsync = jest.fn().mockResolvedValue({ uri: 'at://listitem/123' });
+    mockUseUpdateListMembership.mockReturnValue({ mutateAsync, isPending: false });
+    const showToast = jest.fn();
+    mockUseToast.mockReturnValue({ showToast, hideToast: jest.fn() });
+
+    const { getByText } = render(
+      <ProfileListManagerModal
+        visible
+        onClose={jest.fn()}
+        actorHandle="alice"
+        actorDid="did:example:alice"
+      />,
+    );
+
+    fireEvent.press(getByText('Friends'));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        action: 'add',
+        did: 'did:example:alice',
+        listUri: 'at://list/1',
+      });
+    });
+
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'success', title: 'profile.addToLists', message: 'common.success' }),
+    );
+  });
+
+  it('removes membership when list already selected', async () => {
+    mockUseActorListMemberships.mockReturnValue({
+      data: { listUris: ['at://list/1'], recordUrisByListUri: { 'at://list/1': 'at://listitem/123' } },
+      isLoading: false,
+      error: null,
+    });
+    const mutateAsync = jest.fn().mockResolvedValue({});
+    mockUseUpdateListMembership.mockReturnValue({ mutateAsync, isPending: false });
+
+    const showToast = jest.fn();
+    mockUseToast.mockReturnValue({ showToast, hideToast: jest.fn() });
+
+    const { getByText } = render(
+      <ProfileListManagerModal
+        visible
+        onClose={jest.fn()}
+        actorHandle="alice"
+        actorDid="did:example:alice"
+      />,
+    );
+
+    fireEvent.press(getByText('Friends'));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        action: 'remove',
+        did: 'did:example:alice',
+        listItemUri: 'at://listitem/123',
+        listUri: 'at://list/1',
+      });
+    });
+
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'success', title: 'profile.addToLists', message: 'common.success' }),
+    );
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateListMembership.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateListMembership.test.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateListMembership } from '@/hooks/mutations/useUpdateListMembership';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockCreateListItem = jest.fn();
+const mockDeleteListItem = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createListItem: mockCreateListItem,
+    deleteListItem: mockDeleteListItem,
+  })),
+}));
+
+describe('useUpdateListMembership mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper, invalidateSpy };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:viewer' },
+    });
+    mockCreateListItem.mockResolvedValue({ uri: 'at://listitem/1' });
+    mockDeleteListItem.mockResolvedValue({});
+  });
+
+  it('creates list membership when action is add', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateListMembership(), { wrapper });
+
+    result.current.mutate({ did: 'did:target', listUri: 'at://list/1', action: 'add' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockCreateListItem).toHaveBeenCalledWith('token', 'at://list/1', 'did:target');
+  });
+
+  it('deletes list membership when action is remove', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateListMembership(), { wrapper });
+
+    result.current.mutate({
+      did: 'did:target',
+      listUri: 'at://list/1',
+      action: 'remove',
+      listItemUri: 'at://listitem/1',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockDeleteListItem).toHaveBeenCalledWith('token', 'at://listitem/1');
+  });
+
+  it('errors when removing without list item uri', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateListMembership(), { wrapper });
+
+    result.current.mutate({ did: 'did:target', listUri: 'at://list/1', action: 'remove' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockDeleteListItem).not.toHaveBeenCalled();
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateListMembership(), { wrapper });
+
+    result.current.mutate({ did: 'did:target', listUri: 'at://list/1', action: 'add' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateListItem).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:viewer' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateListMembership(), { wrapper });
+
+    result.current.mutate({ did: 'did:target', listUri: 'at://list/1', action: 'add' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateListItem).not.toHaveBeenCalled();
+  });
+
+  it('invalidates relevant queries on success', async () => {
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useUpdateListMembership(), { wrapper });
+
+    result.current.mutate({ did: 'did:target', listUri: 'at://list/1', action: 'add' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['profile', 'did:target'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['profile'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['listMemberships', 'did:target'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['viewerLists', 'did:viewer'] });
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useActorListMemberships.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useActorListMemberships.test.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+
+import { useActorListMemberships } from '@/hooks/queries/useActorListMemberships';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockListListItems = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({ listListItems: mockListListItems })),
+}));
+
+describe('useActorListMemberships query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did:viewer', pdsUrl: 'https://pds' },
+    });
+  });
+
+  it('collects membership records across pages', async () => {
+    mockListListItems
+      .mockResolvedValueOnce({
+        cursor: 'cursor-1',
+        records: [
+          {
+            uri: 'at://listitem/1',
+            cid: 'cid1',
+            value: { subject: 'did:target', list: 'at://list/1', createdAt: '2024-01-01T00:00:00Z' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        records: [
+          {
+            uri: 'at://listitem/2',
+            cid: 'cid2',
+            value: { subject: 'did:target', list: 'at://list/2', createdAt: '2024-01-02T00:00:00Z' },
+          },
+          {
+            uri: 'at://listitem/3',
+            cid: 'cid3',
+            value: { subject: 'did:someoneElse', list: 'at://list/ignore', createdAt: '2024-01-03T00:00:00Z' },
+          },
+        ],
+      });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useActorListMemberships('did:target'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual({
+        listUris: ['at://list/1', 'at://list/2'],
+        recordUrisByListUri: {
+          'at://list/1': 'at://listitem/1',
+          'at://list/2': 'at://listitem/2',
+        },
+      });
+    });
+
+    expect(mockListListItems).toHaveBeenNthCalledWith(1, 'token', 'did:viewer', 100, undefined);
+    expect(mockListListItems).toHaveBeenNthCalledWith(2, 'token', 'did:viewer', 100, 'cursor-1');
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useActorListMemberships('did:target'), { wrapper });
+
+    let refetchResult;
+    await act(async () => {
+      refetchResult = await result.current.refetch();
+    });
+
+    expect(refetchResult.error?.message).toBe('No access token');
+    expect(mockListListItems).not.toHaveBeenCalled();
+  });
+
+  it('errors when actor DID missing', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useActorListMemberships(undefined), { wrapper });
+
+    let refetchResult;
+    await act(async () => {
+      refetchResult = await result.current.refetch();
+    });
+
+    expect(refetchResult.error?.message).toBe('No actor DID provided');
+    expect(mockListListItems).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:viewer' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useActorListMemberships('did:target'), { wrapper });
+
+    let refetchResult;
+    await act(async () => {
+      refetchResult = await result.current.refetch();
+    });
+
+    expect(refetchResult.error?.message).toBe('No PDS URL available');
+    expect(mockListListItems).not.toHaveBeenCalled();
+  });
+
+  it('errors when viewer DID missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useActorListMemberships('did:target'), { wrapper });
+
+    let refetchResult;
+    await act(async () => {
+      refetchResult = await result.current.refetch();
+    });
+
+    expect(refetchResult.error?.message).toBe('No DID available');
+    expect(mockListListItems).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useViewerLists.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useViewerLists.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+
+import { useViewerLists } from '@/hooks/queries/useViewerLists';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetLists = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({ getLists: mockGetLists })),
+}));
+
+describe('useViewerLists query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did:viewer', pdsUrl: 'https://pds' },
+    });
+  });
+
+  it('fetches viewer lists when prerequisites satisfied', async () => {
+    const lists = { lists: [{ uri: 'at://list/1', name: 'List' }] };
+    mockGetLists.mockResolvedValueOnce(lists);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useViewerLists(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(lists);
+    });
+
+    expect(mockGetLists).toHaveBeenCalledWith('token', 'did:viewer');
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useViewerLists(), { wrapper });
+
+    let refetchResult;
+    await act(async () => {
+      refetchResult = await result.current.refetch();
+    });
+
+    expect(refetchResult.error?.message).toBe('No access token');
+    expect(mockGetLists).not.toHaveBeenCalled();
+  });
+
+  it('errors when DID missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useViewerLists(), { wrapper });
+
+    let refetchResult;
+    await act(async () => {
+      refetchResult = await result.current.refetch();
+    });
+
+    expect(refetchResult.error?.message).toBe('No DID available');
+    expect(mockGetLists).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:viewer' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useViewerLists(), { wrapper });
+
+    let refetchResult;
+    await act(async () => {
+      refetchResult = await result.current.refetch();
+    });
+
+    expect(refetchResult.error?.message).toBe('No PDS URL available');
+    expect(mockGetLists).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/app/(tabs)/profile/[handle].tsx
+++ b/apps/akari/app/(tabs)/profile/[handle].tsx
@@ -5,6 +5,7 @@ import * as Clipboard from 'expo-clipboard';
 
 import { ProfileDropdown } from '@/components/ProfileDropdown';
 import { ProfileHeader } from '@/components/ProfileHeader';
+import { ProfileListManagerModal } from '@/components/profile/ProfileListManagerModal';
 import { ProfileTabs } from '@/components/ProfileTabs';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
@@ -29,6 +30,7 @@ export default function ProfileScreen() {
   const [activeTab, setActiveTab] = useState<ProfileTabType>('posts');
   const [showDropdown, setShowDropdown] = useState(false);
   const [dropdownPosition, setDropdownPosition] = useState({ top: 0, right: 0 });
+  const [showListsModal, setShowListsModal] = useState(false);
   const dropdownRef = useRef<View | null>(null);
   const { t } = useTranslation();
   const { data: currentUser } = useCurrentAccount();
@@ -106,8 +108,7 @@ export default function ProfileScreen() {
   };
 
   const handleAddToLists = () => {
-    // TODO: Implement add to lists functionality
-    console.log('Add to lists');
+    setShowListsModal(true);
     setShowDropdown(false);
   };
 
@@ -202,6 +203,12 @@ export default function ProfileScreen() {
           top: dropdownPosition.top,
           right: dropdownPosition.right,
         }}
+      />
+      <ProfileListManagerModal
+        visible={showListsModal}
+        onClose={() => setShowListsModal(false)}
+        actorHandle={profile.handle}
+        actorDid={profile.did}
       />
     </ThemedView>
   );

--- a/apps/akari/app/(tabs)/profile/index.tsx
+++ b/apps/akari/app/(tabs)/profile/index.tsx
@@ -4,6 +4,7 @@ import * as Clipboard from 'expo-clipboard';
 
 import { ProfileDropdown } from '@/components/ProfileDropdown';
 import { ProfileHeader } from '@/components/ProfileHeader';
+import { ProfileListManagerModal } from '@/components/profile/ProfileListManagerModal';
 import { ProfileTabs } from '@/components/ProfileTabs';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
@@ -30,6 +31,7 @@ export default function ProfileScreen() {
   const insets = useSafeAreaInsets();
   const [activeTab, setActiveTab] = useState<ProfileTabType>('posts');
   const [showDropdown, setShowDropdown] = useState(false);
+  const [showListsModal, setShowListsModal] = useState(false);
   const dropdownRef = useRef<View | null>(null);
   const scrollViewRef = useRef<ScrollView>(null);
   const { t } = useTranslation();
@@ -176,7 +178,7 @@ export default function ProfileScreen() {
         onCopyLink={handleCopyLink}
         onSearchPosts={handleSearchPosts}
         onAddToLists={() => {
-          // TODO: Implement add to lists functionality
+          setShowListsModal(true);
           setShowDropdown(false);
         }}
         onMuteAccount={() => {
@@ -199,6 +201,12 @@ export default function ProfileScreen() {
           top: dropdownPosition.top,
           right: dropdownPosition.right,
         }}
+      />
+      <ProfileListManagerModal
+        visible={showListsModal}
+        onClose={() => setShowListsModal(false)}
+        actorHandle={currentAccount?.handle || profile?.handle || ''}
+        actorDid={profile?.did}
       />
     </ThemedView>
   );

--- a/apps/akari/components/ProfileHeader.tsx
+++ b/apps/akari/components/ProfileHeader.tsx
@@ -137,17 +137,6 @@ export function ProfileHeader({ profile, isOwnProfile = false, onDropdownToggle,
     searchProfilePosts({ handle: profile.handle });
   };
 
-  const handleAddToLists = () => {
-    // TODO: Implement add to lists functionality
-    // This would typically open a modal or navigate to a lists management screen
-    showAlert({
-      title: t('profile.addToLists'),
-      message: 'Lists functionality coming soon!',
-      buttons: [{ text: t('common.ok') }],
-    });
-    setShowDropdown(false);
-  };
-
   const handleMuteAccount = () => {
     // TODO: Implement mute functionality
     const isMuted = profile.viewer?.muted;

--- a/apps/akari/components/profile/ProfileListManagerModal.tsx
+++ b/apps/akari/components/profile/ProfileListManagerModal.tsx
@@ -1,0 +1,337 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Modal, StyleSheet, TouchableOpacity, View } from 'react-native';
+
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { IconSymbol } from '@/components/ui/IconSymbol';
+import { useToast } from '@/contexts/ToastContext';
+import { useUpdateListMembership } from '@/hooks/mutations/useUpdateListMembership';
+import { useActorListMemberships } from '@/hooks/queries/useActorListMemberships';
+import { useViewerLists } from '@/hooks/queries/useViewerLists';
+import { useThemeColor } from '@/hooks/useThemeColor';
+import { useTranslation } from '@/hooks/useTranslation';
+
+import type { BlueskyListView } from '@/bluesky-api';
+
+export type ProfileListManagerModalProps = {
+  visible: boolean;
+  onClose: () => void;
+  actorHandle: string;
+  actorDid?: string;
+};
+
+type MembershipState = {
+  selected: Set<string>;
+  recordUris: Record<string, string>;
+};
+
+export function ProfileListManagerModal({ visible, onClose, actorHandle, actorDid }: ProfileListManagerModalProps) {
+  const { t } = useTranslation();
+  const { showToast, hideToast } = useToast();
+  const themeBackground = useThemeColor({ light: '#ffffff', dark: '#151718' }, 'background');
+  const surfaceColor = useThemeColor({ light: '#f5f5f7', dark: '#1c1c1e' }, 'background');
+  const borderColor = useThemeColor({}, 'border');
+  const textColor = useThemeColor({}, 'text');
+  const accentColor = useThemeColor({}, 'tint');
+
+  const { data: listsData, isLoading: isListsLoading, error: listsError } = useViewerLists();
+  const {
+    data: membershipData,
+    isLoading: isMembershipLoading,
+    error: membershipError,
+  } = useActorListMemberships(visible ? actorDid : undefined);
+  const updateMembership = useUpdateListMembership();
+
+  const [membershipState, setMembershipState] = useState<MembershipState>({
+    selected: new Set(),
+    recordUris: {},
+  });
+
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+
+    if (!membershipData) {
+      setMembershipState({ selected: new Set(), recordUris: {} });
+      return;
+    }
+
+    setMembershipState({
+      selected: new Set(membershipData.listUris),
+      recordUris: { ...membershipData.recordUrisByListUri },
+    });
+  }, [membershipData, visible]);
+
+  const lists: BlueskyListView[] = useMemo(() => listsData?.lists ?? [], [listsData]);
+  const isLoading = isListsLoading || (visible && isMembershipLoading);
+  const hasError = Boolean(listsError || membershipError);
+
+  const handleToggle = async (listUri: string) => {
+    if (!actorDid) {
+      const toastId = showToast({
+        type: 'error',
+        title: t('profile.addToLists'),
+        message: t('common.somethingWentWrong'),
+      });
+      setTimeout(() => hideToast(toastId), 3000);
+      return;
+    }
+
+    const isMember = membershipState.selected.has(listUri);
+    const toastId = showToast({
+      id: `${listUri}-${actorDid}`,
+      type: 'info',
+      title: t('profile.addToLists'),
+      message: t('common.loading'),
+    });
+
+    try {
+      if (isMember) {
+        const recordUri = membershipState.recordUris[listUri];
+        if (!recordUri) {
+          throw new Error('List item URI missing');
+        }
+
+        await updateMembership.mutateAsync({
+          did: actorDid,
+          listUri,
+          action: 'remove',
+          listItemUri: recordUri,
+        });
+
+        setMembershipState((current) => {
+          const nextSelected = new Set(current.selected);
+          nextSelected.delete(listUri);
+          const nextRecordUris = { ...current.recordUris };
+          delete nextRecordUris[listUri];
+          return { selected: nextSelected, recordUris: nextRecordUris };
+        });
+      } else {
+        const response = await updateMembership.mutateAsync({
+          did: actorDid,
+          listUri,
+          action: 'add',
+        });
+
+        setMembershipState((current) => {
+          const nextSelected = new Set(current.selected).add(listUri);
+          const nextRecordUris = { ...current.recordUris };
+          if (typeof response === 'object' && response && 'uri' in response) {
+            nextRecordUris[listUri] = (response as { uri: string }).uri;
+          }
+          return { selected: nextSelected, recordUris: nextRecordUris };
+        });
+      }
+
+      showToast({
+        id: toastId,
+        type: 'success',
+        title: t('profile.addToLists'),
+        message: t('common.success'),
+      });
+    } catch (error) {
+      console.error('List membership update failed:', error);
+      showToast({
+        id: toastId,
+        type: 'error',
+        title: t('profile.addToLists'),
+        message: t('common.somethingWentWrong'),
+      });
+    }
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <ThemedView style={[styles.container, { backgroundColor: themeBackground }]}>
+          <View style={[styles.header, { borderBottomColor: borderColor }]}>
+            <TouchableOpacity
+              accessibilityRole="button"
+              accessibilityLabel={t('common.cancel')}
+              onPress={onClose}
+              style={styles.closeButton}
+            >
+              <IconSymbol name="xmark" size={20} color={textColor} />
+            </TouchableOpacity>
+            <ThemedText style={[styles.title, { color: textColor }]}>{t('profile.addToLists')}</ThemedText>
+            <View style={styles.closeButton} />
+          </View>
+
+          <ThemedView style={[styles.content, { backgroundColor: surfaceColor }]}> 
+            <View style={[styles.handlePill, { borderColor }]}>
+              <ThemedText style={[styles.handleText, { color: textColor }]}>@{actorHandle}</ThemedText>
+            </View>
+            {isLoading ? (
+              <View style={styles.loadingState}>
+                <ActivityIndicator color={accentColor} />
+                <ThemedText style={[styles.loadingText, { color: textColor }]}>{t('common.loading')}</ThemedText>
+              </View>
+            ) : hasError ? (
+              <View style={styles.loadingState}>
+                <ThemedText style={[styles.loadingText, { color: textColor }]}>{t('common.somethingWentWrong')}</ThemedText>
+                <TouchableOpacity accessibilityRole="button" onPress={onClose} style={styles.retryButton}>
+                  <ThemedText style={[styles.retryText, { color: accentColor }]}>{t('common.ok')}</ThemedText>
+                </TouchableOpacity>
+              </View>
+            ) : lists.length === 0 ? (
+              <View style={styles.loadingState}>
+                <ThemedText style={[styles.loadingText, { color: textColor }]}>{t('profile.noContent')}</ThemedText>
+              </View>
+            ) : (
+              <View>
+                {lists.map((list) => {
+                  const isMember = membershipState.selected.has(list.uri);
+                  return (
+                    <TouchableOpacity
+                      key={list.uri}
+                      accessibilityRole="button"
+                      accessibilityState={{ selected: isMember }}
+                      style={[styles.listRow, { borderBottomColor: borderColor }]}
+                      onPress={() => handleToggle(list.uri)}
+                      disabled={updateMembership.isPending}
+                    >
+                      <View style={styles.listInfo}>
+                        <ThemedText style={[styles.listName, { color: textColor }]}>{list.name}</ThemedText>
+                        {list.description ? (
+                          <ThemedText style={styles.listDescription}>{list.description}</ThemedText>
+                        ) : null}
+                      </View>
+                      {isMember ? (
+                        <IconSymbol name="checkmark.circle.fill" size={24} color={accentColor} />
+                      ) : (
+                        <View style={[styles.unselectedIndicator, { borderColor }]} />
+                      )}
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+            )}
+          </ThemedView>
+
+          <View style={[styles.footer, { borderTopColor: borderColor }]}> 
+            <TouchableOpacity
+              accessibilityRole="button"
+              onPress={onClose}
+              style={styles.footerButton}
+            >
+              <ThemedText style={[styles.footerButtonText, { color: accentColor }]}>{t('common.cancel')}</ThemedText>
+            </TouchableOpacity>
+          </View>
+        </ThemedView>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  container: {
+    width: '100%',
+    maxWidth: 420,
+    borderRadius: 16,
+    overflow: 'hidden',
+  },
+  header: {
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  closeButton: {
+    width: 32,
+    height: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  content: {
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+  },
+  handlePill: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    marginBottom: 16,
+  },
+  handleText: {
+    fontSize: 14,
+    fontWeight: '500',
+    opacity: 0.8,
+  },
+  loadingState: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 32,
+    gap: 12,
+  },
+  loadingText: {
+    fontSize: 16,
+    opacity: 0.8,
+    textAlign: 'center',
+  },
+  retryButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  retryText: {
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  listRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 12,
+    gap: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  listInfo: {
+    flex: 1,
+  },
+  listName: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  listDescription: {
+    fontSize: 13,
+    opacity: 0.6,
+    marginTop: 4,
+  },
+  unselectedIndicator: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  footer: {
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    alignItems: 'flex-end',
+  },
+  footerButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  footerButtonText: {
+    fontSize: 15,
+    fontWeight: '500',
+  },
+});

--- a/apps/akari/hooks/mutations/useUpdateListMembership.ts
+++ b/apps/akari/hooks/mutations/useUpdateListMembership.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { BlueskyApi } from '@/bluesky-api';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+
+export type UpdateListMembershipVariables = {
+  did: string;
+  listUri: string;
+  action: 'add' | 'remove';
+  listItemUri?: string;
+};
+
+export function useUpdateListMembership() {
+  const queryClient = useQueryClient();
+  const { data: token } = useJwtToken();
+  const { data: currentAccount } = useCurrentAccount();
+
+  return useMutation({
+    mutationKey: ['updateListMembership'],
+    mutationFn: async ({ did, listUri, action, listItemUri }: UpdateListMembershipVariables) => {
+      if (!token) throw new Error('No access token');
+      if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
+
+      const api = new BlueskyApi(currentAccount.pdsUrl);
+
+      if (action === 'add') {
+        return await api.createListItem(token, listUri, did);
+      }
+
+      if (!listItemUri) {
+        throw new Error('List item URI is required for removal');
+      }
+
+      return await api.deleteListItem(token, listItemUri);
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['profile', variables.did] });
+      queryClient.invalidateQueries({ queryKey: ['profile'] });
+      queryClient.invalidateQueries({ queryKey: ['listMemberships', variables.did] });
+
+      if (currentAccount?.did) {
+        queryClient.invalidateQueries({ queryKey: ['viewerLists', currentAccount.did] });
+      }
+    },
+  });
+}

--- a/apps/akari/hooks/queries/useActorListMemberships.ts
+++ b/apps/akari/hooks/queries/useActorListMemberships.ts
@@ -1,0 +1,45 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { BlueskyApi } from '@/bluesky-api';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+
+export type ActorListMemberships = {
+  listUris: string[];
+  recordUrisByListUri: Record<string, string>;
+};
+
+export function useActorListMemberships(actorDid: string | undefined) {
+  const { data: token } = useJwtToken();
+  const { data: currentAccount } = useCurrentAccount();
+
+  return useQuery<ActorListMemberships>({
+    queryKey: ['listMemberships', actorDid, currentAccount?.did, currentAccount?.pdsUrl],
+    queryFn: async () => {
+      if (!token) throw new Error('No access token');
+      if (!actorDid) throw new Error('No actor DID provided');
+      if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
+      if (!currentAccount?.did) throw new Error('No DID available');
+
+      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const membershipMap: Record<string, string> = {};
+
+      let cursor: string | undefined;
+      do {
+        const response = await api.listListItems(token, currentAccount.did, 100, cursor);
+        for (const record of response.records ?? []) {
+          if (record.value.subject === actorDid) {
+            membershipMap[record.value.list] = record.uri;
+          }
+        }
+        cursor = response.cursor;
+      } while (cursor);
+
+      return {
+        listUris: Object.keys(membershipMap),
+        recordUrisByListUri: membershipMap,
+      };
+    },
+    enabled: Boolean(actorDid && token && currentAccount?.did && currentAccount?.pdsUrl),
+  });
+}

--- a/apps/akari/hooks/queries/useViewerLists.ts
+++ b/apps/akari/hooks/queries/useViewerLists.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { BlueskyApi } from '@/bluesky-api';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+
+export function useViewerLists() {
+  const { data: token } = useJwtToken();
+  const { data: currentAccount } = useCurrentAccount();
+
+  return useQuery({
+    queryKey: ['viewerLists', currentAccount?.did, currentAccount?.pdsUrl],
+    queryFn: async () => {
+      if (!token) throw new Error('No access token');
+      if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
+      if (!currentAccount?.did) throw new Error('No DID available');
+
+      const api = new BlueskyApi(currentAccount.pdsUrl);
+      return await api.getLists(token, currentAccount.did);
+    },
+    enabled: Boolean(token && currentAccount?.did && currentAccount?.pdsUrl),
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/packages/bluesky-api/src/api.test.ts
+++ b/packages/bluesky-api/src/api.test.ts
@@ -182,6 +182,10 @@ describe('BlueskyApi', () => {
       unmuteUser: jest.fn().mockResolvedValue({}),
       muteActorList: jest.fn().mockResolvedValue({}),
       muteThread: jest.fn().mockResolvedValue({}),
+      createListItem: jest.fn().mockResolvedValue({ uri: 'at://listitem/1' }),
+      deleteListItem: jest.fn().mockResolvedValue({}),
+      getLists: jest.fn().mockResolvedValue({ lists: [] }),
+      listListItems: jest.fn().mockResolvedValue({ records: [] }),
     };
 
     internal.search = {
@@ -202,6 +206,10 @@ describe('BlueskyApi', () => {
     await api.unmuteUser('jwt', 'did:example');
     await api.muteActorList('jwt', 'at://list/1');
     await api.muteThread('jwt', 'at://post/1');
+    await api.createListItem('jwt', 'at://list/1', 'did:example');
+    await api.deleteListItem('jwt', 'at://listitem/1');
+    await api.getLists('jwt', 'did:example', 25, 'cursor-1');
+    await api.listListItems('jwt', 'did:example', 100, 'cursor-2');
     await expect(api.searchProfiles('jwt', 'query', 10)).resolves.toBe(actorResults);
     await expect(api.searchPosts('jwt', 'query', 10)).resolves.toBe(postResults);
     await expect(api.listNotifications('jwt', 20)).resolves.toBe(notifications);
@@ -218,6 +226,10 @@ describe('BlueskyApi', () => {
       undefined,
     );
     expect(internal.notifications.getUnreadCount).toHaveBeenCalledWith('jwt');
+    expect(internal.graph.createListItem).toHaveBeenCalledWith('jwt', 'at://list/1', 'did:example');
+    expect(internal.graph.deleteListItem).toHaveBeenCalledWith('jwt', 'at://listitem/1');
+    expect(internal.graph.getLists).toHaveBeenCalledWith('jwt', 'did:example', 25, 'cursor-1');
+    expect(internal.graph.listListItems).toHaveBeenCalledWith('jwt', 'did:example', 100, 'cursor-2');
   });
 
   it('creates instances using the static helper', () => {

--- a/packages/bluesky-api/src/api.ts
+++ b/packages/bluesky-api/src/api.ts
@@ -14,11 +14,14 @@ import type {
   BlueskyMessagesResponse,
   BlueskyCreatePostInput,
   BlueskyCreatePostResponse,
+  BlueskyCreateRecordResponse,
   BlueskyFeedGeneratorsResponse,
   BlueskyNotificationsResponse,
   BlueskyPostView,
   BlueskyPreferencesResponse,
   BlueskyProfileResponse,
+  BlueskyListItemsResponse,
+  BlueskyListsResponse,
   BlueskySearchActorsResponse,
   BlueskySearchPostsResponse,
   BlueskySendMessageResponse,
@@ -439,6 +442,61 @@ export class BlueskyApi extends BlueskyApiClient {
    */
   async muteThread(accessJwt: string, root: string) {
     return this.graph.muteThread(accessJwt, root);
+  }
+
+  /**
+   * Adds an actor to a list owned by the authenticated user.
+   * @param accessJwt - Valid session token for the list owner.
+   * @param list - URI of the list that should receive the member.
+   * @param subject - DID of the actor being added to the list.
+   * @returns Record metadata describing the new list item.
+   */
+  async createListItem(accessJwt: string, list: string, subject: string): Promise<BlueskyCreateRecordResponse> {
+    return this.graph.createListItem(accessJwt, list, subject);
+  }
+
+  /**
+   * Removes an actor from one of the authenticated user's lists.
+   * @param accessJwt - Valid session token for the list owner.
+   * @param listItemUri - URI of the list item record to delete.
+   * @returns Response payload from the deleteRecord mutation.
+   */
+  async deleteListItem(accessJwt: string, listItemUri: string) {
+    return this.graph.deleteListItem(accessJwt, listItemUri);
+  }
+
+  /**
+   * Retrieves lists created by the supplied actor.
+   * @param accessJwt - Valid session token authorised to enumerate lists.
+   * @param actor - DID or handle identifying the list owner.
+   * @param limit - Maximum number of lists to fetch in a single page.
+   * @param cursor - Pagination cursor returned by previous requests.
+   * @returns Collection of lists created by the actor.
+   */
+  async getLists(
+    accessJwt: string,
+    actor: string,
+    limit: number = 50,
+    cursor?: string,
+  ): Promise<BlueskyListsResponse> {
+    return this.graph.getLists(accessJwt, actor, limit, cursor);
+  }
+
+  /**
+   * Lists list item records created by the supplied repository.
+   * @param accessJwt - Valid session token authorised to query the repository.
+   * @param repo - DID or handle of the repository whose list items should be listed.
+   * @param limit - Maximum number of records to fetch in a single request.
+   * @param cursor - Pagination cursor returned from previous calls.
+   * @returns Repository records belonging to the listitem collection.
+   */
+  async listListItems(
+    accessJwt: string,
+    repo: string,
+    limit: number = 100,
+    cursor?: string,
+  ): Promise<BlueskyListItemsResponse> {
+    return this.graph.listListItems(accessJwt, repo, limit, cursor);
   }
 
   /**

--- a/packages/bluesky-api/src/graph.ts
+++ b/packages/bluesky-api/src/graph.ts
@@ -1,4 +1,9 @@
 import { BlueskyApiClient } from './client';
+import type {
+  BlueskyCreateRecordResponse,
+  BlueskyListItemsResponse,
+  BlueskyListsResponse,
+} from './types';
 
 /**
  * Bluesky API graph methods (follows, blocks, mutes, etc.)
@@ -130,6 +135,90 @@ export class BlueskyGraph extends BlueskyApiClient {
       method: 'POST',
       body: {
         root,
+      },
+    });
+  }
+
+  /**
+   * Adds an actor to one of the viewer's lists.
+   * @param accessJwt - Valid access JWT token.
+   * @param list - The list URI that should receive the member.
+   * @param subject - DID of the actor that should be added to the list.
+   * @returns Record metadata returned by the createRecord mutation.
+   */
+  async createListItem(accessJwt: string, list: string, subject: string): Promise<BlueskyCreateRecordResponse> {
+    return this.makeAuthenticatedRequest('/com.atproto.repo.createRecord', accessJwt, {
+      method: 'POST',
+      body: {
+        repo: 'self',
+        collection: 'app.bsky.graph.listitem',
+        record: {
+          list,
+          subject,
+          createdAt: new Date().toISOString(),
+        },
+      },
+    });
+  }
+
+  /**
+   * Removes an actor from one of the viewer's lists.
+   * @param accessJwt - Valid access JWT token.
+   * @param listItemUri - URI of the list item record to delete.
+   * @returns Response payload from the deleteRecord mutation.
+   */
+  async deleteListItem(accessJwt: string, listItemUri: string) {
+    return this.makeAuthenticatedRequest('/com.atproto.repo.deleteRecord', accessJwt, {
+      method: 'POST',
+      body: {
+        uri: listItemUri,
+      },
+    });
+  }
+
+  /**
+   * Retrieves lists owned by the specified actor.
+   * @param accessJwt - Valid access JWT token.
+   * @param actor - DID or handle of the actor whose lists should be returned.
+   * @param limit - Maximum number of lists to return.
+   * @param cursor - Pagination cursor from a previous request.
+   * @returns Collection of list views.
+   */
+  async getLists(
+    accessJwt: string,
+    actor: string,
+    limit: number = 50,
+    cursor?: string,
+  ): Promise<BlueskyListsResponse> {
+    return this.makeAuthenticatedRequest('/app.bsky.graph.getLists', accessJwt, {
+      params: {
+        actor,
+        limit: limit.toString(),
+        ...(cursor ? { cursor } : {}),
+      },
+    });
+  }
+
+  /**
+   * Lists list item records stored in a repository.
+   * @param accessJwt - Valid access JWT token.
+   * @param repo - DID or handle of the repository to inspect.
+   * @param limit - Maximum number of records to return per page.
+   * @param cursor - Pagination cursor from a previous request.
+   * @returns List item records created by the repository owner.
+   */
+  async listListItems(
+    accessJwt: string,
+    repo: string,
+    limit: number = 100,
+    cursor?: string,
+  ): Promise<BlueskyListItemsResponse> {
+    return this.makeAuthenticatedRequest('/com.atproto.repo.listRecords', accessJwt, {
+      params: {
+        repo,
+        collection: 'app.bsky.graph.listitem',
+        limit: limit.toString(),
+        ...(cursor ? { cursor } : {}),
       },
     });
   }

--- a/packages/bluesky-api/src/types.ts
+++ b/packages/bluesky-api/src/types.ts
@@ -150,6 +150,64 @@ export type BlueskyProfileUpdateInput = {
   banner?: string;
 };
 
+export type BlueskyCreateRecordResponse = {
+  uri: string;
+  cid: string;
+  commit?: unknown;
+  validationStatus?: string;
+};
+
+export type BlueskyListPurpose =
+  | 'app.bsky.graph.defs#modlist'
+  | 'app.bsky.graph.defs#curatelist'
+  | 'app.bsky.graph.defs#referencelist';
+
+export type BlueskyListViewerState = {
+  muted?: boolean;
+  blocked?: string;
+};
+
+export type BlueskyListCreator = {
+  did: string;
+  handle: string;
+  displayName?: string;
+  avatar?: string;
+};
+
+export type BlueskyListView = {
+  uri: string;
+  cid: string;
+  creator: BlueskyListCreator;
+  name: string;
+  purpose: BlueskyListPurpose;
+  description?: string;
+  avatar?: string;
+  listItemCount?: number;
+  labels?: BlueskyLabel[];
+  indexedAt: string;
+  viewer?: BlueskyListViewerState;
+};
+
+export type BlueskyListsResponse = {
+  cursor?: string;
+  lists: BlueskyListView[];
+};
+
+export type BlueskyListItemRecord = {
+  uri: string;
+  cid: string;
+  value: {
+    subject: string;
+    list: string;
+    createdAt: string;
+  };
+};
+
+export type BlueskyListItemsResponse = {
+  cursor?: string;
+  records: BlueskyListItemRecord[];
+};
+
 export type BlueskyFeedGeneratorsResponse = {
   feeds: BlueskyFeed[];
 };


### PR DESCRIPTION
## Summary
- add Bluesky API helpers and types for creating, deleting, and listing list items
- introduce hooks and a list management modal to fetch lists, display membership, and mutate selections with toasts
- wire the modal into both profile screens and update tests to cover the new flows

## Testing
- npm run lint -- --filter=bluesky-api
- npm run lint -- --filter=akari
- npm run test -- --filter=bluesky-api
- npm run test -- --filter=akari -- --runTestsByPath __tests__/components/profile/ProfileListManagerModal.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d93a768a64832b8862cdb4212e4116