### PR TITLE
fix: configure release-please token fallback

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,11 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -23,6 +28,7 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          token: ${{ env.RELEASE_PLEASE_TOKEN != '' && env.RELEASE_PLEASE_TOKEN || github.token }}
 
   deploy:
     needs: release-please


### PR DESCRIPTION
## Summary
- allow the release workflow to use an elevated token when provided
- ensure the job retains write permissions even when organization defaults restrict them

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e035ec5490832bbeaef59b865cb685