### PR TITLE
fix: ensure until-async is transformed in package tests

### DIFF
--- a/packages/bluesky-api/jest.config.cjs
+++ b/packages/bluesky-api/jest.config.cjs
@@ -35,6 +35,16 @@ module.exports = {
         tsconfig: jestTsconfig,
       },
     ],
+    'node_modules/until-async/.*\\.js$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          allowJs: true,
+          esModuleInterop: true,
+        },
+      },
+    ],
   },
+  transformIgnorePatterns: ['node_modules/(?!until-async)'],
   ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
 };

--- a/packages/clearsky-api/jest.config.cjs
+++ b/packages/clearsky-api/jest.config.cjs
@@ -20,6 +20,16 @@ module.exports = {
         tsconfig: '<rootDir>/tsconfig.json',
       },
     ],
+    'node_modules/until-async/.*\\.js$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          allowJs: true,
+          esModuleInterop: true,
+        },
+      },
+    ],
   },
+  transformIgnorePatterns: ['node_modules/(?!until-async)'],
   ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
 };

--- a/packages/constellation-api/jest.config.cjs
+++ b/packages/constellation-api/jest.config.cjs
@@ -12,7 +12,17 @@ module.exports = {
         tsconfig: './tsconfig.json',
       },
     ],
+    'node_modules/until-async/.*\\.js$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          allowJs: true,
+          esModuleInterop: true,
+        },
+      },
+    ],
   },
+  transformIgnorePatterns: ['node_modules/(?!until-async)'],
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!**/*.d.ts'],
   coverageDirectory: 'coverage',

--- a/packages/libretranslate-api/jest.config.cjs
+++ b/packages/libretranslate-api/jest.config.cjs
@@ -12,7 +12,17 @@ module.exports = {
         tsconfig: './tsconfig.json',
       },
     ],
+    'node_modules/until-async/.*\\.js$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          allowJs: true,
+          esModuleInterop: true,
+        },
+      },
+    ],
   },
+  transformIgnorePatterns: ['node_modules/(?!until-async)'],
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!**/*.d.ts'],
   coverageDirectory: 'coverage',

--- a/packages/tenor-api/jest.config.cjs
+++ b/packages/tenor-api/jest.config.cjs
@@ -12,7 +12,17 @@ module.exports = {
         tsconfig: './tsconfig.json',
       },
     ],
+    'node_modules/until-async/.*\\.js$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          allowJs: true,
+          esModuleInterop: true,
+        },
+      },
+    ],
   },
+  transformIgnorePatterns: ['node_modules/(?!until-async)'],
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!**/*.d.ts'],
   coverageDirectory: 'coverage',


### PR DESCRIPTION
## Summary
- configure ts-jest to transform the until-async dependency across package test suites
- ensure Jest processes until-async by adjusting transform ignore patterns

## Testing
- npx --yes turbo run lint --filter=bluesky-api *(fails: missing @eslint/eslintrc dependency in lint workspace)*
- npx --yes turbo run test --filter=bluesky-api *(fails: jest binary not installed in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68e04c30984c832b87c12f1eee1be9dc