### PR TITLE
ci: split lint and test workflows by workspace

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --prefer-offline
 
       - name: Build documentation site
         run: npm run build -- --filter=docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,20 +10,120 @@ on:
   workflow_dispatch:
 
 jobs:
+  discover-lint-workspaces:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.workspace-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: workspace-matrix
+        name: Determine lint workspaces
+        shell: bash
+        run: |
+          set -euo pipefail
+          matrix=$(node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const root = process.cwd();
+          const packageJsonPath = path.join(root, 'package.json');
+          const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+          const workspacePatterns = Array.isArray(packageJson.workspaces) ? packageJson.workspaces : [];
+
+          const expandPattern = (pattern) => {
+            const normalized = String(pattern).replace(/\\/g, '/');
+            const segments = normalized.split('/').filter(Boolean);
+            if (segments.length === 0) {
+              return [];
+            }
+
+            const results = [];
+            const traverse = (index, parts) => {
+              if (index === segments.length) {
+                results.push(parts.join('/'));
+                return;
+              }
+
+              const segment = segments[index];
+              if (segment === '*' || segment === '**') {
+                const directory = path.join(root, ...parts);
+                if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) {
+                  return;
+                }
+
+                for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+                  if (entry.isDirectory()) {
+                    traverse(index + 1, [...parts, entry.name]);
+                  }
+                }
+
+                return;
+              }
+
+              const nextParts = [...parts, segment];
+              const nextPath = path.join(root, ...nextParts);
+              if (!fs.existsSync(nextPath)) {
+                return;
+              }
+
+              traverse(index + 1, nextParts);
+            };
+
+            traverse(0, []);
+            return results;
+          };
+
+          const seen = new Set();
+          const workspaces = [];
+
+          for (const pattern of workspacePatterns) {
+            for (const workspacePath of expandPattern(pattern)) {
+              const packageJsonFile = path.join(root, workspacePath, 'package.json');
+              if (!fs.existsSync(packageJsonFile)) {
+                continue;
+              }
+
+              const workspacePackage = JSON.parse(fs.readFileSync(packageJsonFile, 'utf8'));
+              const workspaceName = workspacePackage.name;
+
+              if (typeof workspaceName !== 'string' || workspaceName.length === 0) {
+                continue;
+              }
+
+              if (seen.has(workspaceName)) {
+                continue;
+              }
+
+              seen.add(workspaceName);
+              workspaces.push({
+                workspace: workspaceName,
+                scripts: workspacePackage.scripts ?? {},
+              });
+            }
+          }
+
+          workspaces.sort((a, b) => a.workspace.localeCompare(b.workspace));
+
+          const lintWorkspaces = workspaces
+            .filter(({ scripts }) => typeof scripts.lint === 'string')
+            .map(({ workspace }) => ({ workspace }));
+
+          if (lintWorkspaces.length === 0) {
+            throw new Error('No lint workspaces found in the repository workspaces configuration.');
+          }
+
+          process.stdout.write(JSON.stringify({ include: lintWorkspaces }));
+          NODE
+          )
+
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
   lint:
+    needs: discover-lint-workspaces
     name: lint (${{ matrix.workspace }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - workspace: akari
-          - workspace: docs
-          - workspace: bluesky-api
-          - workspace: clearsky-api
-          - workspace: constellation-api
-          - workspace: libretranslate-api
-          - workspace: tenor-api
+      matrix: ${{ fromJSON(needs.discover-lint-workspaces.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -130,6 +130,13 @@ jobs:
         with:
           node-version: 24.9.0
           cache: npm
-      - run: npm ci
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+      - if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
       - name: Run lint
         run: npm run lint --workspace ${{ matrix.workspace }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,19 @@ on:
 
 jobs:
   lint:
+    name: lint (${{ matrix.workspace }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - workspace: akari
+          - workspace: docs
+          - workspace: bluesky-api
+          - workspace: clearsky-api
+          - workspace: constellation-api
+          - workspace: libretranslate-api
+          - workspace: tenor-api
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -19,4 +31,5 @@ jobs:
           node-version: 24.9.0
           cache: npm
       - run: npm ci
-      - run: npm run lint
+      - name: Run lint
+        run: npm run lint --workspace ${{ matrix.workspace }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -129,14 +129,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24.9.0
-          cache: npm
-      - name: Cache node modules
-        id: cache-node-modules
+      - name: Cache npm
         uses: actions/cache@v4
         with:
-          path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-      - if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: npm ci
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+      - run: npm ci
       - name: Run lint
         run: npm run lint --workspace ${{ matrix.workspace }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -136,6 +136,6 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
-      - run: npm ci
+      - run: npm ci --prefer-offline
       - name: Run lint
         run: npm run lint --workspace ${{ matrix.workspace }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -55,7 +55,7 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --prefer-offline
 
       - name: Build ClearSky API package
         run: npm --workspace clearsky-api run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --prefer-offline
 
       - name: Build ClearSky API package
         run: npm --workspace clearsky-api run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,22 +10,71 @@ on:
 
 jobs:
   unit:
-    name: unit
+    name: unit (${{ matrix.workspace }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - workspace: akari
+            path: apps/akari
+          - workspace: bluesky-api
+            path: packages/bluesky-api
+          - workspace: clearsky-api
+            path: packages/clearsky-api
+          - workspace: constellation-api
+            path: packages/constellation-api
+          - workspace: libretranslate-api
+            path: packages/libretranslate-api
+          - workspace: tenor-api
+            path: packages/tenor-api
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.9.0
+          cache: npm
+      - run: npm ci
+      - name: Run tests with coverage
+        run: npm run test:coverage --workspace ${{ matrix.workspace }}
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.workspace }}
+          path: ${{ matrix.path }}/coverage
+          if-no-files-found: error
+  coverage-report:
+    name: coverage report
+    needs: unit
+    if: ${{ needs.unit.result == 'success' }}
     permissions:
       contents: write
       pull-requests: write
       checks: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 24.9.0
           cache: npm
       - run: npm ci
-      - run: npm run test:coverage --workspaces --if-present
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: coverage-artifacts
+          pattern: coverage-*
+      - name: Restore coverage directories
+        run: |
+          shopt -s dotglob nullglob
+          for artifact in coverage-artifacts/*; do
+            if [ -d "$artifact" ]; then
+              cp -R "$artifact"/. ./
+            fi
+          done
       - name: Merge coverage reports
-        run: node ./scripts/merge-coverage.cjs
+        run: npm run merge-coverage
       - name: Report coverage
         uses: ./.github/actions/report-coverage
         with:
@@ -38,7 +87,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 24.9.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,25 +9,121 @@ on:
       - '**/docs/**'
 
 jobs:
+  discover-unit-workspaces:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.workspace-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: workspace-matrix
+        name: Determine unit test workspaces
+        shell: bash
+        run: |
+          set -euo pipefail
+          matrix=$(node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const root = process.cwd();
+          const packageJsonPath = path.join(root, 'package.json');
+          const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+          const workspacePatterns = Array.isArray(packageJson.workspaces) ? packageJson.workspaces : [];
+
+          const expandPattern = (pattern) => {
+            const normalized = String(pattern).replace(/\\/g, '/');
+            const segments = normalized.split('/').filter(Boolean);
+            if (segments.length === 0) {
+              return [];
+            }
+
+            const results = [];
+            const traverse = (index, parts) => {
+              if (index === segments.length) {
+                results.push(parts.join('/'));
+                return;
+              }
+
+              const segment = segments[index];
+              if (segment === '*' || segment === '**') {
+                const directory = path.join(root, ...parts);
+                if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) {
+                  return;
+                }
+
+                for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+                  if (entry.isDirectory()) {
+                    traverse(index + 1, [...parts, entry.name]);
+                  }
+                }
+
+                return;
+              }
+
+              const nextParts = [...parts, segment];
+              const nextPath = path.join(root, ...nextParts);
+              if (!fs.existsSync(nextPath)) {
+                return;
+              }
+
+              traverse(index + 1, nextParts);
+            };
+
+            traverse(0, []);
+            return results;
+          };
+
+          const seen = new Set();
+          const workspaces = [];
+
+          for (const pattern of workspacePatterns) {
+            for (const workspacePath of expandPattern(pattern)) {
+              const packageJsonFile = path.join(root, workspacePath, 'package.json');
+              if (!fs.existsSync(packageJsonFile)) {
+                continue;
+              }
+
+              const workspacePackage = JSON.parse(fs.readFileSync(packageJsonFile, 'utf8'));
+              const workspaceName = workspacePackage.name;
+
+              if (typeof workspaceName !== 'string' || workspaceName.length === 0) {
+                continue;
+              }
+
+              if (seen.has(workspaceName)) {
+                continue;
+              }
+
+              seen.add(workspaceName);
+              workspaces.push({
+                workspace: workspaceName,
+                path: workspacePath,
+                scripts: workspacePackage.scripts ?? {},
+              });
+            }
+          }
+
+          workspaces.sort((a, b) => a.workspace.localeCompare(b.workspace));
+
+          const coverageWorkspaces = workspaces
+            .filter(({ scripts }) => typeof scripts['test:coverage'] === 'string')
+            .map(({ workspace, path: workspacePath }) => ({ workspace, path: workspacePath }));
+
+          if (coverageWorkspaces.length === 0) {
+            throw new Error('No workspaces with a test:coverage script were found in the repository.');
+          }
+
+          process.stdout.write(JSON.stringify({ include: coverageWorkspaces }));
+          NODE
+          )
+
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
   unit:
+    needs: discover-unit-workspaces
     name: unit (${{ matrix.workspace }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - workspace: akari
-            path: apps/akari
-          - workspace: bluesky-api
-            path: packages/bluesky-api
-          - workspace: clearsky-api
-            path: packages/clearsky-api
-          - workspace: constellation-api
-            path: packages/constellation-api
-          - workspace: libretranslate-api
-            path: packages/libretranslate-api
-          - workspace: tenor-api
-            path: packages/tenor-api
+      matrix: ${{ fromJSON(needs.discover-unit-workspaces.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,15 +129,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24.9.0
-          cache: npm
-      - name: Cache node modules
-        id: cache-node-modules
+      - name: Cache npm
         uses: actions/cache@v4
         with:
-          path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-      - if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: npm ci
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+      - run: npm ci
       - name: Run tests with coverage
         run: npm run test:coverage --workspace ${{ matrix.workspace }}
       - name: Upload coverage artifact
@@ -161,15 +160,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24.9.0
-          cache: npm
-      - name: Cache node modules
-        id: cache-node-modules
+      - name: Cache npm
         uses: actions/cache@v4
         with:
-          path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-      - if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: npm ci
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+      - run: npm ci
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4
         with:
@@ -201,14 +199,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24.9.0
-          cache: npm
-      - name: Cache node modules
-        id: cache-node-modules
+      - name: Cache npm
         uses: actions/cache@v4
         with:
-          path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-      - if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: npm ci
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+      - run: npm ci
       - run: npx playwright install --with-deps chromium
       - run: npm run test:e2e -- --reporter=github

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,11 +139,19 @@ jobs:
       - run: npm ci
       - name: Run tests with coverage
         run: npm run test:coverage --workspace ${{ matrix.workspace }}
+      - name: Prepare coverage artifact metadata
+        if: always()
+        id: coverage-metadata
+        shell: bash
+        run: |
+          workspace_path='${{ matrix.path }}'
+          sanitized="${workspace_path//\//___SLASH___}"
+          echo "name=coverage-${sanitized}" >> "$GITHUB_OUTPUT"
       - name: Upload coverage artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.workspace }}
+          name: ${{ steps.coverage-metadata.outputs.name }}
           path: ${{ matrix.path }}/coverage
           if-no-files-found: error
   coverage-report:
@@ -178,7 +186,19 @@ jobs:
           shopt -s dotglob nullglob
           for artifact in coverage-artifacts/*; do
             if [ -d "$artifact" ]; then
-              cp -R "$artifact"/. ./
+              name="${artifact##*/}"
+              sanitized="${name#coverage-}"
+              workspace_path="${sanitized//___SLASH___//}"
+              coverage_dir="$artifact/coverage"
+
+              if [ ! -d "$coverage_dir" ]; then
+                echo "Coverage directory not found in $artifact" >&2
+                exit 1
+              fi
+
+              rm -rf "$workspace_path/coverage"
+              mkdir -p "$workspace_path"
+              cp -R "$coverage_dir" "$workspace_path/coverage"
             fi
           done
       - name: Merge coverage reports

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,7 +136,7 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
-      - run: npm ci
+      - run: npm ci --prefer-offline
       - name: Run tests with coverage
         run: npm run test:coverage --workspace ${{ matrix.workspace }}
       - name: Prepare coverage artifact metadata
@@ -175,7 +175,7 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
-      - run: npm ci
+      - run: npm ci --prefer-offline
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4
         with:
@@ -226,6 +226,6 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
-      - run: npm ci
+      - run: npm ci --prefer-offline
       - run: npx playwright install --with-deps chromium
       - run: npm run test:e2e -- --reporter=github

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,14 @@ jobs:
         with:
           node-version: 24.9.0
           cache: npm
-      - run: npm ci
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+      - if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
       - name: Run tests with coverage
         run: npm run test:coverage --workspace ${{ matrix.workspace }}
       - name: Upload coverage artifact
@@ -155,7 +162,14 @@ jobs:
         with:
           node-version: 24.9.0
           cache: npm
-      - run: npm ci
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+      - if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4
         with:
@@ -188,6 +202,13 @@ jobs:
         with:
           node-version: 24.9.0
           cache: npm
-      - run: npm ci
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+      - if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
       - run: npx playwright install --with-deps chromium
       - run: npm run test:e2e -- --reporter=github

--- a/.github/workflows/translation-validation.yml
+++ b/.github/workflows/translation-validation.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: 24.9.0
           cache: npm
-      - run: npm ci
+      - run: npm ci --prefer-offline
       - name: Validate translations
         id: validate_translations
         continue-on-error: true


### PR DESCRIPTION
## Summary
- run lint jobs with a matrix to execute one workspace per job
- execute unit test coverage per workspace and collect artifacts for merging
- add a coverage report aggregation job that merges artifacts before commenting

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68e04d439bec832b84bab97d9e03c4a3