### PR TITLE
feat(profile): add Leaflets tab with document viewer

### DIFF
--- a/apps/akari/__tests__/app/profile/[handle].test.tsx
+++ b/apps/akari/__tests__/app/profile/[handle].test.tsx
@@ -43,7 +43,7 @@ jest.mock('@/components/ProfileTabs', () => {
   return {
     ProfileTabs: ({ onTabChange }: any) => (
       <>
-        {['posts', 'replies', 'likes', 'media', 'videos', 'feeds', 'starterpacks', 'unknown'].map(
+        {['posts', 'replies', 'likes', 'media', 'videos', 'leaflets', 'feeds', 'starterpacks', 'unknown'].map(
           (tab) => (
             <Text key={tab} accessibilityRole="button" onPress={() => onTabChange(tab as any)}>
               {tab}
@@ -125,6 +125,11 @@ jest.mock('@/components/profile/VideosTab', () => {
 jest.mock('@/components/profile/FeedsTab', () => {
   const { Text } = require('react-native');
   return { FeedsTab: ({ handle }: any) => <Text>{`feeds ${handle}`}</Text> };
+});
+
+jest.mock('@/components/profile/LeafletsTab', () => {
+  const { Text } = require('react-native');
+  return { LeafletsTab: ({ did }: any) => <Text>{`leaflets ${did}`}</Text> };
 });
 
 jest.mock('@/components/profile/StarterpacksTab', () => {
@@ -213,6 +218,8 @@ describe('ProfileScreen', () => {
     expect(getByText('media alice')).toBeTruthy();
     fireEvent.press(getByText('videos'));
     expect(getByText('videos alice')).toBeTruthy();
+    fireEvent.press(getByText('leaflets'));
+    expect(getByText('leaflets did')).toBeTruthy();
     fireEvent.press(getByText('feeds'));
     expect(getByText('feeds alice')).toBeTruthy();
     fireEvent.press(getByText('starterpacks'));

--- a/apps/akari/__tests__/app/tabs-profile.test.tsx
+++ b/apps/akari/__tests__/app/tabs-profile.test.tsx
@@ -148,6 +148,9 @@ jest.mock('@/components/ProfileTabs', () => {
         <TouchableOpacity onPress={() => onTabChange('videos')}>
           <Text>videos tab</Text>
         </TouchableOpacity>
+        <TouchableOpacity onPress={() => onTabChange('leaflets')}>
+          <Text>leaflets tab</Text>
+        </TouchableOpacity>
         <TouchableOpacity onPress={() => onTabChange('feeds')}>
           <Text>feeds tab</Text>
         </TouchableOpacity>
@@ -196,6 +199,12 @@ jest.mock('@/components/profile/FeedsTab', () => {
   const React = require('react');
   const { Text } = require('react-native');
   return { FeedsTab: ({ handle }: any) => <Text>feeds {handle}</Text> };
+});
+
+jest.mock('@/components/profile/LeafletsTab', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return { LeafletsTab: ({ did }: any) => <Text>leaflets {did}</Text> };
 });
 
 jest.mock('@/components/profile/StarterpacksTab', () => {
@@ -253,7 +262,7 @@ describe('ProfileScreen', () => {
   });
 
   it('renders all tab content and registers scroll handler', () => {
-    mockUseCurrentAccount.mockReturnValue({ data: { handle: 'alice' } });
+    mockUseCurrentAccount.mockReturnValue({ data: { handle: 'alice', did: 'did:alice' } });
     mockUseProfile.mockReturnValue({ data: { displayName: 'Alice' } });
 
     const { getByText } = render(<ProfileScreen />);
@@ -271,6 +280,9 @@ describe('ProfileScreen', () => {
 
     fireEvent.press(getByText('videos tab'));
     expect(getByText('videos alice')).toBeTruthy();
+
+    fireEvent.press(getByText('leaflets tab'));
+    expect(getByText('leaflets did:alice')).toBeTruthy();
 
     fireEvent.press(getByText('feeds tab'));
     expect(getByText('feeds alice')).toBeTruthy();

--- a/apps/akari/__tests__/components/ProfileTabs.test.tsx
+++ b/apps/akari/__tests__/components/ProfileTabs.test.tsx
@@ -29,6 +29,7 @@ describe('ProfileTabs', () => {
           'profile.media': 'Media',
           'common.likes': 'Likes',
           'profile.videos': 'Videos',
+          'profile.leaflets': 'Leaflets',
           'profile.feeds': 'Feeds',
           'profile.starterpacks': 'Starterpacks',
         };
@@ -54,6 +55,7 @@ describe('ProfileTabs', () => {
       'Media',
       'Likes',
       'Videos',
+      'Leaflets',
       'Feeds',
       'Starterpacks',
     ];
@@ -74,7 +76,7 @@ describe('ProfileTabs', () => {
       />,
     );
 
-    const labels = ['Posts', 'Replies', 'Media', 'Videos', 'Feeds', 'Starterpacks'];
+    const labels = ['Posts', 'Replies', 'Media', 'Videos', 'Leaflets', 'Feeds', 'Starterpacks'];
 
     for (const label of labels) {
       expect(getByText(label)).toBeTruthy();

--- a/apps/akari/__tests__/components/profile/LeafletsTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/LeafletsTab.test.tsx
@@ -1,0 +1,147 @@
+import { act, fireEvent, render } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+import { LeafletsTab } from '@/components/profile/LeafletsTab';
+import { useLeafletDocuments } from '@/hooks/queries/useLeafletDocuments';
+import { useThemeColor } from '@/hooks/useThemeColor';
+import { useTranslation } from '@/hooks/useTranslation';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
+
+jest.mock('@/hooks/queries/useLeafletDocuments');
+jest.mock('@/hooks/useThemeColor');
+jest.mock('@/hooks/useTranslation');
+jest.mock('@/components/skeletons', () => {
+  const { Text } = require('react-native');
+  return { FeedSkeleton: () => <Text>leaflets skeleton</Text> };
+});
+jest.mock('@shopify/flash-list', () => require('../../../test-utils/flash-list'));
+
+const mockUseLeafletDocuments = useLeafletDocuments as jest.Mock;
+const mockUseThemeColor = useThemeColor as jest.Mock;
+const mockUseTranslation = useTranslation as jest.Mock;
+
+describe('LeafletsTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseThemeColor.mockImplementation((palette) => palette.light);
+    mockUseTranslation.mockReturnValue({
+      t: (key: string) =>
+        ({
+          'profile.noLeaflets': 'profile.noLeaflets',
+          'profile.expandLeaflet': 'profile.expandLeaflet',
+          'profile.collapseLeaflet': 'profile.collapseLeaflet',
+          'common.loading': 'common.loading',
+        }[key] ?? key),
+    });
+  });
+
+  it('renders loading skeleton while fetching', () => {
+    mockUseLeafletDocuments.mockReturnValue({
+      data: [],
+      isLoading: true,
+      isError: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    const { getByText } = render(<LeafletsTab did="did:example" />);
+    expect(getByText('leaflets skeleton')).toBeTruthy();
+  });
+
+  it('shows empty state when no documents', () => {
+    mockUseLeafletDocuments.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    const { getByText } = render(<LeafletsTab did="did:example" />);
+    expect(getByText('profile.noLeaflets')).toBeTruthy();
+  });
+
+  it('renders documents and loads additional pages', () => {
+    const fetchNextPage = jest.fn();
+    const document = {
+      uri: 'at://did:example/pub.leaflet.document/doc1',
+      cid: 'cid1',
+      value: {
+        title: 'Leaflet One',
+        description: 'Summary text',
+        publishedAt: new Date().toISOString(),
+        pages: [
+          {
+            blocks: [
+              {
+                block: {
+                  $type: 'pub.leaflet.blocks.text',
+                  plaintext: 'Full content',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    mockUseLeafletDocuments.mockReturnValue({
+      data: [document],
+      isLoading: false,
+      isError: false,
+      fetchNextPage,
+      hasNextPage: true,
+      isFetchingNextPage: false,
+    });
+
+    const { getByText, queryByText, UNSAFE_getByType } = render(<LeafletsTab did="did:example" />);
+
+    expect(getByText('Leaflet One')).toBeTruthy();
+    expect(getByText('Summary text')).toBeTruthy();
+    expect(queryByText('Full content')).toBeNull();
+
+    fireEvent.press(getByText('profile.expandLeaflet'));
+    expect(getByText('Full content')).toBeTruthy();
+
+    act(() => {
+      UNSAFE_getByType(VirtualizedList).props.onEndReached();
+    });
+    expect(fetchNextPage).toHaveBeenCalled();
+  });
+
+  it('shows loading footer when fetching next page', () => {
+    mockUseLeafletDocuments.mockReturnValue({
+      data: [
+        {
+          uri: 'at://did:example/pub.leaflet.document/doc1',
+          cid: 'cid1',
+          value: { description: 'Summary' },
+        },
+      ],
+      isLoading: false,
+      isError: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: true,
+      isFetchingNextPage: true,
+    });
+
+    const { getByText } = render(<LeafletsTab did="did:example" />);
+    expect(getByText('common.loading')).toBeTruthy();
+  });
+
+  it('falls back to empty state when the query errors', () => {
+    mockUseLeafletDocuments.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    const { getByText } = render(<LeafletsTab did="did:example" />);
+    expect(getByText('profile.noLeaflets')).toBeTruthy();
+  });
+});

--- a/apps/akari/__tests__/hooks/useLeafletDocuments.test.tsx
+++ b/apps/akari/__tests__/hooks/useLeafletDocuments.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import { useLeafletDocuments } from '@/hooks/queries/useLeafletDocuments';
+
+const mockListRecords = jest.fn();
+const mockGetPdsUrlFromDid = jest.fn();
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    listRecords: mockListRecords,
+  })),
+  getPdsUrlFromDid: jest.fn((did: string) => mockGetPdsUrlFromDid(did)),
+}));
+
+describe('useLeafletDocuments', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetPdsUrlFromDid.mockResolvedValue('https://pds.example');
+  });
+
+  it('fetches and paginates leaflet documents', async () => {
+    mockListRecords
+      .mockResolvedValueOnce({
+        records: [{ uri: 'doc1' }],
+        cursor: 'cursor1',
+      })
+      .mockResolvedValueOnce({
+        records: [{ uri: 'doc2' }],
+        cursor: undefined,
+      });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useLeafletDocuments('did:example:alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual([{ uri: 'doc1' }]);
+    expect(mockGetPdsUrlFromDid).toHaveBeenCalledTimes(1);
+    expect(mockGetPdsUrlFromDid).toHaveBeenCalledWith('did:example:alice');
+    expect(mockListRecords).toHaveBeenCalledWith({
+      collection: 'pub.leaflet.document',
+      repo: 'did:example:alice',
+      limit: 5,
+      cursor: undefined,
+      reverse: true,
+    });
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ uri: 'doc1' }, { uri: 'doc2' }]);
+    });
+
+    expect(mockListRecords).toHaveBeenLastCalledWith({
+      collection: 'pub.leaflet.document',
+      repo: 'did:example:alice',
+      limit: 5,
+      cursor: 'cursor1',
+      reverse: true,
+    });
+    expect(mockGetPdsUrlFromDid).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when DID is missing', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useLeafletDocuments(undefined), { wrapper });
+
+    await expect(result.current.refetch({ throwOnError: true })).rejects.toThrow('No DID provided');
+  });
+
+  it('throws when PDS cannot be resolved', async () => {
+    mockGetPdsUrlFromDid.mockResolvedValueOnce(null);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useLeafletDocuments('did:example:alice'), { wrapper });
+
+    await expect(result.current.refetch({ throwOnError: true })).rejects.toThrow(
+      'Unable to resolve PDS URL',
+    );
+  });
+});

--- a/apps/akari/app/(tabs)/profile/[handle].tsx
+++ b/apps/akari/app/(tabs)/profile/[handle].tsx
@@ -15,6 +15,7 @@ import { PostsTab } from '@/components/profile/PostsTab';
 import { RepliesTab } from '@/components/profile/RepliesTab';
 import { StarterpacksTab } from '@/components/profile/StarterpacksTab';
 import { VideosTab } from '@/components/profile/VideosTab';
+import { LeafletsTab } from '@/components/profile/LeafletsTab';
 import { searchProfilePosts } from '@/components/profile/profileActions';
 import { ProfileHeaderSkeleton } from '@/components/skeletons';
 import { useToast } from '@/contexts/ToastContext';
@@ -132,6 +133,8 @@ export default function ProfileScreen() {
   const renderTabContent = () => {
     if (!handle) return null;
 
+    const did = profile?.did;
+
     switch (activeTab) {
       case 'posts':
         return <PostsTab handle={handle} />;
@@ -143,6 +146,11 @@ export default function ProfileScreen() {
         return <MediaTab handle={handle} />;
       case 'videos':
         return <VideosTab handle={handle} />;
+      case 'leaflets':
+        if (!did) {
+          return null;
+        }
+        return <LeafletsTab did={did} />;
       case 'feeds':
         return <FeedsTab handle={handle} />;
       case 'starterpacks':

--- a/apps/akari/app/(tabs)/profile/index.tsx
+++ b/apps/akari/app/(tabs)/profile/index.tsx
@@ -14,6 +14,7 @@ import { PostsTab } from '@/components/profile/PostsTab';
 import { RepliesTab } from '@/components/profile/RepliesTab';
 import { StarterpacksTab } from '@/components/profile/StarterpacksTab';
 import { VideosTab } from '@/components/profile/VideosTab';
+import { LeafletsTab } from '@/components/profile/LeafletsTab';
 import { searchProfilePosts } from '@/components/profile/profileActions';
 import { useToast } from '@/contexts/ToastContext';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
@@ -115,6 +116,8 @@ export default function ProfileScreen() {
       );
     }
 
+    const did = profile?.did ?? currentAccount?.did;
+
     switch (activeTab) {
       case 'posts':
         return <PostsTab handle={currentAccount.handle} />;
@@ -126,6 +129,15 @@ export default function ProfileScreen() {
         return <MediaTab handle={currentAccount.handle} />;
       case 'videos':
         return <VideosTab handle={currentAccount.handle} />;
+      case 'leaflets':
+        if (!did) {
+          return (
+            <ThemedView style={styles.emptyState}>
+              <ThemedText style={styles.emptyStateText}>{t('profile.noLeaflets')}</ThemedText>
+            </ThemedView>
+          );
+        }
+        return <LeafletsTab did={did} />;
       case 'feeds':
         return <FeedsTab handle={currentAccount.handle} />;
       case 'starterpacks':

--- a/apps/akari/components/ProfileTabs.tsx
+++ b/apps/akari/components/ProfileTabs.tsx
@@ -21,6 +21,7 @@ export function ProfileTabs({ activeTab, onTabChange, profileHandle }: ProfileTa
     { key: 'media' as const, label: t('profile.media') },
     ...(isOwnProfile ? [{ key: 'likes' as const, label: t('common.likes') }] : []),
     { key: 'videos' as const, label: t('profile.videos') },
+    { key: 'leaflets' as const, label: t('profile.leaflets') },
     { key: 'feeds' as const, label: t('profile.feeds') },
     { key: 'starterpacks' as const, label: t('profile.starterpacks') },
   ];

--- a/apps/akari/components/profile/LeafletsTab.tsx
+++ b/apps/akari/components/profile/LeafletsTab.tsx
@@ -1,0 +1,318 @@
+import { useState } from 'react';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
+
+import { ExternalLink } from '@/components/ExternalLink';
+import { FeedSkeleton } from '@/components/skeletons';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
+import {
+  type LeafletDocumentBlock,
+  type LeafletDocumentListItem,
+  type LeafletListItem,
+  useLeafletDocuments,
+} from '@/hooks/queries/useLeafletDocuments';
+import { useThemeColor } from '@/hooks/useThemeColor';
+import { useTranslation } from '@/hooks/useTranslation';
+import { formatRelativeTime } from '@/utils/timeUtils';
+
+type LeafletsTabProps = {
+  did: string;
+};
+
+const ESTIMATED_LEAFLET_CARD_HEIGHT = 260;
+
+function LeafletList({ items }: { items: LeafletListItem[] }) {
+  if (!items || items.length === 0) {
+    return null;
+  }
+
+  return (
+    <ThemedView style={styles.listContainer}>
+      {items.map((item, index) => {
+        if (!item.content?.plaintext) {
+          return null;
+        }
+
+        return (
+          <View key={`${item.content.plaintext}-${index}`} style={styles.listItem}>
+            <ThemedText style={styles.listBullet}>•</ThemedText>
+            <ThemedText style={styles.listText}>{item.content.plaintext}</ThemedText>
+          </View>
+        );
+      })}
+    </ThemedView>
+  );
+}
+
+function LeafletBlockView({ block }: { block: LeafletDocumentBlock }) {
+  const content = block.block;
+  const type = content.$type;
+  const borderAccent = useThemeColor({ light: '#d2d2d7', dark: '#2c2c2e' }, 'background');
+  const blockquoteBorderColor = useThemeColor({ light: '#8e8e93', dark: '#636366' }, 'text');
+  const inlineColor = useThemeColor({ light: '#6e6e73', dark: '#8e8e93' }, 'text');
+
+  if (!type) {
+    return null;
+  }
+
+  if (type === 'pub.leaflet.blocks.text') {
+    if (!content.plaintext) {
+      return null;
+    }
+
+    return <ThemedText style={styles.paragraph}>{content.plaintext}</ThemedText>;
+  }
+
+  if (type === 'pub.leaflet.blocks.header') {
+    return content.plaintext ? (
+      <ThemedText style={styles.heading}>{content.plaintext}</ThemedText>
+    ) : null;
+  }
+
+  if (type === 'pub.leaflet.blocks.blockquote') {
+    return content.plaintext ? (
+      <ThemedText style={[styles.blockquote, { borderLeftColor: blockquoteBorderColor }]}>
+        {content.plaintext}
+      </ThemedText>
+    ) : null;
+  }
+
+  if (type === 'pub.leaflet.blocks.website') {
+    return (
+      <ThemedView style={[styles.linkCard, { borderColor: borderAccent }]}>
+        {content.title ? <ThemedText style={styles.linkTitle}>{content.title}</ThemedText> : null}
+        {content.description ? (
+          <ThemedText style={styles.linkDescription}>{content.description}</ThemedText>
+        ) : null}
+        {content.src ? (
+          <ExternalLink href={content.src}>
+            <ThemedText style={[styles.linkUrl, { color: inlineColor }]}>{content.src}</ThemedText>
+          </ExternalLink>
+        ) : null}
+      </ThemedView>
+    );
+  }
+
+  if (type === 'pub.leaflet.blocks.bskyPost') {
+    const uri = content.postRef?.uri;
+    return uri ? <ThemedText style={[styles.inlineMeta, { color: inlineColor }]}>{uri}</ThemedText> : null;
+  }
+
+  if (type === 'pub.leaflet.blocks.unorderedList') {
+    return <LeafletList items={content.children ?? []} />;
+  }
+
+  return null;
+}
+
+function LeafletDocumentItem({ document }: { document: LeafletDocumentListItem }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const { t } = useTranslation();
+  const backgroundColor = useThemeColor({ light: '#ffffff', dark: '#1c1c1e' }, 'background');
+  const borderColor = useThemeColor({ light: '#e5e5ea', dark: '#2c2c2e' }, 'background');
+  const secondaryTextColor = useThemeColor({ light: '#6e6e73', dark: '#8e8e93' }, 'text');
+
+  const description = document.value?.description;
+  const title = document.value?.title;
+  const publishedAt = document.value?.publishedAt ? formatRelativeTime(document.value.publishedAt) : undefined;
+  const blocks = document.value?.pages?.flatMap((page) => page.blocks ?? []) ?? [];
+
+  return (
+    <ThemedView style={[styles.leafletCard, { backgroundColor, borderColor }]}> 
+      {title ? <ThemedText style={styles.title}>{title}</ThemedText> : null}
+      {publishedAt ? (
+        <ThemedText style={[styles.meta, { color: secondaryTextColor }]}>{publishedAt}</ThemedText>
+      ) : null}
+      {description ? (
+        <ThemedText style={[styles.description, { color: secondaryTextColor }]} numberOfLines={isExpanded ? undefined : 3}>
+          {description}
+        </ThemedText>
+      ) : null}
+
+      {isExpanded ? (
+        <ThemedView style={styles.fullContent}>
+          {blocks.map((block, index) => (
+            <LeafletBlockView key={index} block={block} />
+          ))}
+        </ThemedView>
+      ) : null}
+
+      {blocks.length > 0 || description ? (
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessibilityLabel={isExpanded ? t('profile.collapseLeaflet') : t('profile.expandLeaflet')}
+          onPress={() => setIsExpanded((value) => !value)}
+          style={styles.expandButton}
+        >
+          <ThemedText style={styles.expandLabel}>
+            {isExpanded ? t('profile.collapseLeaflet') : t('profile.expandLeaflet')}
+          </ThemedText>
+        </TouchableOpacity>
+      ) : null}
+    </ThemedView>
+  );
+}
+
+/**
+ * Profile tab that surfaces Leaflet publications with expandable full document content.
+ * @param did - DID of the profile owner whose Leaflet posts should be displayed.
+ */
+export function LeafletsTab({ did }: LeafletsTabProps) {
+  const { t } = useTranslation();
+  const {
+    data: documents,
+    isLoading,
+    isError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useLeafletDocuments(did);
+
+  const handleLoadMore = () => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  };
+
+  if (isLoading) {
+    return <FeedSkeleton count={3} />;
+  }
+
+  if (isError || !documents || documents.length === 0) {
+    return (
+      <ThemedView style={styles.emptyContainer}>
+        <ThemedText style={styles.emptyText}>{t('profile.noLeaflets')}</ThemedText>
+      </ThemedView>
+    );
+  }
+
+  const renderItem = ({ item }: { item: LeafletDocumentListItem }) => <LeafletDocumentItem document={item} />;
+
+  const renderFooter = () => {
+    if (!isFetchingNextPage) {
+      return null;
+    }
+
+    return (
+      <ThemedView style={styles.loadingFooter}>
+        <ThemedText style={styles.loadingText}>{t('common.loading')}</ThemedText>
+      </ThemedView>
+    );
+  };
+
+  return (
+    <VirtualizedList
+      data={documents}
+      renderItem={renderItem}
+      keyExtractor={(item) => item.uri}
+      onEndReached={handleLoadMore}
+      onEndReachedThreshold={0.1}
+      ListFooterComponent={renderFooter}
+      showsVerticalScrollIndicator={false}
+      scrollEnabled={false}
+      estimatedItemSize={ESTIMATED_LEAFLET_CARD_HEIGHT}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  emptyContainer: {
+    paddingVertical: 60,
+    alignItems: 'center',
+  },
+  emptyText: {
+    fontSize: 16,
+    opacity: 0.6,
+  },
+  loadingFooter: {
+    paddingVertical: 20,
+    alignItems: 'center',
+  },
+  loadingText: {
+    fontSize: 14,
+    opacity: 0.6,
+  },
+  leafletCard: {
+    marginHorizontal: 16,
+    marginVertical: 8,
+    borderRadius: 12,
+    borderWidth: 1,
+    padding: 16,
+    gap: 8,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  meta: {
+    fontSize: 13,
+  },
+  description: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  fullContent: {
+    gap: 10,
+  },
+  paragraph: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  heading: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  blockquote: {
+    fontSize: 14,
+    fontStyle: 'italic',
+    borderLeftWidth: 3,
+    paddingLeft: 10,
+  },
+  linkCard: {
+    borderWidth: 1,
+    borderRadius: 10,
+    padding: 12,
+    gap: 4,
+  },
+  linkTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  linkDescription: {
+    fontSize: 14,
+  },
+  linkUrl: {
+    fontSize: 13,
+    textDecorationLine: 'underline',
+  },
+  inlineMeta: {
+    fontSize: 13,
+    opacity: 0.7,
+  },
+  listContainer: {
+    gap: 6,
+  },
+  listItem: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 6,
+  },
+  listBullet: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  listText: {
+    flex: 1,
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  expandButton: {
+    alignSelf: 'flex-start',
+    paddingVertical: 6,
+  },
+  expandLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/apps/akari/hooks/queries/useLeafletDocuments.ts
+++ b/apps/akari/hooks/queries/useLeafletDocuments.ts
@@ -1,0 +1,114 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useRef } from 'react';
+
+import { BlueskyApi, getPdsUrlFromDid } from '@/bluesky-api';
+import type { BlueskyRepoRecord } from '@/bluesky-api';
+
+export type LeafletDocumentListItem = BlueskyRepoRecord<LeafletDocumentRecord>;
+
+export type LeafletDocumentRecord = {
+  $type?: string;
+  title?: string;
+  description?: string;
+  publishedAt?: string;
+  pages?: LeafletDocumentPage[];
+  postRef?: {
+    uri?: string;
+    cid?: string;
+  };
+};
+
+export type LeafletDocumentPage = {
+  $type?: string;
+  blocks?: LeafletDocumentBlock[];
+};
+
+export type LeafletDocumentBlock = {
+  $type?: string;
+  block: {
+    $type?: string;
+    plaintext?: string;
+    level?: number;
+    src?: string;
+    title?: string;
+    description?: string;
+    postRef?: {
+      uri?: string;
+      cid?: string;
+    };
+    facets?: {
+      index: {
+        byteStart: number;
+        byteEnd: number;
+      };
+      features: {
+        $type: string;
+        uri?: string;
+      }[];
+    }[];
+    children?: LeafletListItem[];
+  };
+  alignment?: string;
+  children?: {
+    content: {
+      $type?: string;
+      plaintext?: string;
+    };
+    children?: unknown[];
+  }[];
+};
+
+export type LeafletListItem = {
+  $type?: string;
+  content?: {
+    $type?: string;
+    plaintext?: string;
+  };
+  children?: LeafletListItem[];
+};
+
+/**
+ * Infinite query hook that loads Leaflet documents for a profile directly from their repository.
+ * @param did - DID of the author whose Leaflet posts should be retrieved.
+ * @param limit - Maximum number of records to request per page (default: 10).
+ */
+export function useLeafletDocuments(did: string | undefined, limit: number = 10) {
+  const pdsUrlRef = useRef<string | null>(null);
+
+  return useInfiniteQuery({
+    queryKey: ['leafletDocuments', did, limit],
+    enabled: !!did,
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.cursor,
+    staleTime: 5 * 60 * 1000,
+    select: (data) => data.pages.flatMap((page) => page.documents),
+    queryFn: async ({ pageParam }) => {
+      if (!did) {
+        throw new Error('No DID provided');
+      }
+
+      let pdsUrl = pdsUrlRef.current;
+      if (!pdsUrl) {
+        pdsUrl = await getPdsUrlFromDid(did);
+        if (!pdsUrl) {
+          throw new Error('Unable to resolve PDS URL');
+        }
+        pdsUrlRef.current = pdsUrl;
+      }
+
+      const api = new BlueskyApi(pdsUrl);
+      const response = await api.listRecords<LeafletDocumentRecord>({
+        collection: 'pub.leaflet.document',
+        repo: did,
+        limit,
+        cursor: pageParam,
+        reverse: true,
+      });
+
+      return {
+        documents: response.records,
+        cursor: response.cursor,
+      };
+    },
+  });
+}

--- a/apps/akari/translations/ar.json
+++ b/apps/akari/translations/ar.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "فشل في تحديث الملف الشخصي",
       "handleHistory": "سجل المعرف",
       "noHandleHistory": "لا يوجد سجل للمعرف",
-      "noHandleHistoryDescription": "لم يغيّر هذا المستخدم معرفه بعد."
+      "noHandleHistoryDescription": "لم يغيّر هذا المستخدم معرفه بعد.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "جاري تحميل المزيد من المنشورات...",

--- a/apps/akari/translations/az.json
+++ b/apps/akari/translations/az.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Profilini yeniləmək alınmadı. Xahiş edirəm yenidən cəhd edin.",
       "handleHistory": "Tarixi idarə edin",
       "noHandleHistory": "Dəstək tarixi yoxdur",
-      "noHandleHistoryDescription": "Bu istifadəçi hələ də saplarını dəyişməyib."
+      "noHandleHistoryDescription": "Bu istifadəçi hələ də saplarını dəyişməyib.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Daha çox yazı yüklənir ...",

--- a/apps/akari/translations/bg.json
+++ b/apps/akari/translations/bg.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Неуспешно актуализиране на профила. Моля, опитайте отново.",
       "handleHistory": "Справяне с историята",
       "noHandleHistory": "Без дръжка история",
-      "noHandleHistoryDescription": "Този потребител все още не е променил дръжката си."
+      "noHandleHistoryDescription": "Този потребител все още не е променил дръжката си.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Зареждане на още публикации ...",

--- a/apps/akari/translations/cs.json
+++ b/apps/akari/translations/cs.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Nepodařilo se aktualizovat profil. Zkuste to prosím znovu.",
       "handleHistory": "HISTORIE Zvládněte",
       "noHandleHistory": "Žádná historie rukojeti",
-      "noHandleHistoryDescription": "Tento uživatel ještě nezměnil rukojeť."
+      "noHandleHistoryDescription": "Tento uživatel ještě nezměnil rukojeť.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Načítání více příspěvků ...",

--- a/apps/akari/translations/cy.json
+++ b/apps/akari/translations/cy.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Methu diweddaru proffil",
       "handleHistory": "Hanes handlen",
       "noHandleHistory": "Dim hanes handlen",
-      "noHandleHistoryDescription": "Nid yw'r defnyddiwr hwn wedi newid ei handlen eto."
+      "noHandleHistoryDescription": "Nid yw'r defnyddiwr hwn wedi newid ei handlen eto.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Wrth lwytho mwy o bostiadau...",

--- a/apps/akari/translations/da.json
+++ b/apps/akari/translations/da.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Kunne ikke opdatere profilen. Prøv igen.",
       "handleHistory": "Håndtere historie",
       "noHandleHistory": "Ingen håndtagshistorie",
-      "noHandleHistoryDescription": "Denne bruger har ikke ændret deres håndtag endnu."
+      "noHandleHistoryDescription": "Denne bruger har ikke ændret deres håndtag endnu.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Indlæser flere indlæg ...",

--- a/apps/akari/translations/de.json
+++ b/apps/akari/translations/de.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Profil konnte nicht aktualisiert werden",
       "handleHistory": "Handle-Verlauf",
       "noHandleHistory": "Kein Handle-Verlauf",
-      "noHandleHistoryDescription": "Dieser Nutzer hat sein Handle noch nicht geändert."
+      "noHandleHistoryDescription": "Dieser Nutzer hat sein Handle noch nicht geändert.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Lade weitere Beiträge...",

--- a/apps/akari/translations/el.json
+++ b/apps/akari/translations/el.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Αποτυχία ενημέρωσης προφίλ. Δοκιμάστε ξανά.",
       "handleHistory": "Χειριστήριο ιστορικό",
       "noHandleHistory": "Χωρίς ιστορικό λαβής",
-      "noHandleHistoryDescription": "Αυτός ο χρήστης δεν έχει αλλάξει ακόμα τη λαβή του."
+      "noHandleHistoryDescription": "Αυτός ο χρήστης δεν έχει αλλάξει ακόμα τη λαβή του.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Φόρτωση περισσότερων αναρτήσεων ...",

--- a/apps/akari/translations/en-US.json
+++ b/apps/akari/translations/en-US.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Failed to update profile",
       "handleHistory": "Handle History",
       "noHandleHistory": "No handle history",
-      "noHandleHistoryDescription": "This user hasn't changed their handle yet."
+      "noHandleHistoryDescription": "This user hasn't changed their handle yet.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Loading more posts...",

--- a/apps/akari/translations/en.json
+++ b/apps/akari/translations/en.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Failed to update profile. Please try again.",
       "handleHistory": "Handle History",
       "noHandleHistory": "No handle history",
-      "noHandleHistoryDescription": "This user hasn't changed their handle yet."
+      "noHandleHistoryDescription": "This user hasn't changed their handle yet.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Loading more posts...",

--- a/apps/akari/translations/es.json
+++ b/apps/akari/translations/es.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Error al actualizar perfil",
       "handleHistory": "Historial del identificador",
       "noHandleHistory": "Sin historial de identificador",
-      "noHandleHistoryDescription": "Este usuario aún no ha cambiado su identificador."
+      "noHandleHistoryDescription": "Este usuario aún no ha cambiado su identificador.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Cargando más publicaciones...",

--- a/apps/akari/translations/fa.json
+++ b/apps/akari/translations/fa.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "به روزرسانی نمایه انجام نشد. لطفا دوباره امتحان کنید",
       "handleHistory": "تاریخ رسیدگی",
       "noHandleHistory": "بدون سابقه دسته",
-      "noHandleHistoryDescription": "این کاربر هنوز دسته خود را تغییر نداده است."
+      "noHandleHistoryDescription": "این کاربر هنوز دسته خود را تغییر نداده است.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "در حال بارگیری بیشتر پست ها ...",

--- a/apps/akari/translations/fi.json
+++ b/apps/akari/translations/fi.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Profiilin päivittäminen epäonnistui. Yritä uudelleen.",
       "handleHistory": "Käsityshistoria",
       "noHandleHistory": "Ei kahvahistoriaa",
-      "noHandleHistoryDescription": "Tämä käyttäjä ei ole vielä muuttanut kahtaansa."
+      "noHandleHistoryDescription": "Tämä käyttäjä ei ole vielä muuttanut kahtaansa.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Lataa lisää viestejä ...",

--- a/apps/akari/translations/fr.json
+++ b/apps/akari/translations/fr.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Échec de la mise à jour du profil",
       "handleHistory": "Historique du handle",
       "noHandleHistory": "Aucun historique de handle",
-      "noHandleHistoryDescription": "Cet utilisateur n'a pas encore changé de handle."
+      "noHandleHistoryDescription": "Cet utilisateur n'a pas encore changé de handle.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Chargement de plus de publications...",

--- a/apps/akari/translations/he.json
+++ b/apps/akari/translations/he.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "עדכון הפרופיל נכשל. אנא נסה שוב.",
       "handleHistory": "לטפל בהיסטוריה",
       "noHandleHistory": "אין היסטוריה של ידית",
-      "noHandleHistoryDescription": "משתמש זה עדיין לא שינה את הידית שלו."
+      "noHandleHistoryDescription": "משתמש זה עדיין לא שינה את הידית שלו.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "טוען פוסטים נוספים ...",

--- a/apps/akari/translations/hi.json
+++ b/apps/akari/translations/hi.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "प्रोफ़ाइल अपडेट करने में विफल",
       "handleHistory": "हैंडल इतिहास",
       "noHandleHistory": "कोई हैंडल इतिहास नहीं",
-      "noHandleHistoryDescription": "इस उपयोगकर्ता ने अभी तक अपना हैंडल नहीं बदला है।"
+      "noHandleHistoryDescription": "इस उपयोगकर्ता ने अभी तक अपना हैंडल नहीं बदला है।",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "और पोस्ट लोड हो रही हैं...",

--- a/apps/akari/translations/hu.json
+++ b/apps/akari/translations/hu.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Nem sikerült frissíteni a profilot. Kérjük, próbálkozzon újra.",
       "handleHistory": "Kezelje a történetet",
       "noHandleHistory": "Nincs fogantyú története",
-      "noHandleHistoryDescription": "Ez a felhasználó még nem változtatta meg a fogantyúját."
+      "noHandleHistoryDescription": "Ez a felhasználó még nem változtatta meg a fogantyúját.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "További hozzászólások betöltése ...",

--- a/apps/akari/translations/id.json
+++ b/apps/akari/translations/id.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Gagal memperbarui profil",
       "handleHistory": "Riwayat handle",
       "noHandleHistory": "Tidak ada riwayat handle",
-      "noHandleHistoryDescription": "Pengguna ini belum pernah mengganti handle-nya."
+      "noHandleHistoryDescription": "Pengguna ini belum pernah mengganti handle-nya.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Memuat lebih banyak postingan...",

--- a/apps/akari/translations/it.json
+++ b/apps/akari/translations/it.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Errore nell'aggiornamento del profilo",
       "handleHistory": "Cronologia dell'handle",
       "noHandleHistory": "Nessuna cronologia dell'handle",
-      "noHandleHistoryDescription": "Questo utente non ha ancora cambiato handle."
+      "noHandleHistoryDescription": "Questo utente non ha ancora cambiato handle.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Caricamento di altri post...",

--- a/apps/akari/translations/ja.json
+++ b/apps/akari/translations/ja.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "プロフィールの更新に失敗しました",
       "handleHistory": "ハンドルの履歴",
       "noHandleHistory": "ハンドルの履歴はありません",
-      "noHandleHistoryDescription": "このユーザーはまだハンドルを変更していません。"
+      "noHandleHistoryDescription": "このユーザーはまだハンドルを変更していません。",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "さらに投稿を読み込み中...",

--- a/apps/akari/translations/ko.json
+++ b/apps/akari/translations/ko.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "프로필 업데이트에 실패했습니다",
       "handleHistory": "핸들 변경 기록",
       "noHandleHistory": "핸들 변경 기록이 없습니다",
-      "noHandleHistoryDescription": "이 사용자는 아직 핸들을 변경하지 않았습니다."
+      "noHandleHistoryDescription": "이 사용자는 아직 핸들을 변경하지 않았습니다.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "더 많은 게시물 로딩 중...",

--- a/apps/akari/translations/nl.json
+++ b/apps/akari/translations/nl.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Profiel kon niet worden bijgewerkt",
       "handleHistory": "Handle-geschiedenis",
       "noHandleHistory": "Geen handle-geschiedenis",
-      "noHandleHistoryDescription": "Deze gebruiker heeft zijn handle nog niet gewijzigd."
+      "noHandleHistoryDescription": "Deze gebruiker heeft zijn handle nog niet gewijzigd.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Meer berichten laden...",

--- a/apps/akari/translations/pl.json
+++ b/apps/akari/translations/pl.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Nie udało się zaktualizować profilu",
       "handleHistory": "Historia handle'u",
       "noHandleHistory": "Brak historii handle'u",
-      "noHandleHistoryDescription": "Ten użytkownik jeszcze nie zmienił swojego handle'u."
+      "noHandleHistoryDescription": "Ten użytkownik jeszcze nie zmienił swojego handle'u.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Ładowanie większej liczby postów...",

--- a/apps/akari/translations/pt.json
+++ b/apps/akari/translations/pt.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Erro ao atualizar perfil",
       "handleHistory": "Histórico do identificador",
       "noHandleHistory": "Nenhum histórico do identificador",
-      "noHandleHistoryDescription": "Este usuário ainda não alterou o identificador."
+      "noHandleHistoryDescription": "Este usuário ainda não alterou o identificador.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Carregando mais publicações...",

--- a/apps/akari/translations/ro.json
+++ b/apps/akari/translations/ro.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Nu a reușit să actualizeze profilul. Vă rugăm să încercați din nou.",
       "handleHistory": "Gestionează istoria",
       "noHandleHistory": "Fără istorie",
-      "noHandleHistoryDescription": "Acest utilizator nu și -a schimbat încă mânerul."
+      "noHandleHistoryDescription": "Acest utilizator nu și -a schimbat încă mânerul.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Încărcarea mai multor postări ...",

--- a/apps/akari/translations/ru.json
+++ b/apps/akari/translations/ru.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Не удалось обновить профиль",
       "handleHistory": "История хэндла",
       "noHandleHistory": "Нет истории хэндла",
-      "noHandleHistoryDescription": "Этот пользователь ещё не менял свой хэндл."
+      "noHandleHistoryDescription": "Этот пользователь ещё не менял свой хэндл.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Загрузка дополнительных постов...",

--- a/apps/akari/translations/sk.json
+++ b/apps/akari/translations/sk.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Nepodarilo sa aktualizovať profil. Skúste to znova.",
       "handleHistory": "History",
       "noHandleHistory": "Žiadna história rukovätia",
-      "noHandleHistoryDescription": "Tento používateľ ešte nezmenil ich rukoväť."
+      "noHandleHistoryDescription": "Tento používateľ ešte nezmenil ich rukoväť.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Načítava viac príspevkov ...",

--- a/apps/akari/translations/sl.json
+++ b/apps/akari/translations/sl.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Ni uspelo posodobiti profila. Poskusite znova.",
       "handleHistory": "Zgodovina",
       "noHandleHistory": "Brez zgodovine ročaja",
-      "noHandleHistoryDescription": "Ta uporabnik še ni spremenil ročaja."
+      "noHandleHistoryDescription": "Ta uporabnik še ni spremenil ročaja.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Nalaganje več objav ...",

--- a/apps/akari/translations/sv.json
+++ b/apps/akari/translations/sv.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Det gick inte att uppdatera profilen. Försök igen.",
       "handleHistory": "Hantera historia",
       "noHandleHistory": "Inget handtagshistorik",
-      "noHandleHistoryDescription": "Den här användaren har inte bytt handtag ännu."
+      "noHandleHistoryDescription": "Den här användaren har inte bytt handtag ännu.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Laddar fler inlägg ...",

--- a/apps/akari/translations/th.json
+++ b/apps/akari/translations/th.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "อัปเดตโปรไฟล์ไม่สำเร็จ",
       "handleHistory": "ประวัติแฮนเดิล",
       "noHandleHistory": "ไม่มีประวัติแฮนเดิล",
-      "noHandleHistoryDescription": "ผู้ใช้นี้ยังไม่เคยเปลี่ยนแฮนเดิล"
+      "noHandleHistoryDescription": "ผู้ใช้นี้ยังไม่เคยเปลี่ยนแฮนเดิล",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "กำลังโหลดโพสต์เพิ่มเติม...",

--- a/apps/akari/translations/tr.json
+++ b/apps/akari/translations/tr.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Profil güncellenemedi",
       "handleHistory": "Kullanıcı adı geçmişi",
       "noHandleHistory": "Kullanıcı adı geçmişi yok",
-      "noHandleHistoryDescription": "Bu kullanıcı henüz kullanıcı adını değiştirmedi."
+      "noHandleHistoryDescription": "Bu kullanıcı henüz kullanıcı adını değiştirmedi.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Daha fazla gönderi yükleniyor...",

--- a/apps/akari/translations/uk.json
+++ b/apps/akari/translations/uk.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Не вдалося оновити профіль. Будь ласка, спробуйте ще раз.",
       "handleHistory": "Обробляти історію",
       "noHandleHistory": "Немає історії ручки",
-      "noHandleHistoryDescription": "Цей користувач ще не змінив свою ручку."
+      "noHandleHistoryDescription": "Цей користувач ще не змінив свою ручку.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Завантаження більше публікацій ...",

--- a/apps/akari/translations/vi.json
+++ b/apps/akari/translations/vi.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "Cập nhật hồ sơ thất bại",
       "handleHistory": "Lịch sử tên định danh",
       "noHandleHistory": "Chưa có lịch sử tên định danh",
-      "noHandleHistoryDescription": "Người dùng này chưa từng đổi tên định danh."
+      "noHandleHistoryDescription": "Người dùng này chưa từng đổi tên định danh.",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "Đang tải thêm bài đăng...",

--- a/apps/akari/translations/zh-CN.json
+++ b/apps/akari/translations/zh-CN.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "更新个人资料失败",
       "handleHistory": "用户名历史记录",
       "noHandleHistory": "暂无用户名历史记录",
-      "noHandleHistoryDescription": "该用户尚未更改过用户名。"
+      "noHandleHistoryDescription": "该用户尚未更改过用户名。",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "加载更多帖子...",

--- a/apps/akari/translations/zh-TW.json
+++ b/apps/akari/translations/zh-TW.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "更新個人資料失敗",
       "handleHistory": "使用者代號歷程",
       "noHandleHistory": "沒有使用者代號歷程",
-      "noHandleHistoryDescription": "此使用者尚未變更過代號。"
+      "noHandleHistoryDescription": "此使用者尚未變更過代號。",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "載入更多貼文...",

--- a/apps/akari/translations/zh.json
+++ b/apps/akari/translations/zh.json
@@ -210,7 +210,11 @@
       "profileUpdateError": "无法更新配置文件。请重试。",
       "handleHistory": "处理历史",
       "noHandleHistory": "没有处理历史",
-      "noHandleHistoryDescription": "该用户尚未更改其手柄。"
+      "noHandleHistoryDescription": "该用户尚未更改其手柄。",
+      "leaflets": "Leaflets",
+      "noLeaflets": "No leaflet posts yet",
+      "expandLeaflet": "Show full post",
+      "collapseLeaflet": "Show less"
     },
     "feed": {
       "loadingMorePosts": "加载更多帖子...",

--- a/apps/akari/types/profile.ts
+++ b/apps/akari/types/profile.ts
@@ -1,1 +1,9 @@
-export type ProfileTabType = 'posts' | 'replies' | 'likes' | 'media' | 'videos' | 'feeds' | 'starterpacks';
+export type ProfileTabType =
+  | 'posts'
+  | 'replies'
+  | 'likes'
+  | 'media'
+  | 'videos'
+  | 'leaflets'
+  | 'feeds'
+  | 'starterpacks';

--- a/packages/bluesky-api/src/api.test.ts
+++ b/packages/bluesky-api/src/api.test.ts
@@ -35,6 +35,7 @@ describe('BlueskyApi', () => {
       graph: Record<string, jest.Mock>;
       search: Record<string, jest.Mock>;
       notifications: Record<string, jest.Mock>;
+      repo: Record<string, jest.Mock>;
     };
 
     return { api, internal };
@@ -218,6 +219,25 @@ describe('BlueskyApi', () => {
       undefined,
     );
     expect(internal.notifications.getUnreadCount).toHaveBeenCalledWith('jwt');
+  });
+
+  it('delegates listRecords to the repo client', async () => {
+    const { api, internal } = setupApi();
+    const records = { records: [] };
+
+    internal.repo = {
+      listRecords: jest.fn().mockResolvedValue(records),
+    };
+
+    await expect(
+      api.listRecords({ collection: 'pub.leaflet.document', repo: 'did:example:alice', limit: 3 }),
+    ).resolves.toBe(records);
+
+    expect(internal.repo.listRecords).toHaveBeenCalledWith({
+      collection: 'pub.leaflet.document',
+      repo: 'did:example:alice',
+      limit: 3,
+    });
   });
 
   it('creates instances using the static helper', () => {

--- a/packages/bluesky-api/src/api.ts
+++ b/packages/bluesky-api/src/api.ts
@@ -6,6 +6,7 @@ import { BlueskyFeeds } from './feeds';
 import { BlueskyGraph } from './graph';
 import { BlueskyNotifications } from './notifications';
 import { BlueskySearch } from './search';
+import { BlueskyRepo } from './repo';
 import type {
   BlueskyBookmarksResponse,
   BlueskyConvosResponse,
@@ -19,6 +20,8 @@ import type {
   BlueskyPostView,
   BlueskyPreferencesResponse,
   BlueskyProfileResponse,
+  BlueskyRepoListRecordsQuery,
+  BlueskyRepoListRecordsResponse,
   BlueskySearchActorsResponse,
   BlueskySearchPostsResponse,
   BlueskySendMessageResponse,
@@ -43,6 +46,7 @@ export class BlueskyApi extends BlueskyApiClient {
   private graph: BlueskyGraph;
   private notifications: BlueskyNotifications;
   private search: BlueskySearch;
+  private repo: BlueskyRepo;
 
   /**
    * Creates a convenience wrapper around the various Bluesky domain clients while sharing the base PDS URL.
@@ -57,6 +61,7 @@ export class BlueskyApi extends BlueskyApiClient {
     this.graph = new BlueskyGraph(pdsUrl);
     this.notifications = new BlueskyNotifications(pdsUrl);
     this.search = new BlueskySearch(pdsUrl);
+    this.repo = new BlueskyRepo(pdsUrl);
   }
 
   /**
@@ -263,6 +268,17 @@ export class BlueskyApi extends BlueskyApiClient {
     cursor?: string,
   ): Promise<BlueskyStarterPacksResponse> {
     return this.feeds.getAuthorStarterpacks(accessJwt, actor, limit, cursor);
+  }
+
+  /**
+   * Lists records from the specified collection within a repository.
+   * @param query - Parameters describing the repo, collection, and pagination options.
+   * @returns Paginated collection of records stored in the repository.
+   */
+  async listRecords<TValue = Record<string, unknown>>(
+    query: BlueskyRepoListRecordsQuery,
+  ): Promise<BlueskyRepoListRecordsResponse<TValue>> {
+    return this.repo.listRecords<TValue>(query);
   }
 
   /**

--- a/packages/bluesky-api/src/index.ts
+++ b/packages/bluesky-api/src/index.ts
@@ -7,6 +7,7 @@ export * from './conversations';
 export * from './feeds';
 export * from './graph';
 export * from './notifications';
+export * from './repo';
 export * from './pds';
 export * from './search';
 export * from './types';

--- a/packages/bluesky-api/src/repo.test.ts
+++ b/packages/bluesky-api/src/repo.test.ts
@@ -1,0 +1,74 @@
+import { BlueskyRepo } from './repo';
+import type { BlueskyRepoListRecordsResponse } from './types';
+
+describe('BlueskyRepo', () => {
+  class TestRepo extends BlueskyRepo {
+    public calls: {
+      endpoint: string;
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      };
+    }[] = [];
+
+    public responses: unknown[] = [];
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeRequest<T>(
+      endpoint: string,
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      this.calls.push({ endpoint, options });
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+  }
+
+  it('serialises query parameters when listing records', async () => {
+    const repo = new TestRepo();
+    const response = {
+      records: [],
+      cursor: 'cursor',
+    } as BlueskyRepoListRecordsResponse;
+
+    repo.responses = [response];
+
+    await expect(
+      repo.listRecords({
+        collection: 'pub.leaflet.document',
+        repo: 'did:example:alice',
+        limit: 5,
+        cursor: 'prev',
+        rkeyStart: 'a',
+        rkeyEnd: 'b',
+        reverse: true,
+      }),
+    ).resolves.toBe(response);
+
+    expect(repo.calls).toEqual([
+      {
+        endpoint: '/com.atproto.repo.listRecords',
+        options: {
+          params: {
+            collection: 'pub.leaflet.document',
+            repo: 'did:example:alice',
+            limit: '5',
+            cursor: 'prev',
+            rkeyStart: 'a',
+            rkeyEnd: 'b',
+            reverse: 'true',
+          },
+        },
+      },
+    ]);
+  });
+});

--- a/packages/bluesky-api/src/repo.ts
+++ b/packages/bluesky-api/src/repo.ts
@@ -1,0 +1,30 @@
+import { BlueskyApiClient } from './client';
+import type { BlueskyRepoListRecordsQuery, BlueskyRepoListRecordsResponse } from './types';
+
+export class BlueskyRepo extends BlueskyApiClient {
+  /**
+   * Lists records from a repository collection using the AT Protocol repo.listRecords endpoint.
+   * @param query - Parameters describing which repository and collection to read plus pagination options.
+   * @returns Paginated records returned by the server typed to the supplied record shape.
+   */
+  async listRecords<TValue = Record<string, unknown>>(
+    query: BlueskyRepoListRecordsQuery,
+  ): Promise<BlueskyRepoListRecordsResponse<TValue>> {
+    const { collection, repo, cursor, limit, rkeyStart, rkeyEnd, reverse } = query;
+
+    const params: Record<string, string> = {
+      collection,
+      repo,
+    };
+
+    if (cursor) params.cursor = cursor;
+    if (typeof limit === 'number') params.limit = String(limit);
+    if (rkeyStart) params.rkeyStart = rkeyStart;
+    if (rkeyEnd) params.rkeyEnd = rkeyEnd;
+    if (typeof reverse === 'boolean') params.reverse = reverse ? 'true' : 'false';
+
+    return this.makeRequest<BlueskyRepoListRecordsResponse<TValue>>('/com.atproto.repo.listRecords', {
+      params,
+    });
+  }
+}

--- a/packages/bluesky-api/src/types.ts
+++ b/packages/bluesky-api/src/types.ts
@@ -843,6 +843,52 @@ export type BlueskyStarterPacksResponse = {
 };
 
 /**
+ * Query parameters for listing repository records via com.atproto.repo.listRecords
+ */
+export type BlueskyRepoListRecordsQuery = {
+  /** NSID of the collection to list (e.g. pub.leaflet.document) */
+  collection: string;
+  /** DID of the repository owner */
+  repo: string;
+  /** Pagination cursor returned from a previous response */
+  cursor?: string;
+  /** Maximum number of records to return */
+  limit?: number;
+  /** Inclusive lower bound for the rkey range */
+  rkeyStart?: string;
+  /** Inclusive upper bound for the rkey range */
+  rkeyEnd?: string;
+  /** Whether to return records in reverse order */
+  reverse?: boolean;
+};
+
+/**
+ * Generic record entry returned from com.atproto.repo.listRecords
+ */
+export type BlueskyRepoRecord<TValue = Record<string, unknown>> = {
+  /** AT URI of the record */
+  uri: string;
+  /** CID of the record */
+  cid: string;
+  /** Parsed record value */
+  value: TValue;
+  /** Optional record key associated with the URI */
+  rkey?: string;
+  /** Additional properties surfaced by the server */
+  [key: string]: unknown;
+};
+
+/**
+ * Response shape returned from com.atproto.repo.listRecords
+ */
+export type BlueskyRepoListRecordsResponse<TValue = Record<string, unknown>> = {
+  /** Cursor for pagination */
+  cursor?: string;
+  /** Records stored within the requested collection */
+  records: BlueskyRepoRecord<TValue>[];
+};
+
+/**
  * Error response from Bluesky API endpoints
  */
 export type BlueskyError = {


### PR DESCRIPTION
## Summary
- add a Leaflets tab on user profiles that renders leaflet.pub documents with an expandable viewer
- implement a useLeafletDocuments hook backed by a new bluesky-api repo.listRecords helper
- update translations and unit tests to cover the new tab, hook, and API helper

## Testing
- npm run lint -- --filter=akari
- npm run lint -- --filter=bluesky-api
- npm run test -- --filter=akari
- npm run test -- --filter=bluesky-api

------
https://chatgpt.com/codex/tasks/task_e_68dc0d08f730832ba7be8d8746f400e9